### PR TITLE
Add Param3 to Notifications protocol

### DIFF
--- a/init.go
+++ b/init.go
@@ -15,4 +15,5 @@ func init() {
 	nex.RegisterDataHolderType(authentication.NewNintendoLoginData())
 	nex.RegisterDataHolderType(account_management.NewAccountExtraInfo())
 	nex.RegisterDataHolderType(match_making.NewGathering())
+	nex.RegisterDataHolderType(match_making.NewMatchmakeSession())
 }

--- a/notifications/types.go
+++ b/notifications/types.go
@@ -10,15 +10,22 @@ type NotificationEvent struct {
 	Param1    uint32
 	Param2    uint32
 	StrParam  string
+	Param3    uint32
 }
 
 // Bytes encodes the NotificationEvent and returns a byte array
 func (notificationEventGeneral *NotificationEvent) Bytes(stream *nex.StreamOut) []byte {
+	nexVersion := stream.Server.NEXVersion()
+
 	stream.WriteUInt32LE(notificationEventGeneral.PIDSource)
 	stream.WriteUInt32LE(notificationEventGeneral.Type)
 	stream.WriteUInt32LE(notificationEventGeneral.Param1)
 	stream.WriteUInt32LE(notificationEventGeneral.Param2)
 	stream.WriteString(notificationEventGeneral.StrParam)
+
+	if nexVersion.Major >= 3 && nexVersion.Minor >= 5 {
+		stream.WriteUInt32LE(notificationEventGeneral.Param3)
+	}
 
 	return stream.Bytes()
 }


### PR DESCRIPTION
This parameter seems to appear on NEX version 3.5+

MatchmakeSession has been modified to implement proper versioning of its parameters and has been added as a Data Holder.