### PR TITLE
Various fixes

### DIFF
--- a/authentication/types.go
+++ b/authentication/types.go
@@ -50,6 +50,7 @@ func NewNintendoLoginData() *NintendoLoginData {
 
 // AuthenticationInfo holds information about an authentication request
 type AuthenticationInfo struct {
+	nex.Structure
 	*nex.Data
 	Token         string
 	NGSVersion    uint32

--- a/datastore/types.go
+++ b/datastore/types.go
@@ -1076,13 +1076,13 @@ type DataStorePrepareUpdateParam struct {
 
 // ExtractFromStream extracts a DataStorePrepareUpdateParam structure from a stream
 func (dataStorePrepareUpdateParam *DataStorePrepareUpdateParam) ExtractFromStream(stream *nex.StreamIn) error {
-	dataStoreVersion := stream.Server.DataStoreProtocolVersion()
+	datastoreVersion := stream.Server.DataStoreProtocolVersion()
 
 	dataStorePrepareUpdateParam.DataID = stream.ReadUInt64LE()
 	dataStorePrepareUpdateParam.Size = stream.ReadUInt32LE()
 	dataStorePrepareUpdateParam.UpdatePassword = stream.ReadUInt64LE()
 
-	if dataStoreVersion.Major >= 3 && dataStoreVersion.Minor >= 5 {
+	if datastoreVersion.Major >= 3 && datastoreVersion.Minor >= 5 {
 		dataStorePrepareUpdateParam.ExtraData = stream.ReadListString()
 	}
 
@@ -1091,13 +1091,13 @@ func (dataStorePrepareUpdateParam *DataStorePrepareUpdateParam) ExtractFromStrea
 
 // Bytes encodes the DataStorePrepareUpdateParam and returns a byte array
 func (dataStorePrepareUpdateParam *DataStorePrepareUpdateParam) Bytes(stream *nex.StreamOut) []byte {
-	dataStoreVersion := stream.Server.DataStoreProtocolVersion()
+	datastoreVersion := stream.Server.DataStoreProtocolVersion()
 
 	stream.WriteUInt64LE(dataStorePrepareUpdateParam.DataID)
 	stream.WriteUInt32LE(dataStorePrepareUpdateParam.Size)
 	stream.WriteUInt64LE(dataStorePrepareUpdateParam.UpdatePassword)
 
-	if dataStoreVersion.Major >= 3 && dataStoreVersion.Minor >= 5 {
+	if datastoreVersion.Major >= 3 && datastoreVersion.Minor >= 5 {
 		stream.WriteListString(dataStorePrepareUpdateParam.ExtraData)
 	}
 
@@ -2280,7 +2280,7 @@ type DataStorePreparePostParam struct {
 
 // ExtractFromStream extracts a DataStorePreparePostParam structure from a stream
 func (dataStorePreparePostParam *DataStorePreparePostParam) ExtractFromStream(stream *nex.StreamIn) error {
-	dataStoreVersion := stream.Server.DataStoreProtocolVersion()
+	datastoreVersion := stream.Server.DataStoreProtocolVersion()
 
 	dataStorePreparePostParam.Size = stream.ReadUInt32LE()
 
@@ -2331,7 +2331,7 @@ func (dataStorePreparePostParam *DataStorePreparePostParam) ExtractFromStream(st
 
 	dataStorePreparePostParam.PersistenceInitParam = persistenceInitParam.(*DataStorePersistenceInitParam)
 
-	if dataStoreVersion.Major >= 3 && dataStoreVersion.Minor >= 5 {
+	if datastoreVersion.Major >= 3 && datastoreVersion.Minor >= 5 {
 		dataStorePreparePostParam.ExtraData = stream.ReadListString()
 	}
 
@@ -2478,7 +2478,7 @@ type DataStoreSearchParam struct {
 
 // ExtractFromStream extracts a DataStoreSearchParam structure from a stream
 func (dataStoreSearchParam *DataStoreSearchParam) ExtractFromStream(stream *nex.StreamIn) error {
-	dataStoreVersion := stream.Server.DataStoreProtocolVersion()
+	datastoreVersion := stream.Server.DataStoreProtocolVersion()
 
 	dataStoreSearchParam.SearchTarget = stream.ReadUInt8()
 	dataStoreSearchParam.OwnerIds = stream.ReadListUInt32LE()
@@ -2504,7 +2504,7 @@ func (dataStoreSearchParam *DataStoreSearchParam) ExtractFromStream(stream *nex.
 	dataStoreSearchParam.ResultOption = stream.ReadUInt8()
 	dataStoreSearchParam.MinimalRatingFrequency = stream.ReadUInt32LE()
 
-	if dataStoreVersion.Major >= 3 && dataStoreVersion.Minor >= 5 {
+	if datastoreVersion.Major >= 3 && datastoreVersion.Minor >= 5 {
 		dataStoreSearchParam.UseCache = stream.ReadBool()
 	}
 
@@ -3514,7 +3514,7 @@ type DataStorePrepareGetParam struct {
 
 // ExtractFromStream extracts a DataStorePrepareGetParam structure from a stream
 func (dataStorePrepareGetParam *DataStorePrepareGetParam) ExtractFromStream(stream *nex.StreamIn) error {
-	dataStoreVersion := stream.Server.DataStoreProtocolVersion()
+	datastoreVersion := stream.Server.DataStoreProtocolVersion()
 
 	dataStorePrepareGetParam.DataID = stream.ReadUInt64LE()
 	dataStorePrepareGetParam.LockID = stream.ReadUInt32LE()
@@ -3527,7 +3527,7 @@ func (dataStorePrepareGetParam *DataStorePrepareGetParam) ExtractFromStream(stre
 	dataStorePrepareGetParam.PersistenceTarget = persistenceTarget.(*DataStorePersistenceTarget)
 	dataStorePrepareGetParam.AccessPassword = stream.ReadUInt64LE()
 
-	if dataStoreVersion.Major >= 3 && dataStoreVersion.Minor >= 5 {
+	if datastoreVersion.Major >= 3 && datastoreVersion.Minor >= 5 {
 		dataStorePrepareGetParam.ExtraData = stream.ReadListString()
 	}
 
@@ -3644,14 +3644,14 @@ type DataStoreReqGetInfo struct {
 
 // Bytes encodes the DataStoreReqGetInfo and returns a byte array
 func (dataStoreReqGetInfo *DataStoreReqGetInfo) Bytes(stream *nex.StreamOut) []byte {
-	dataStoreVersion := stream.Server.DataStoreProtocolVersion()
+	datastoreVersion := stream.Server.DataStoreProtocolVersion()
 
 	stream.WriteString(dataStoreReqGetInfo.URL)
 	stream.WriteListStructure(dataStoreReqGetInfo.RequestHeaders)
 	stream.WriteUInt32LE(dataStoreReqGetInfo.Size)
 	stream.WriteBuffer(dataStoreReqGetInfo.RootCA)
 
-	if dataStoreVersion.Major >= 3 && dataStoreVersion.Minor >= 5 {
+	if datastoreVersion.Major >= 3 && datastoreVersion.Minor >= 5 {
 		stream.WriteUInt64LE(dataStoreReqGetInfo.DataID)
 	}
 

--- a/match-making/types.go
+++ b/match-making/types.go
@@ -147,7 +147,7 @@ type MatchmakeSessionSearchCriteria struct {
 	ExcludeLocked       bool
 	ExcludeNonHostPid   bool
 	SelectionMethod     uint32
-	VacantParticipants  uint16 // NEX v3.5.0+
+	VacantParticipants  uint16 // NEX v3.4.0+
 }
 
 // ExtractFromStream extracts a Gathering structure from a stream
@@ -178,7 +178,7 @@ func (matchmakeSessionSearchCriteria *MatchmakeSessionSearchCriteria) ExtractFro
 	matchmakeSessionSearchCriteria.ExcludeNonHostPid = stream.ReadBool()
 	matchmakeSessionSearchCriteria.SelectionMethod = stream.ReadUInt32LE()
 
-	if matchmakingVersion.Major >= 3 && matchmakingVersion.Minor >= 5 {
+	if matchmakingVersion.Major >= 3 && matchmakingVersion.Minor >= 4 {
 		matchmakeSessionSearchCriteria.VacantParticipants = stream.ReadUInt16LE()
 	}
 
@@ -199,7 +199,7 @@ func (matchmakeSessionSearchCriteria *MatchmakeSessionSearchCriteria) Bytes(stre
 	stream.WriteBool(matchmakeSessionSearchCriteria.ExcludeNonHostPid)
 	stream.WriteUInt32LE(matchmakeSessionSearchCriteria.SelectionMethod)
 
-	if matchmakingVersion.Major >= 3 && matchmakingVersion.Minor >= 5 {
+	if matchmakingVersion.Major >= 3 && matchmakingVersion.Minor >= 4 {
 		stream.WriteUInt16LE(matchmakeSessionSearchCriteria.VacantParticipants)
 	}
 
@@ -295,7 +295,7 @@ type MatchmakeSession struct {
 	MatchmakeSystemType   uint32
 	ApplicationData       []byte
 	ParticipationCount    uint32
-	ProgressScore         uint8           // NEX v3.5.0+
+	ProgressScore         uint8           // NEX v3.4.0+
 	SessionKey            []byte          // NEX v3.0.0+
 	Option                uint32          // NEX v3.5.0+
 	MatchmakeParam        *MatchmakeParam // NEX v3.6.0+
@@ -325,7 +325,7 @@ func (matchmakeSession *MatchmakeSession) ExtractFromStream(stream *nex.StreamIn
 
 	matchmakeSession.ParticipationCount = stream.ReadUInt32LE()
 
-	if matchmakingVersion.Major >= 3 && matchmakingVersion.Minor >= 5 {
+	if matchmakingVersion.Major >= 3 && matchmakingVersion.Minor >= 4 {
 		matchmakeSession.ProgressScore = stream.ReadUInt8()
 	}
 
@@ -389,7 +389,7 @@ func (matchmakeSession *MatchmakeSession) Bytes(stream *nex.StreamOut) []byte {
 
 	stream.WriteUInt32LE(matchmakeSession.ParticipationCount)
 
-	if matchmakingVersion.Major >= 3 && matchmakingVersion.Minor >= 5 {
+	if matchmakingVersion.Major >= 3 && matchmakingVersion.Minor >= 4 {
 		stream.WriteUInt8(matchmakeSession.ProgressScore)
 	}
 

--- a/match-making/types.go
+++ b/match-making/types.go
@@ -287,6 +287,7 @@ func NewMatchmakeSessionSearchCriteria() *MatchmakeSessionSearchCriteria {
 
 // MatchmakeSession holds information about a matchmake session
 type MatchmakeSession struct {
+	nex.Structure
 	*Gathering
 	GameMode              uint32
 	Attributes            []uint32
@@ -1034,6 +1035,7 @@ func NewAutoMatchmakeParam() *AutoMatchmakeParam {
 
 // PersistentGathering holds parameters for a matchmake session
 type PersistentGathering struct {
+	nex.Structure
 	*Gathering
 	M_CommunityType          uint32
 	M_Password               string

--- a/nintendo-notifications/notification_types.go
+++ b/nintendo-notifications/notification_types.go
@@ -1,8 +1,13 @@
 package nintendo_notifications
 
 type notificationTypes struct {
+	FriendPresenceUpdated3DS               uint32
+	FriendFavoriteGameUpdated3DS           uint32
+	FriendCommentUpdated3DS                uint32
+	FriendMiiChanged3DS                    uint32
+	FriendshipCompleted3DS                 uint32
 	FriendOffline                          uint32
-	FriendMiiChange                        uint32
+	FriendMiiChanged                       uint32
 	Unknown1MiiRelated                     uint32
 	FriendPreferencesChanged               uint32
 	FriendStartedTitle                     uint32
@@ -22,8 +27,13 @@ type notificationTypes struct {
 }
 
 var NotificationTypes = notificationTypes{
+	FriendPresenceUpdated3DS:                1,
+	FriendFavoriteGameUpdated3DS:            2,
+	FriendCommentUpdated3DS:                 3,
+	FriendMiiChanged3DS:                     5,
+	FriendshipCompleted3DS:                  7,
 	FriendOffline:                          10,
-	FriendMiiChange:                        21,
+	FriendMiiChanged:                       21,
 	Unknown1MiiRelated:                     22,
 	FriendPreferencesChanged:               23,
 	FriendStartedTitle:                     24,

--- a/notifications/notification_types.go
+++ b/notifications/notification_types.go
@@ -8,6 +8,7 @@ type notificationTypes struct {
 	OwnershipChanged             uint32
 	GatheringUnregistered        uint32
 	HostChanged                  uint32
+	ServiceItemRequestCompleted  uint32
 	MatchmakeRefereeRoundStarted uint32
 	SystemPasswordChanged        uint32
 	SystemPasswordCleared        uint32
@@ -22,6 +23,7 @@ var NotificationTypes = notificationTypes{
 	OwnershipChanged:             4000,
 	GatheringUnregistered:        109000,
 	HostChanged:                  110000,
+	ServiceItemRequestCompleted:  115000,
 	MatchmakeRefereeRoundStarted: 116000,
 	SystemPasswordChanged:        120000,
 	SystemPasswordCleared:        121000,


### PR DESCRIPTION
- Add nex.Structure to structures with parents to prevent stack overflow.
- Add NEX versioning to some DataStore types and fix versioning on Matchmaking types. Some Matchmaking fields which require NEX 3.5+ have been found on Wii Sports Club, which requires NEX 3.4. Downgrade the version requirement. Some DataStore fields are aswell missing on DDL trees prior to NEX 3.5.
- Add missing notification types related to Friends 3DS and Service Item.