### PR TITLE
Fix MatchMaking function signatures and add Bytes() to MatchmakeParam

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/PretendoNetwork/nex-protocols-go
 go 1.19
 
 require (
-	github.com/PretendoNetwork/nex-go v1.0.24
+	github.com/PretendoNetwork/nex-go v1.0.25
 	github.com/PretendoNetwork/plogger-go v1.0.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/PretendoNetwork/nex-go v1.0.24 h1:Mv9iCGjmkKKI6fhQgoRhdEljBpu6pQP5JJt2mWJftHQ=
-github.com/PretendoNetwork/nex-go v1.0.24/go.mod h1:qzc5s4iNrt1ubS9Axb38b2jPuEsiETN2mDijn+MthmI=
+github.com/PretendoNetwork/nex-go v1.0.25 h1:x324hqKItxZSq+8KFhdwjVusB9y05CciTmAOZ+i819U=
+github.com/PretendoNetwork/nex-go v1.0.25/go.mod h1:qzc5s4iNrt1ubS9Axb38b2jPuEsiETN2mDijn+MthmI=
 github.com/PretendoNetwork/plogger-go v1.0.2 h1:vWKEnEmJJzYwqLxLyiSsAvCrZV6qnnu/a0GQOjIfzY0=
 github.com/PretendoNetwork/plogger-go v1.0.2/go.mod h1:7kD6M4vPq1JL4LTuPg6kuB1OvUBOwQOtAvTaUwMbwvU=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=

--- a/match-making/get_session_urls.go
+++ b/match-making/get_session_urls.go
@@ -6,7 +6,7 @@ import (
 )
 
 // GetSessionURLs sets the GetSessionURLs handler function
-func (protocol *MatchMakingProtocol) GetSessionURLs(handler func(err error, client *nex.Client, callID uint32, gatheringId uint32)) {
+func (protocol *MatchMakingProtocol) GetSessionURLs(handler func(err error, client *nex.Client, callID uint32, gid uint32)) {
 	protocol.GetSessionURLsHandler = handler
 }
 
@@ -25,7 +25,7 @@ func (protocol *MatchMakingProtocol) HandleGetSessionURLs(packet nex.PacketInter
 
 	parametersStream := nex.NewStreamIn(parameters, protocol.Server)
 
-	gatheringId := parametersStream.ReadUInt32LE()
+	gid := parametersStream.ReadUInt32LE()
 
-	go protocol.GetSessionURLsHandler(nil, client, callID, gatheringId)
+	go protocol.GetSessionURLsHandler(nil, client, callID, gid)
 }

--- a/match-making/protocol.go
+++ b/match-making/protocol.go
@@ -36,9 +36,9 @@ type MatchMakingProtocol struct {
 	UnregisterGatheringHandler  func(err error, client *nex.Client, callID uint32, idGathering uint32)
 	UnregisterGatheringsHandler func(err error, client *nex.Client, callID uint32, lstGatherings []uint32)
 	FindBySingleIDHandler       func(err error, client *nex.Client, callID uint32, id uint32)
-	UpdateSessionHostV1Handler  func(err error, client *nex.Client, callID uint32, gatheringId uint32)
-	GetSessionURLsHandler       func(err error, client *nex.Client, callID uint32, gatheringId uint32)
-	UpdateSessionHostHandler    func(err error, client *nex.Client, callID uint32, gatheringId uint32)
+	UpdateSessionHostV1Handler  func(err error, client *nex.Client, callID uint32, gid uint32)
+	GetSessionURLsHandler       func(err error, client *nex.Client, callID uint32, gid uint32)
+	UpdateSessionHostHandler    func(err error, client *nex.Client, callID uint32, gid uint32, isMigrateOwner bool)
 }
 
 // Setup initializes the protocol

--- a/match-making/types.go
+++ b/match-making/types.go
@@ -577,7 +577,7 @@ func NewMatchmakeSession() *MatchmakeSession {
 // MatchmakeParam holds parameters for a matchmake session
 type MatchmakeParam struct {
 	nex.Structure
-	parameters map[string]*nex.Variant
+	Parameters map[string]*nex.Variant
 }
 
 // ExtractFromStream extracts a MatchmakeParam structure from a stream
@@ -588,23 +588,30 @@ func (matchmakeParam *MatchmakeParam) ExtractFromStream(stream *nex.StreamIn) er
 		return err
 	}
 
-	matchmakeParam.parameters = make(map[string]*nex.Variant, len(parameters))
+	matchmakeParam.Parameters = make(map[string]*nex.Variant, len(parameters))
 
 	for key, value := range parameters {
-		matchmakeParam.parameters[key.(string)] = value.(*nex.Variant)
+		matchmakeParam.Parameters[key.(string)] = value.(*nex.Variant)
 	}
 
 	return nil
+}
+
+// // Bytes extracts a MatchmakeParam structure from a stream
+func (matchmakeParam *MatchmakeParam) Bytes(stream *nex.StreamOut) []byte {
+	stream.WriteMap(matchmakeParam.Parameters, stream.WriteString, stream.WriteVariant)
+
+	return stream.Bytes()
 }
 
 // Copy returns a new copied instance of MatchmakeParam
 func (matchmakeParam *MatchmakeParam) Copy() nex.StructureInterface {
 	copied := NewMatchmakeParam()
 
-	copied.parameters = make(map[string]*nex.Variant, len(matchmakeParam.parameters))
+	copied.Parameters = make(map[string]*nex.Variant, len(matchmakeParam.Parameters))
 
-	for key, value := range matchmakeParam.parameters {
-		copied.parameters[key] = value.Copy()
+	for key, value := range matchmakeParam.Parameters {
+		copied.Parameters[key] = value.Copy()
 	}
 
 	return copied
@@ -614,12 +621,12 @@ func (matchmakeParam *MatchmakeParam) Copy() nex.StructureInterface {
 func (matchmakeParam *MatchmakeParam) Equals(structure nex.StructureInterface) bool {
 	other := structure.(*MatchmakeParam)
 
-	if len(matchmakeParam.parameters) != len(other.parameters) {
+	if len(matchmakeParam.Parameters) != len(other.Parameters) {
 		return false
 	}
 
-	for key, value := range matchmakeParam.parameters {
-		if !value.Equals(other.parameters[key]) {
+	for key, value := range matchmakeParam.Parameters {
+		if !value.Equals(other.Parameters[key]) {
 			return false
 		}
 	}

--- a/match-making/types.go
+++ b/match-making/types.go
@@ -315,7 +315,7 @@ func (matchmakeSession *MatchmakeSession) ExtractFromStream(stream *nex.StreamIn
 
 	matchmakeSession.GameMode = stream.ReadUInt32LE()
 	matchmakeSession.Attributes = stream.ReadListUInt32LE()
-	matchmakeSession.OpenParticipation = stream.ReadUInt8() == 1
+	matchmakeSession.OpenParticipation = stream.ReadBool()
 	matchmakeSession.MatchmakeSystemType = stream.ReadUInt32LE()
 	matchmakeSession.ApplicationData, err = stream.ReadBuffer()
 
@@ -599,7 +599,7 @@ func (matchmakeParam *MatchmakeParam) ExtractFromStream(stream *nex.StreamIn) er
 
 // // Bytes extracts a MatchmakeParam structure from a stream
 func (matchmakeParam *MatchmakeParam) Bytes(stream *nex.StreamOut) []byte {
-	stream.WriteMap(matchmakeParam.Parameters, stream.WriteString, stream.WriteVariant)
+	stream.WriteMap(matchmakeParam.Parameters)
 
 	return stream.Bytes()
 }

--- a/match-making/update_session_host.go
+++ b/match-making/update_session_host.go
@@ -8,7 +8,7 @@ import (
 )
 
 // GetSessionURLs sets the GetSessionURLs handler function
-func (protocol *MatchMakingProtocol) UpdateSessionHost(handler func(err error, client *nex.Client, callID uint32, gatheringId uint32)) {
+func (protocol *MatchMakingProtocol) UpdateSessionHost(handler func(err error, client *nex.Client, callID uint32, gid uint32, isMigrateOwner bool)) {
 	protocol.UpdateSessionHostHandler = handler
 }
 
@@ -27,7 +27,9 @@ func (protocol *MatchMakingProtocol) HandleUpdateSessionHost(packet nex.PacketIn
 
 	parametersStream := nex.NewStreamIn(parameters, protocol.Server)
 
-	gatheringId := parametersStream.ReadUInt32LE()
+	gid := parametersStream.ReadUInt32LE()
 
-	go protocol.UpdateSessionHostHandler(nil, client, callID, gatheringId)
+	isMigrateOwner := parametersStream.ReadBool()
+
+	go protocol.UpdateSessionHostHandler(nil, client, callID, gid, isMigrateOwner)
 }

--- a/match-making/update_session_host_v_1.go
+++ b/match-making/update_session_host_v_1.go
@@ -8,7 +8,7 @@ import (
 )
 
 // GetSessionURLs sets the GetSessionURLs handler function
-func (protocol *MatchMakingProtocol) UpdateSessionHostV1(handler func(err error, client *nex.Client, callID uint32, gatheringId uint32)) {
+func (protocol *MatchMakingProtocol) UpdateSessionHostV1(handler func(err error, client *nex.Client, callID uint32, gid uint32)) {
 	protocol.UpdateSessionHostV1Handler = handler
 }
 
@@ -27,7 +27,7 @@ func (protocol *MatchMakingProtocol) HandleUpdateSessionHostV1(packet nex.Packet
 
 	parametersStream := nex.NewStreamIn(parameters, protocol.Server)
 
-	gatheringId := parametersStream.ReadUInt32LE()
+	gid := parametersStream.ReadUInt32LE()
 
-	go protocol.UpdateSessionHostV1Handler(nil, client, callID, gatheringId)
+	go protocol.UpdateSessionHostV1Handler(nil, client, callID, gid)
 }

--- a/matchmake-extension/auto_matchmake_with_search_criteria_postpone.go
+++ b/matchmake-extension/auto_matchmake_with_search_criteria_postpone.go
@@ -31,13 +31,13 @@ func (protocol *MatchmakeExtensionProtocol) HandleAutoMatchmakeWithSearchCriteri
 
 	lstSearchCriteria, err := parametersStream.ReadListStructure(match_making.NewMatchmakeSessionSearchCriteria())
 	if err != nil {
-		go protocol.AutoMatchmakeWithSearchCriteria_PostponeHandler(nil, client, callID, nil, nil, "")
+		go protocol.AutoMatchmakeWithSearchCriteria_PostponeHandler(err, client, callID, nil, nil, "")
 	}
 
 	anyGathering := parametersStream.ReadDataHolder()
 	strMessage, err := parametersStream.ReadString()
 	if err != nil {
-		go protocol.AutoMatchmakeWithSearchCriteria_PostponeHandler(nil, client, callID, nil, nil, "")
+		go protocol.AutoMatchmakeWithSearchCriteria_PostponeHandler(err, client, callID, nil, nil, "")
 	}
 
 	go protocol.AutoMatchmakeWithSearchCriteria_PostponeHandler(nil, client, callID, lstSearchCriteria.([]*match_making.MatchmakeSessionSearchCriteria), anyGathering, strMessage)

--- a/matchmake-extension/create_matchmake_session.go
+++ b/matchmake-extension/create_matchmake_session.go
@@ -75,7 +75,7 @@ func (protocol *MatchmakeExtensionProtocol) HandleCreateMatchmakeSession(packet 
 
 	var participationCount uint16 = 0
 
-	if matchmakingVersion.Major >= 3 && matchmakingVersion.Minor >= 5 {
+	if matchmakingVersion.Major >= 3 && matchmakingVersion.Minor >= 4 {
 		participationCount = dataHolderContentStream.ReadUInt16LE()
 	}
 

--- a/matchmake-extension/protocol.go
+++ b/matchmake-extension/protocol.go
@@ -88,7 +88,7 @@ type MatchmakeExtensionProtocol struct {
 	JoinMatchmakeSessionExHandler                   func(err error, client *nex.Client, callID uint32, gid uint32, strMessage string, dontCareMyBlockList bool, participationCount uint16)
 	GetSimplePlayingSessionHandler                  func(err error, client *nex.Client, callID uint32, listPID []uint32, includeLoginUser bool)
 	GetSimpleCommunityHandler                       func(err error, client *nex.Client, callID uint32, gatheringIDList []uint32)
-	UpdateProgressScoreHandler                      func(err error, client *nex.Client, callID uint32, GID uint32, progressScore uint8)
+	UpdateProgressScoreHandler                      func(err error, client *nex.Client, callID uint32, gid uint32, progressScore uint8)
 	CreateMatchmakeSessionWithParamHandler          func(err error, client *nex.Client, callID uint32, createMatchmakeSessionParam *match_making.CreateMatchmakeSessionParam)
 	JoinMatchmakeSessionWithParamHandler            func(err error, client *nex.Client, callID uint32, joinMatchmakeSessionParam *match_making.JoinMatchmakeSessionParam)
 	AutoMatchmakeWithParam_PostponeHandler          func(err error, client *nex.Client, callID uint32, autoMatchmakeParam *match_making.AutoMatchmakeParam)

--- a/matchmake-extension/update_progress_score.go
+++ b/matchmake-extension/update_progress_score.go
@@ -6,7 +6,7 @@ import (
 )
 
 // UpdateProgressScore sets the UpdateProgressScore handler function
-func (protocol *MatchmakeExtensionProtocol) UpdateProgressScore(handler func(err error, client *nex.Client, callID uint32, GID uint32, progressScore uint8)) {
+func (protocol *MatchmakeExtensionProtocol) UpdateProgressScore(handler func(err error, client *nex.Client, callID uint32, gid uint32, progressScore uint8)) {
 	protocol.UpdateProgressScoreHandler = handler
 }
 
@@ -25,8 +25,8 @@ func (protocol *MatchmakeExtensionProtocol) HandleUpdateProgressScore(packet nex
 
 	parametersStream := nex.NewStreamIn(parameters, protocol.Server)
 
-	GID := parametersStream.ReadUInt32LE()
+	gid := parametersStream.ReadUInt32LE()
 	progressScore := parametersStream.ReadUInt8()
 
-	go protocol.UpdateProgressScoreHandler(nil, client, callID, GID, progressScore)
+	go protocol.UpdateProgressScoreHandler(nil, client, callID, gid, progressScore)
 }

--- a/nat-traversal/report_nat_traversal_result.go
+++ b/nat-traversal/report_nat_traversal_result.go
@@ -11,6 +11,8 @@ func (protocol *NATTraversalProtocol) ReportNATTraversalResult(handler func(err 
 }
 
 func (protocol *NATTraversalProtocol) HandleReportNATTraversalResult(packet nex.PacketInterface) {
+	matchmakingVersion := protocol.Server.MatchMakingProtocolVersion()
+
 	if protocol.ReportNATTraversalResultHandler == nil {
 		globals.Logger.Warning("NATTraversal::ReportNATTraversalResult not implemented")
 		go globals.RespondNotImplemented(packet, ProtocolID)
@@ -27,7 +29,13 @@ func (protocol *NATTraversalProtocol) HandleReportNATTraversalResult(packet nex.
 
 	cid := parametersStream.ReadUInt32LE()
 	result := parametersStream.ReadBool()
-	rtt := parametersStream.ReadUInt32LE()
+
+	var rtt uint32 = 0
+
+	// TODO - Is this the right version?
+	if matchmakingVersion.Major >= 3 && matchmakingVersion.Minor >= 0 {
+		rtt = parametersStream.ReadUInt32LE()
+	}
 
 	go protocol.ReportNATTraversalResultHandler(nil, client, callID, cid, result, rtt)
 }


### PR DESCRIPTION
We didn't have support for writing maps before, but now that we do,
implement the function.

Also export the `Parameters` parameter on `MatchmakeParam` so that it can
be modified outside nex-protocols-go.

I also noticed that Yokai Watch 2 uses the `rtt` argument on
`ReportNATTraversalResult`, so it looks like the field was added on a NEX
version (and not just that it doesn't exist on 3DS).

Only the `MatchmakeParam` changes has been tested.

Depends on https://github.com/PretendoNetwork/nex-go/pull/30