### PR TITLE
Fix Structure.Copy() and versioning on AuthenticationInfo

### DIFF
--- a/authentication/types.go
+++ b/authentication/types.go
@@ -86,7 +86,8 @@ func (authenticationInfo *AuthenticationInfo) ExtractFromStream(stream *nex.Stre
 func (authenticationInfo *AuthenticationInfo) Copy() nex.StructureInterface {
 	copied := NewAuthenticationInfo()
 
-	copied.SetParentType(authenticationInfo.ParentType().Copy())
+	copied.Data = authenticationInfo.Data.Copy().(*nex.Data)
+	copied.SetParentType(copied.Data)
 	copied.Token = authenticationInfo.Token
 	copied.TokenType = authenticationInfo.TokenType
 	copied.NGSVersion = authenticationInfo.NGSVersion

--- a/authentication/types.go
+++ b/authentication/types.go
@@ -57,8 +57,6 @@ type AuthenticationInfo struct {
 
 // ExtractFromStream extracts a AuthenticationInfo structure from a stream
 func (authenticationInfo *AuthenticationInfo) ExtractFromStream(stream *nex.StreamIn) error {
-	nexVersion := stream.Server.NEXVersion()
-
 	var err error
 
 	authenticationInfo.Token, err = stream.ReadString()
@@ -71,8 +69,7 @@ func (authenticationInfo *AuthenticationInfo) ExtractFromStream(stream *nex.Stre
 		return fmt.Errorf("Failed to extract AccountExtraInfo.NGSVersion. %s", err.Error())
 	}
 
-	// TODO - Is this the right version?
-	if nexVersion.Major >= 3 && nexVersion.Minor >= 2 {
+	if authenticationInfo.NGSVersion > 2 {
 		authenticationInfo.TokenType, err = stream.ReadUInt8()
 		if err != nil {
 			return fmt.Errorf("Failed to extract AccountExtraInfo.TokenType. %s", err.Error())

--- a/authentication/types.go
+++ b/authentication/types.go
@@ -72,7 +72,7 @@ func (authenticationInfo *AuthenticationInfo) ExtractFromStream(stream *nex.Stre
 	}
 
 	// TODO - Is this the right version?
-	if nexVersion.Major >= 3 {
+	if nexVersion.Major >= 3 && nexVersion.Minor >= 2 {
 		authenticationInfo.TokenType, err = stream.ReadUInt8()
 		if err != nil {
 			return fmt.Errorf("Failed to extract AccountExtraInfo.TokenType. %s", err.Error())

--- a/authentication/types.go
+++ b/authentication/types.go
@@ -57,6 +57,8 @@ type AuthenticationInfo struct {
 
 // ExtractFromStream extracts a AuthenticationInfo structure from a stream
 func (authenticationInfo *AuthenticationInfo) ExtractFromStream(stream *nex.StreamIn) error {
+	nexVersion := stream.Server.NEXVersion()
+
 	var err error
 
 	authenticationInfo.Token, err = stream.ReadString()
@@ -69,14 +71,17 @@ func (authenticationInfo *AuthenticationInfo) ExtractFromStream(stream *nex.Stre
 		return fmt.Errorf("Failed to extract AccountExtraInfo.NGSVersion. %s", err.Error())
 	}
 
-	authenticationInfo.TokenType, err = stream.ReadUInt8()
-	if err != nil {
-		return fmt.Errorf("Failed to extract AccountExtraInfo.TokenType. %s", err.Error())
-	}
+	// TODO - Is this the right version?
+	if nexVersion.Major >= 3 {
+		authenticationInfo.TokenType, err = stream.ReadUInt8()
+		if err != nil {
+			return fmt.Errorf("Failed to extract AccountExtraInfo.TokenType. %s", err.Error())
+		}
 
-	authenticationInfo.ServerVersion, err = stream.ReadUInt32LE()
-	if err != nil {
-		return fmt.Errorf("Failed to extract AccountExtraInfo.ServerVersion. %s", err.Error())
+		authenticationInfo.ServerVersion, err = stream.ReadUInt32LE()
+		if err != nil {
+			return fmt.Errorf("Failed to extract AccountExtraInfo.ServerVersion. %s", err.Error())
+		}
 	}
 
 	return nil

--- a/match-making/types.go
+++ b/match-making/types.go
@@ -523,7 +523,8 @@ func (matchmakeSession *MatchmakeSession) Bytes(stream *nex.StreamOut) []byte {
 func (matchmakeSession *MatchmakeSession) Copy() nex.StructureInterface {
 	copied := NewMatchmakeSession()
 
-	copied.SetParentType(matchmakeSession.ParentType().Copy())
+	copied.Gathering = matchmakeSession.Gathering.Copy().(*Gathering)
+	copied.SetParentType(copied.Gathering)
 	copied.GameMode = matchmakeSession.GameMode
 	copied.Attributes = make([]uint32, len(matchmakeSession.Attributes))
 
@@ -1290,7 +1291,8 @@ func (persistentGathering *PersistentGathering) ExtractFromStream(stream *nex.St
 func (persistentGathering *PersistentGathering) Copy() nex.StructureInterface {
 	copied := NewPersistentGathering()
 
-	copied.SetParentType(persistentGathering.ParentType().Copy())
+	copied.Gathering = persistentGathering.Gathering.Copy().(*Gathering)
+	copied.SetParentType(copied.Gathering)
 	copied.M_CommunityType = persistentGathering.M_CommunityType
 	copied.M_Password = persistentGathering.M_Password
 	copied.M_Attribs = make([]uint32, len(persistentGathering.M_Attribs))

--- a/message-delivery/types.go
+++ b/message-delivery/types.go
@@ -143,7 +143,8 @@ func (userMessage *UserMessage) ExtractFromStream(stream *nex.StreamIn) error {
 func (userMessage *UserMessage) Copy() nex.StructureInterface {
 	copied := NewUserMessage()
 
-	copied.SetParentType(userMessage.ParentType().Copy())
+	copied.Data = userMessage.Data.Copy().(*nex.Data)
+	copied.SetParentType(copied.Data)
 	copied.m_uiID = userMessage.m_uiID
 	copied.m_uiParentID = userMessage.m_uiParentID
 	copied.m_pidSender = userMessage.m_pidSender
@@ -240,7 +241,8 @@ func (binaryMessage *BinaryMessage) ExtractFromStream(stream *nex.StreamIn) erro
 func (binaryMessage *BinaryMessage) Copy() nex.StructureInterface {
 	copied := NewBinaryMessage()
 
-	copied.SetParentType(binaryMessage.ParentType().Copy())
+	copied.UserMessage = binaryMessage.UserMessage.Copy().(*UserMessage)
+	copied.SetParentType(copied.UserMessage)
 	copied.m_binaryBody = make([]byte, len(binaryMessage.m_binaryBody))
 
 	copy(copied.m_binaryBody, binaryMessage.m_binaryBody)

--- a/notifications/types.go
+++ b/notifications/types.go
@@ -23,7 +23,7 @@ func (notificationEvent *NotificationEvent) Bytes(stream *nex.StreamOut) []byte 
 	stream.WriteUInt32LE(notificationEvent.Param2)
 	stream.WriteString(notificationEvent.StrParam)
 
-	if nexVersion.Major >= 3 && nexVersion.Minor >= 5 {
+	if nexVersion.Major >= 3 && nexVersion.Minor >= 4 {
 		stream.WriteUInt32LE(notificationEvent.Param3)
 	}
 


### PR DESCRIPTION
- The parent types weren't assigned to the parent structure inside the
child one, so no data was written from those parents when using
StreamOut.

- On Mario Kart 7, the `TokenType` and `ServerVersion` fields aren't
present on AuthenticationInfo.

I'm starting to doubt that the Mario Kart 7 NEX version actually *is*
3.4. Considering we only have the server build version for that game
as a reference, I'm considering dropping the version to 2.0 or
something.

If we consider this an option, I'll add another commit related to
notifications, as the `Param3` is present on NEX 3.4, according to
Wii Sports Club (which I trust a lot more for the versioning since we
have DDL trees and the server build matches).