### PR TITLE
Add DataStore.GetSpecificMeta(V1) method and more

### DIFF
--- a/datastore/get_specific_meta.go
+++ b/datastore/get_specific_meta.go
@@ -15,7 +15,7 @@ func (protocol *DataStoreProtocol) GetSpecificMeta(handler func(err error, clien
 }
 
 func (protocol *DataStoreProtocol) handleGetSpecificMeta(packet nex.PacketInterface) {
-	if protocol.PrepareGetObjectV1Handler == nil {
+	if protocol.GetSpecificMetaHandler == nil {
 		globals.Logger.Warning("DataStore::GetSpecificMeta not implemented")
 		go globals.RespondNotImplemented(packet, ProtocolID)
 		return
@@ -31,7 +31,7 @@ func (protocol *DataStoreProtocol) handleGetSpecificMeta(packet nex.PacketInterf
 
 	param, err := parametersStream.ReadStructure(datastore_types.NewDataStoreGetSpecificMetaParam())
 	if err != nil {
-		go protocol.GetSpecificMetaHandler(fmt.Errorf("Failed to read dataStoreGetSpecificMetaParam from parameters. %s", err.Error()), client, callID, nil)
+		go protocol.GetSpecificMetaHandler(fmt.Errorf("Failed to read param from parameters. %s", err.Error()), client, callID, nil)
 		return
 	}
 

--- a/datastore/get_specific_meta.go
+++ b/datastore/get_specific_meta.go
@@ -1,0 +1,39 @@
+// Package datastore implements the DataStore NEX protocol
+package datastore
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	datastore_types "github.com/PretendoNetwork/nex-protocols-go/datastore/types"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+)
+
+// GetSpecificMeta sets the GetSpecificMeta handler function
+func (protocol *DataStoreProtocol) GetSpecificMeta(handler func(err error, client *nex.Client, callID uint32, param *datastore_types.DataStoreGetSpecificMetaParam)) {
+	protocol.GetSpecificMetaHandler = handler
+}
+
+func (protocol *DataStoreProtocol) handleGetSpecificMeta(packet nex.PacketInterface) {
+	if protocol.PrepareGetObjectV1Handler == nil {
+		globals.Logger.Warning("DataStore::GetSpecificMeta not implemented")
+		go globals.RespondNotImplemented(packet, ProtocolID)
+		return
+	}
+
+	client := packet.Sender()
+	request := packet.RMCRequest()
+
+	callID := request.CallID()
+	parameters := request.Parameters()
+
+	parametersStream := nex.NewStreamIn(parameters, protocol.Server)
+
+	param, err := parametersStream.ReadStructure(datastore_types.NewDataStoreGetSpecificMetaParam())
+	if err != nil {
+		go protocol.GetSpecificMetaHandler(fmt.Errorf("Failed to read dataStoreGetSpecificMetaParam from parameters. %s", err.Error()), client, callID, nil)
+		return
+	}
+
+	go protocol.GetSpecificMetaHandler(nil, client, callID, param.(*datastore_types.DataStoreGetSpecificMetaParam))
+}

--- a/datastore/get_specific_meta_v1.go
+++ b/datastore/get_specific_meta_v1.go
@@ -1,0 +1,39 @@
+// Package datastore implements the DataStore NEX protocol
+package datastore
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	datastore_types "github.com/PretendoNetwork/nex-protocols-go/datastore/types"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+)
+
+// GetSpecificMetaV1 sets the GetSpecificMetaV1 handler function
+func (protocol *DataStoreProtocol) GetSpecificMetaV1(handler func(err error, client *nex.Client, callID uint32, param *datastore_types.DataStoreGetSpecificMetaParamV1)) {
+	protocol.GetSpecificMetaV1Handler = handler
+}
+
+func (protocol *DataStoreProtocol) handleGetSpecificMetaV1(packet nex.PacketInterface) {
+	if protocol.PrepareGetObjectV1Handler == nil {
+		globals.Logger.Warning("DataStore::GetSpecificMetaV1 not implemented")
+		go globals.RespondNotImplemented(packet, ProtocolID)
+		return
+	}
+
+	client := packet.Sender()
+	request := packet.RMCRequest()
+
+	callID := request.CallID()
+	parameters := request.Parameters()
+
+	parametersStream := nex.NewStreamIn(parameters, protocol.Server)
+
+	param, err := parametersStream.ReadStructure(datastore_types.NewDataStoreGetSpecificMetaParamV1())
+	if err != nil {
+		go protocol.GetSpecificMetaV1Handler(fmt.Errorf("Failed to read dataStoreGetSpecificMetaParamV1 from parameters. %s", err.Error()), client, callID, nil)
+		return
+	}
+
+	go protocol.GetSpecificMetaV1Handler(nil, client, callID, param.(*datastore_types.DataStoreGetSpecificMetaParamV1))
+}

--- a/datastore/get_specific_meta_v1.go
+++ b/datastore/get_specific_meta_v1.go
@@ -15,7 +15,7 @@ func (protocol *DataStoreProtocol) GetSpecificMetaV1(handler func(err error, cli
 }
 
 func (protocol *DataStoreProtocol) handleGetSpecificMetaV1(packet nex.PacketInterface) {
-	if protocol.PrepareGetObjectV1Handler == nil {
+	if protocol.GetSpecificMetaV1Handler == nil {
 		globals.Logger.Warning("DataStore::GetSpecificMetaV1 not implemented")
 		go globals.RespondNotImplemented(packet, ProtocolID)
 		return
@@ -31,7 +31,7 @@ func (protocol *DataStoreProtocol) handleGetSpecificMetaV1(packet nex.PacketInte
 
 	param, err := parametersStream.ReadStructure(datastore_types.NewDataStoreGetSpecificMetaParamV1())
 	if err != nil {
-		go protocol.GetSpecificMetaV1Handler(fmt.Errorf("Failed to read dataStoreGetSpecificMetaParamV1 from parameters. %s", err.Error()), client, callID, nil)
+		go protocol.GetSpecificMetaV1Handler(fmt.Errorf("Failed to read param from parameters. %s", err.Error()), client, callID, nil)
 		return
 	}
 

--- a/datastore/protocol.go
+++ b/datastore/protocol.go
@@ -167,11 +167,13 @@ type DataStoreProtocol struct {
 	CompleteUpdateObjectHandler         func(err error, client *nex.Client, callID uint32, dataStoreCompleteUpdateParam *datastore_types.DataStoreCompleteUpdateParam)
 	SearchObjectHandler                 func(err error, client *nex.Client, callID uint32, param *datastore_types.DataStoreSearchParam)
 	RateObjectHandler                   func(err error, client *nex.Client, callID uint32, target *datastore_types.DataStoreRatingTarget, param *datastore_types.DataStoreRateObjectParam, fetchRatings bool)
+	GetSpecificMetaV1Handler            func(err error, client *nex.Client, callID uint32, param *datastore_types.DataStoreGetSpecificMetaParamV1)
 	PostMetaBinaryHandler               func(err error, client *nex.Client, callID uint32, dataStorePreparePostParam *datastore_types.DataStorePreparePostParam)
 	PreparePostObjectHandler            func(err error, client *nex.Client, callID uint32, dataStorePrepareGetParam *datastore_types.DataStorePreparePostParam)
 	PrepareGetObjectHandler             func(err error, client *nex.Client, callID uint32, dataStorePrepareGetParam *datastore_types.DataStorePrepareGetParam)
 	CompletePostObjectHandler           func(err error, client *nex.Client, callID uint32, dataStoreCompletePostParam *datastore_types.DataStoreCompletePostParam)
 	GetNewArrivedNotificationsHandler   func(err error, client *nex.Client, callID uint32, param *datastore_types.DataStoreGetNewArrivedNotificationsParam)
+	GetSpecificMetaHandler              func(err error, client *nex.Client, callID uint32, param *datastore_types.DataStoreGetSpecificMetaParam)
 	GetPersistenceInfoHandler           func(err error, client *nex.Client, callID uint32, ownerID uint32, persistenceSlotID uint16)
 	GetMetasMultipleParamHandler        func(err error, client *nex.Client, callID uint32, dataStoreGetMetaParams []*datastore_types.DataStoreGetMetaParam)
 	CompletePostObjectsHandler          func(err error, client *nex.Client, callID uint32, dataIDs []uint64)
@@ -220,6 +222,8 @@ func (protocol *DataStoreProtocol) HandlePacket(packet nex.PacketInterface) {
 		go protocol.handleGetNewArrivedNotificationsV1(packet)
 	case MethodRateObject:
 		go protocol.handleRateObject(packet)
+	case MethodGetSpecificMetaV1:
+		go protocol.handleGetSpecificMetaV1(packet)
 	case MethodPostMetaBinary:
 		go protocol.handlePostMetaBinary(packet)
 	case MethodPreparePostObject:
@@ -230,6 +234,8 @@ func (protocol *DataStoreProtocol) HandlePacket(packet nex.PacketInterface) {
 		go protocol.handleCompletePostObject(packet)
 	case MethodGetNewArrivedNotifications:
 		go protocol.handleGetNewArrivedNotifications(packet)
+	case MethodGetSpecificMeta:
+		go protocol.handleGetSpecificMeta(packet)
 	case MethodGetPersistenceInfo:
 		go protocol.handleGetPersistenceInfo(packet)
 	case MethodGetMetasMultipleParam:

--- a/match-making/types/matchmake_session_search_criteria.go
+++ b/match-making/types/matchmake_session_search_criteria.go
@@ -22,7 +22,7 @@ type MatchmakeSessionSearchCriteria struct {
 	VacantOnly          bool
 	ExcludeLocked       bool
 	ExcludeNonHostPID   bool
-	SelectionMethod     uint32
+	SelectionMethod     uint32 // NEX v3.0.0+
 	VacantParticipants  uint16 // NEX v3.4.0+
 }
 
@@ -72,10 +72,13 @@ func (matchmakeSessionSearchCriteria *MatchmakeSessionSearchCriteria) ExtractFro
 		return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.ExcludeNonHostPID. %s", err.Error())
 	}
 
-	matchmakeSessionSearchCriteria.SelectionMethod, err = stream.ReadUInt32LE()
-	if err != nil {
-		return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.SelectionMethod. %s", err.Error())
+	if matchmakingVersion.Major >= 3 {
+		matchmakeSessionSearchCriteria.SelectionMethod, err = stream.ReadUInt32LE()
+		if err != nil {
+			return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.SelectionMethod. %s", err.Error())
+		}
 	}
+
 
 	if matchmakingVersion.Major >= 3 && matchmakingVersion.Minor >= 4 {
 		matchmakeSessionSearchCriteria.VacantParticipants, err = stream.ReadUInt16LE()
@@ -99,7 +102,10 @@ func (matchmakeSessionSearchCriteria *MatchmakeSessionSearchCriteria) Bytes(stre
 	stream.WriteBool(matchmakeSessionSearchCriteria.VacantOnly)
 	stream.WriteBool(matchmakeSessionSearchCriteria.ExcludeLocked)
 	stream.WriteBool(matchmakeSessionSearchCriteria.ExcludeNonHostPID)
-	stream.WriteUInt32LE(matchmakeSessionSearchCriteria.SelectionMethod)
+
+	if matchmakingVersion.Major >= 3 {
+		stream.WriteUInt32LE(matchmakeSessionSearchCriteria.SelectionMethod)
+	}
 
 	if matchmakingVersion.Major >= 3 && matchmakingVersion.Minor >= 4 {
 		stream.WriteUInt16LE(matchmakeSessionSearchCriteria.VacantParticipants)


### PR DESCRIPTION
## Other changes
- Add versioning to DataStore update structures
  - On Mario Kart 7, the data ID is a Uint32 and the version is a Uint16.
Specify these changes as part of NEX versions prior to 3.0.

- Update versions on MatchmakeSessionSearchCriteria
  - This field isn't present on Mario Tennis Open, which uses a NEX version
prior to 3.0.

Only the `GetSpecificMeta(V1)` method has been tested with HPP and fake data.