### PR TITLE
Add Matchmake Referee Protocol (0x78)

### DIFF
--- a/matchmake-referee/create_stats.go
+++ b/matchmake-referee/create_stats.go
@@ -1,0 +1,39 @@
+// Package matchmake_referee implements the Matchmake Referee NEX protocol
+package matchmake_referee
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+	matchmake_referee_types "github.com/PretendoNetwork/nex-protocols-go/matchmake-referee/types"
+)
+
+// CreateStats sets the CreateStats handler function
+func (protocol *MatchmakeRefereeProtocol) CreateStats(handler func(err error, client *nex.Client, callID uint32, param *matchmake_referee_types.MatchmakeRefereeStatsInitParam)) {
+	protocol.CreateStatsHandler = handler
+}
+
+func (protocol *MatchmakeRefereeProtocol) handleCreateStats(packet nex.PacketInterface) {
+	if protocol.CreateStatsHandler == nil {
+		globals.Logger.Warning("MatchmakeReferee::CreateStats not implemented")
+		go globals.RespondNotImplemented(packet, ProtocolID)
+		return
+	}
+
+	client := packet.Sender()
+	request := packet.RMCRequest()
+
+	callID := request.CallID()
+	parameters := request.Parameters()
+
+	parametersStream := nex.NewStreamIn(parameters, protocol.Server)
+
+	param, err := parametersStream.ReadStructure(matchmake_referee_types.NewMatchmakeRefereeStatsInitParam())
+	if err != nil {
+		go protocol.CreateStatsHandler(fmt.Errorf("Failed to read param from parameters. %s", err.Error()), client, callID, nil)
+		return
+	}
+
+	go protocol.CreateStatsHandler(nil, client, callID, param.(*matchmake_referee_types.MatchmakeRefereeStatsInitParam))
+}

--- a/matchmake-referee/end_round.go
+++ b/matchmake-referee/end_round.go
@@ -1,0 +1,39 @@
+// Package matchmake_referee implements the Matchmake Referee NEX protocol
+package matchmake_referee
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+	matchmake_referee_types "github.com/PretendoNetwork/nex-protocols-go/matchmake-referee/types"
+)
+
+// EndRound sets the EndRound handler function
+func (protocol *MatchmakeRefereeProtocol) EndRound(handler func(err error, client *nex.Client, callID uint32, endRoundParam *matchmake_referee_types.MatchmakeRefereeEndRoundParam)) {
+	protocol.EndRoundHandler = handler
+}
+
+func (protocol *MatchmakeRefereeProtocol) handleEndRound(packet nex.PacketInterface) {
+	if protocol.EndRoundHandler == nil {
+		globals.Logger.Warning("MatchmakeReferee::EndRound not implemented")
+		go globals.RespondNotImplemented(packet, ProtocolID)
+		return
+	}
+
+	client := packet.Sender()
+	request := packet.RMCRequest()
+
+	callID := request.CallID()
+	parameters := request.Parameters()
+
+	parametersStream := nex.NewStreamIn(parameters, protocol.Server)
+
+	endRoundParam, err := parametersStream.ReadStructure(matchmake_referee_types.NewMatchmakeRefereeEndRoundParam())
+	if err != nil {
+		go protocol.EndRoundHandler(fmt.Errorf("Failed to read endRoundParam from parameters. %s", err.Error()), client, callID, nil)
+		return
+	}
+
+	go protocol.EndRoundHandler(nil, client, callID, endRoundParam.(*matchmake_referee_types.MatchmakeRefereeEndRoundParam))
+}

--- a/matchmake-referee/end_round_without_report.go
+++ b/matchmake-referee/end_round_without_report.go
@@ -1,0 +1,38 @@
+// Package matchmake_referee implements the Matchmake Referee NEX protocol
+package matchmake_referee
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+)
+
+// EndRoundWithoutReport sets the EndRoundWithoutReport handler function
+func (protocol *MatchmakeRefereeProtocol) EndRoundWithoutReport(handler func(err error, client *nex.Client, callID uint32, roundId uint64)) {
+	protocol.EndRoundWithoutReportHandler = handler
+}
+
+func (protocol *MatchmakeRefereeProtocol) handleEndRoundWithoutReport(packet nex.PacketInterface) {
+	if protocol.EndRoundWithoutReportHandler == nil {
+		globals.Logger.Warning("MatchmakeReferee::EndRoundWithoutReport not implemented")
+		go globals.RespondNotImplemented(packet, ProtocolID)
+		return
+	}
+
+	client := packet.Sender()
+	request := packet.RMCRequest()
+
+	callID := request.CallID()
+	parameters := request.Parameters()
+
+	parametersStream := nex.NewStreamIn(parameters, protocol.Server)
+
+	roundId, err := parametersStream.ReadUInt64LE()
+	if err != nil {
+		go protocol.EndRoundWithoutReportHandler(fmt.Errorf("Failed to read roundId from parameters. %s", err.Error()), client, callID, 0)
+		return
+	}
+
+	go protocol.EndRoundWithoutReportHandler(nil, client, callID, roundId)
+}

--- a/matchmake-referee/end_round_without_report.go
+++ b/matchmake-referee/end_round_without_report.go
@@ -34,5 +34,5 @@ func (protocol *MatchmakeRefereeProtocol) handleEndRoundWithoutReport(packet nex
 		return
 	}
 
-	go protocol.EndRoundWithoutReportHandler(nil, client, callID, roundId)
+	go protocol.EndRoundWithoutReportHandler(nil, client, callID, roundID)
 }

--- a/matchmake-referee/end_round_without_report.go
+++ b/matchmake-referee/end_round_without_report.go
@@ -28,7 +28,7 @@ func (protocol *MatchmakeRefereeProtocol) handleEndRoundWithoutReport(packet nex
 
 	parametersStream := nex.NewStreamIn(parameters, protocol.Server)
 
-	roundId, err := parametersStream.ReadUInt64LE()
+	roundID, err := parametersStream.ReadUInt64LE()
 	if err != nil {
 		go protocol.EndRoundWithoutReportHandler(fmt.Errorf("Failed to read roundId from parameters. %s", err.Error()), client, callID, 0)
 		return

--- a/matchmake-referee/end_round_without_report.go
+++ b/matchmake-referee/end_round_without_report.go
@@ -30,7 +30,7 @@ func (protocol *MatchmakeRefereeProtocol) handleEndRoundWithoutReport(packet nex
 
 	roundID, err := parametersStream.ReadUInt64LE()
 	if err != nil {
-		go protocol.EndRoundWithoutReportHandler(fmt.Errorf("Failed to read roundId from parameters. %s", err.Error()), client, callID, 0)
+		go protocol.EndRoundWithoutReportHandler(fmt.Errorf("Failed to read roundID from parameters. %s", err.Error()), client, callID, 0)
 		return
 	}
 

--- a/matchmake-referee/get_not_summarized_round.go
+++ b/matchmake-referee/get_not_summarized_round.go
@@ -1,0 +1,27 @@
+// Package matchmake_referee implements the Matchmake Referee NEX protocol
+package matchmake_referee
+
+import (
+	nex "github.com/PretendoNetwork/nex-go"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+)
+
+// GetNotSummarizedRound sets the GetNotSummarizedRound handler function
+func (protocol *MatchmakeRefereeProtocol) GetNotSummarizedRound(handler func(err error, client *nex.Client, callID uint32)) {
+	protocol.GetNotSummarizedRoundHandler = handler
+}
+
+func (protocol *MatchmakeRefereeProtocol) handleGetNotSummarizedRound(packet nex.PacketInterface) {
+	if protocol.GetNotSummarizedRoundHandler == nil {
+		globals.Logger.Warning("MatchmakeReferee::GetNotSummarizedRound not implemented")
+		go globals.RespondNotImplemented(packet, ProtocolID)
+		return
+	}
+
+	client := packet.Sender()
+	request := packet.RMCRequest()
+
+	callID := request.CallID()
+
+	go protocol.GetNotSummarizedRoundHandler(nil, client, callID)
+}

--- a/matchmake-referee/get_or_create_stats.go
+++ b/matchmake-referee/get_or_create_stats.go
@@ -1,0 +1,39 @@
+// Package matchmake_referee implements the Matchmake Referee NEX protocol
+package matchmake_referee
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+	matchmake_referee_types "github.com/PretendoNetwork/nex-protocols-go/matchmake-referee/types"
+)
+
+// GetOrCreateStats sets the GetOrCreateStats handler function
+func (protocol *MatchmakeRefereeProtocol) GetOrCreateStats(handler func(err error, client *nex.Client, callID uint32, param *matchmake_referee_types.MatchmakeRefereeStatsInitParam)) {
+	protocol.GetOrCreateStatsHandler = handler
+}
+
+func (protocol *MatchmakeRefereeProtocol) handleGetOrCreateStats(packet nex.PacketInterface) {
+	if protocol.GetOrCreateStatsHandler == nil {
+		globals.Logger.Warning("MatchmakeReferee::GetOrCreateStats not implemented")
+		go globals.RespondNotImplemented(packet, ProtocolID)
+		return
+	}
+
+	client := packet.Sender()
+	request := packet.RMCRequest()
+
+	callID := request.CallID()
+	parameters := request.Parameters()
+
+	parametersStream := nex.NewStreamIn(parameters, protocol.Server)
+
+	param, err := parametersStream.ReadStructure(matchmake_referee_types.NewMatchmakeRefereeStatsInitParam())
+	if err != nil {
+		go protocol.GetOrCreateStatsHandler(fmt.Errorf("Failed to read param from parameters. %s", err.Error()), client, callID, nil)
+		return
+	}
+
+	go protocol.GetOrCreateStatsHandler(nil, client, callID, param.(*matchmake_referee_types.MatchmakeRefereeStatsInitParam))
+}

--- a/matchmake-referee/get_round.go
+++ b/matchmake-referee/get_round.go
@@ -1,0 +1,38 @@
+// Package matchmake_referee implements the Matchmake Referee NEX protocol
+package matchmake_referee
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+)
+
+// GetRound sets the GetRound handler function
+func (protocol *MatchmakeRefereeProtocol) GetRound(handler func(err error, client *nex.Client, callID uint32, roundId uint64)) {
+	protocol.GetRoundHandler = handler
+}
+
+func (protocol *MatchmakeRefereeProtocol) handleGetRound(packet nex.PacketInterface) {
+	if protocol.GetRoundHandler == nil {
+		globals.Logger.Warning("MatchmakeReferee::GetRound not implemented")
+		go globals.RespondNotImplemented(packet, ProtocolID)
+		return
+	}
+
+	client := packet.Sender()
+	request := packet.RMCRequest()
+
+	callID := request.CallID()
+	parameters := request.Parameters()
+
+	parametersStream := nex.NewStreamIn(parameters, protocol.Server)
+
+	roundId, err := parametersStream.ReadUInt64LE()
+	if err != nil {
+		go protocol.GetRoundHandler(fmt.Errorf("Failed to read roundId from parameters. %s", err.Error()), client, callID, 0)
+		return
+	}
+
+	go protocol.GetRoundHandler(nil, client, callID, roundId)
+}

--- a/matchmake-referee/get_round.go
+++ b/matchmake-referee/get_round.go
@@ -9,7 +9,7 @@ import (
 )
 
 // GetRound sets the GetRound handler function
-func (protocol *MatchmakeRefereeProtocol) GetRound(handler func(err error, client *nex.Client, callID uint32, roundId uint64)) {
+func (protocol *MatchmakeRefereeProtocol) GetRound(handler func(err error, client *nex.Client, callID uint32, roundID uint64)) {
 	protocol.GetRoundHandler = handler
 }
 
@@ -28,11 +28,11 @@ func (protocol *MatchmakeRefereeProtocol) handleGetRound(packet nex.PacketInterf
 
 	parametersStream := nex.NewStreamIn(parameters, protocol.Server)
 
-	roundId, err := parametersStream.ReadUInt64LE()
+	roundID, err := parametersStream.ReadUInt64LE()
 	if err != nil {
-		go protocol.GetRoundHandler(fmt.Errorf("Failed to read roundId from parameters. %s", err.Error()), client, callID, 0)
+		go protocol.GetRoundHandler(fmt.Errorf("Failed to read roundID from parameters. %s", err.Error()), client, callID, 0)
 		return
 	}
 
-	go protocol.GetRoundHandler(nil, client, callID, roundId)
+	go protocol.GetRoundHandler(nil, client, callID, roundID)
 }

--- a/matchmake-referee/get_round_participants.go
+++ b/matchmake-referee/get_round_participants.go
@@ -9,7 +9,7 @@ import (
 )
 
 // GetRoundParticipants sets the GetRoundParticipants handler function
-func (protocol *MatchmakeRefereeProtocol) GetRoundParticipants(handler func(err error, client *nex.Client, callID uint32, roundId uint64)) {
+func (protocol *MatchmakeRefereeProtocol) GetRoundParticipants(handler func(err error, client *nex.Client, callID uint32, roundID uint64)) {
 	protocol.GetRoundParticipantsHandler = handler
 }
 
@@ -28,11 +28,11 @@ func (protocol *MatchmakeRefereeProtocol) handleGetRoundParticipants(packet nex.
 
 	parametersStream := nex.NewStreamIn(parameters, protocol.Server)
 
-	roundId, err := parametersStream.ReadUInt64LE()
+	roundID, err := parametersStream.ReadUInt64LE()
 	if err != nil {
-		go protocol.GetRoundParticipantsHandler(fmt.Errorf("Failed to read roundId from parameters. %s", err.Error()), client, callID, 0)
+		go protocol.GetRoundParticipantsHandler(fmt.Errorf("Failed to read roundID from parameters. %s", err.Error()), client, callID, 0)
 		return
 	}
 
-	go protocol.GetRoundParticipantsHandler(nil, client, callID, roundId)
+	go protocol.GetRoundParticipantsHandler(nil, client, callID, roundID)
 }

--- a/matchmake-referee/get_round_participants.go
+++ b/matchmake-referee/get_round_participants.go
@@ -1,0 +1,38 @@
+// Package matchmake_referee implements the Matchmake Referee NEX protocol
+package matchmake_referee
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+)
+
+// GetRoundParticipants sets the GetRoundParticipants handler function
+func (protocol *MatchmakeRefereeProtocol) GetRoundParticipants(handler func(err error, client *nex.Client, callID uint32, roundId uint64)) {
+	protocol.GetRoundParticipantsHandler = handler
+}
+
+func (protocol *MatchmakeRefereeProtocol) handleGetRoundParticipants(packet nex.PacketInterface) {
+	if protocol.GetRoundParticipantsHandler == nil {
+		globals.Logger.Warning("MatchmakeReferee::GetRoundParticipants not implemented")
+		go globals.RespondNotImplemented(packet, ProtocolID)
+		return
+	}
+
+	client := packet.Sender()
+	request := packet.RMCRequest()
+
+	callID := request.CallID()
+	parameters := request.Parameters()
+
+	parametersStream := nex.NewStreamIn(parameters, protocol.Server)
+
+	roundId, err := parametersStream.ReadUInt64LE()
+	if err != nil {
+		go protocol.GetRoundParticipantsHandler(fmt.Errorf("Failed to read roundId from parameters. %s", err.Error()), client, callID, 0)
+		return
+	}
+
+	go protocol.GetRoundParticipantsHandler(nil, client, callID, roundId)
+}

--- a/matchmake-referee/get_start_round_param.go
+++ b/matchmake-referee/get_start_round_param.go
@@ -1,0 +1,38 @@
+// Package matchmake_referee implements the Matchmake Referee NEX protocol
+package matchmake_referee
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+)
+
+// GetStartRoundParam sets the GetStartRoundParam handler function
+func (protocol *MatchmakeRefereeProtocol) GetStartRoundParam(handler func(err error, client *nex.Client, callID uint32, roundId uint64)) {
+	protocol.GetStartRoundParamHandler = handler
+}
+
+func (protocol *MatchmakeRefereeProtocol) handleGetStartRoundParam(packet nex.PacketInterface) {
+	if protocol.GetStartRoundParamHandler == nil {
+		globals.Logger.Warning("MatchmakeReferee::GetStartRoundParam not implemented")
+		go globals.RespondNotImplemented(packet, ProtocolID)
+		return
+	}
+
+	client := packet.Sender()
+	request := packet.RMCRequest()
+
+	callID := request.CallID()
+	parameters := request.Parameters()
+
+	parametersStream := nex.NewStreamIn(parameters, protocol.Server)
+
+	roundId, err := parametersStream.ReadUInt64LE()
+	if err != nil {
+		go protocol.GetStartRoundParamHandler(fmt.Errorf("Failed to read roundId from parameters. %s", err.Error()), client, callID, 0)
+		return
+	}
+
+	go protocol.GetStartRoundParamHandler(nil, client, callID, roundId)
+}

--- a/matchmake-referee/get_start_round_param.go
+++ b/matchmake-referee/get_start_round_param.go
@@ -9,7 +9,7 @@ import (
 )
 
 // GetStartRoundParam sets the GetStartRoundParam handler function
-func (protocol *MatchmakeRefereeProtocol) GetStartRoundParam(handler func(err error, client *nex.Client, callID uint32, roundId uint64)) {
+func (protocol *MatchmakeRefereeProtocol) GetStartRoundParam(handler func(err error, client *nex.Client, callID uint32, roundID uint64)) {
 	protocol.GetStartRoundParamHandler = handler
 }
 
@@ -28,11 +28,11 @@ func (protocol *MatchmakeRefereeProtocol) handleGetStartRoundParam(packet nex.Pa
 
 	parametersStream := nex.NewStreamIn(parameters, protocol.Server)
 
-	roundId, err := parametersStream.ReadUInt64LE()
+	roundID, err := parametersStream.ReadUInt64LE()
 	if err != nil {
-		go protocol.GetStartRoundParamHandler(fmt.Errorf("Failed to read roundId from parameters. %s", err.Error()), client, callID, 0)
+		go protocol.GetStartRoundParamHandler(fmt.Errorf("Failed to read roundID from parameters. %s", err.Error()), client, callID, 0)
 		return
 	}
 
-	go protocol.GetStartRoundParamHandler(nil, client, callID, roundId)
+	go protocol.GetStartRoundParamHandler(nil, client, callID, roundID)
 }

--- a/matchmake-referee/get_stats_all.go
+++ b/matchmake-referee/get_stats_all.go
@@ -1,0 +1,39 @@
+// Package matchmake_referee implements the Matchmake Referee NEX protocol
+package matchmake_referee
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+	matchmake_referee_types "github.com/PretendoNetwork/nex-protocols-go/matchmake-referee/types"
+)
+
+// GetStatsAll sets the GetStatsAll handler function
+func (protocol *MatchmakeRefereeProtocol) GetStatsAll(handler func(err error, client *nex.Client, callID uint32, target *matchmake_referee_types.MatchmakeRefereeStatsTarget)) {
+	protocol.GetStatsAllHandler = handler
+}
+
+func (protocol *MatchmakeRefereeProtocol) handleGetStatsAll(packet nex.PacketInterface) {
+	if protocol.GetStatsAllHandler == nil {
+		globals.Logger.Warning("MatchmakeReferee::GetStatsAll not implemented")
+		go globals.RespondNotImplemented(packet, ProtocolID)
+		return
+	}
+
+	client := packet.Sender()
+	request := packet.RMCRequest()
+
+	callID := request.CallID()
+	parameters := request.Parameters()
+
+	parametersStream := nex.NewStreamIn(parameters, protocol.Server)
+
+	target, err := parametersStream.ReadStructure(matchmake_referee_types.NewMatchmakeRefereeStatsTarget())
+	if err != nil {
+		go protocol.GetStatsAllHandler(fmt.Errorf("Failed to read target from parameters. %s", err.Error()), client, callID, nil)
+		return
+	}
+
+	go protocol.GetStatsAllHandler(nil, client, callID, target.(*matchmake_referee_types.MatchmakeRefereeStatsTarget))
+}

--- a/matchmake-referee/get_stats_primaries.go
+++ b/matchmake-referee/get_stats_primaries.go
@@ -1,0 +1,39 @@
+// Package matchmake_referee implements the Matchmake Referee NEX protocol
+package matchmake_referee
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+	matchmake_referee_types "github.com/PretendoNetwork/nex-protocols-go/matchmake-referee/types"
+)
+
+// GetStatsPrimaries sets the GetStatsPrimaries handler function
+func (protocol *MatchmakeRefereeProtocol) GetStatsPrimaries(handler func(err error, client *nex.Client, callID uint32, targets []*matchmake_referee_types.MatchmakeRefereeStatsTarget)) {
+	protocol.GetStatsPrimariesHandler = handler
+}
+
+func (protocol *MatchmakeRefereeProtocol) handleGetStatsPrimaries(packet nex.PacketInterface) {
+	if protocol.GetStatsPrimariesHandler == nil {
+		globals.Logger.Warning("MatchmakeReferee::GetStatsPrimaries not implemented")
+		go globals.RespondNotImplemented(packet, ProtocolID)
+		return
+	}
+
+	client := packet.Sender()
+	request := packet.RMCRequest()
+
+	callID := request.CallID()
+	parameters := request.Parameters()
+
+	parametersStream := nex.NewStreamIn(parameters, protocol.Server)
+
+	targets, err := parametersStream.ReadListStructure(matchmake_referee_types.NewMatchmakeRefereeStatsTarget())
+	if err != nil {
+		go protocol.GetStatsPrimariesHandler(fmt.Errorf("Failed to read targets from parameters. %s", err.Error()), client, callID, nil)
+		return
+	}
+
+	go protocol.GetStatsPrimariesHandler(nil, client, callID, targets.([]*matchmake_referee_types.MatchmakeRefereeStatsTarget))
+}

--- a/matchmake-referee/get_stats_primary.go
+++ b/matchmake-referee/get_stats_primary.go
@@ -1,0 +1,39 @@
+// Package matchmake_referee implements the Matchmake Referee NEX protocol
+package matchmake_referee
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+	matchmake_referee_types "github.com/PretendoNetwork/nex-protocols-go/matchmake-referee/types"
+)
+
+// GetStatsPrimary sets the GetStatsPrimary handler function
+func (protocol *MatchmakeRefereeProtocol) GetStatsPrimary(handler func(err error, client *nex.Client, callID uint32, target *matchmake_referee_types.MatchmakeRefereeStatsTarget)) {
+	protocol.GetStatsPrimaryHandler = handler
+}
+
+func (protocol *MatchmakeRefereeProtocol) handleGetStatsPrimary(packet nex.PacketInterface) {
+	if protocol.GetStatsPrimaryHandler == nil {
+		globals.Logger.Warning("MatchmakeReferee::GetStatsPrimary not implemented")
+		go globals.RespondNotImplemented(packet, ProtocolID)
+		return
+	}
+
+	client := packet.Sender()
+	request := packet.RMCRequest()
+
+	callID := request.CallID()
+	parameters := request.Parameters()
+
+	parametersStream := nex.NewStreamIn(parameters, protocol.Server)
+
+	target, err := parametersStream.ReadStructure(matchmake_referee_types.NewMatchmakeRefereeStatsTarget())
+	if err != nil {
+		go protocol.GetStatsPrimaryHandler(fmt.Errorf("Failed to read target from parameters. %s", err.Error()), client, callID, nil)
+		return
+	}
+
+	go protocol.GetStatsPrimaryHandler(nil, client, callID, target.(*matchmake_referee_types.MatchmakeRefereeStatsTarget))
+}

--- a/matchmake-referee/protocol.go
+++ b/matchmake-referee/protocol.go
@@ -1,0 +1,122 @@
+// Package matchmake_referee implements the Matchmake Referee NEX protocol
+package matchmake_referee
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+	matchmake_referee_types "github.com/PretendoNetwork/nex-protocols-go/matchmake-referee/types"
+)
+
+const (
+	// ProtocolID is the protocol ID for the Message Delivery protocol
+	ProtocolID = 0x78
+
+	// MethodStartRound is the method ID for the method StartRound
+	MethodStartRound = 0x1
+
+	// MethodGetStartRoundParam is the method ID for the method GetStartRoundParam
+	MethodGetStartRoundParam = 0x2
+
+	// MethodEndRound is the method ID for the method EndRound
+	MethodEndRound = 0x3
+
+	// MethodEndRoundWithoutReport is the method ID for the method EndRoundWithoutReport
+	MethodEndRoundWithoutReport = 0x4
+
+	// MethodGetRoundParticipants is the method ID for the method GetRoundParticipants
+	MethodGetRoundParticipants = 0x5
+
+	// MethodGetNotSummarizedRound is the method ID for the method GetNotSummarizedRound
+	MethodGetNotSummarizedRound = 0x6
+
+	// MethodGetRound is the method ID for the method GetRound
+	MethodGetRound = 0x7
+
+	// MethodGetStatsPrimary is the method ID for the method GetStatsPrimary
+	MethodGetStatsPrimary = 0x8
+
+	// MethodGetStatsPrimaries is the method ID for the method GetStatsPrimaries
+	MethodGetStatsPrimaries = 0x9
+
+	// MethodGetStatsAll is the method ID for the method GetStatsAll
+	MethodGetStatsAll = 0xA
+
+	// MethodCreateStats is the method ID for the method CreateStats
+	MethodCreateStats = 0xB
+
+	// MethodGetOrCreateStats is the method ID for the method GetOrCreateStats
+	MethodGetOrCreateStats = 0xC
+
+	// MethodResetStats is the method ID for the method ResetStats
+	MethodResetStats = 0xD
+)
+
+// MatchmakeRefereeProtocol handles the Matchmake Referee NEX protocol
+type MatchmakeRefereeProtocol struct {
+	Server                       *nex.Server
+	StartRoundHandler            func(err error, client *nex.Client, callID uint32, param *matchmake_referee_types.MatchmakeRefereeStartRoundParam)
+	GetStartRoundParamHandler    func(err error, client *nex.Client, callID uint32, roundId uint64)
+	EndRoundHandler              func(err error, client *nex.Client, callID uint32, endRoundParam *matchmake_referee_types.MatchmakeRefereeEndRoundParam)
+	EndRoundWithoutReportHandler func(err error, client *nex.Client, callID uint32, roundId uint64)
+	GetRoundParticipantsHandler  func(err error, client *nex.Client, callID uint32, roundId uint64)
+	GetNotSummarizedRoundHandler func(err error, client *nex.Client, callID uint32)
+	GetRoundHandler              func(err error, client *nex.Client, callID uint32, roundId uint64)
+	GetStatsPrimaryHandler       func(err error, client *nex.Client, callID uint32, target *matchmake_referee_types.MatchmakeRefereeStatsTarget)
+	GetStatsPrimariesHandler     func(err error, client *nex.Client, callID uint32, targets []*matchmake_referee_types.MatchmakeRefereeStatsTarget)
+	GetStatsAllHandler           func(err error, client *nex.Client, callID uint32, target *matchmake_referee_types.MatchmakeRefereeStatsTarget)
+	CreateStatsHandler           func(err error, client *nex.Client, callID uint32, param *matchmake_referee_types.MatchmakeRefereeStatsInitParam)
+	GetOrCreateStatsHandler      func(err error, client *nex.Client, callID uint32, param *matchmake_referee_types.MatchmakeRefereeStatsInitParam)
+	ResetStatsHandler            func(err error, client *nex.Client, callID uint32)
+}
+
+// Setup initializes the protocol
+func (protocol *MatchmakeRefereeProtocol) Setup() {
+	protocol.Server.On("Data", func(packet nex.PacketInterface) {
+		request := packet.RMCRequest()
+
+		if request.ProtocolID() == ProtocolID {
+			switch request.MethodID() {
+			case MethodStartRound:
+				go protocol.handleStartRound(packet)
+			case MethodGetStartRoundParam:
+				go protocol.handleGetStartRoundParam(packet)
+			case MethodEndRound:
+				go protocol.handleEndRound(packet)
+			case MethodEndRoundWithoutReport:
+				go protocol.handleEndRoundWithoutReport(packet)
+			case MethodGetRoundParticipants:
+				go protocol.handleGetRoundParticipants(packet)
+			case MethodGetNotSummarizedRound:
+				go protocol.handleGetNotSummarizedRound(packet)
+			case MethodGetRound:
+				go protocol.handleGetRound(packet)
+			case MethodGetStatsPrimary:
+				go protocol.handleGetStatsPrimary(packet)
+			case MethodGetStatsPrimaries:
+				go protocol.handleGetStatsPrimaries(packet)
+			case MethodGetStatsAll:
+				go protocol.handleGetStatsAll(packet)
+			case MethodCreateStats:
+				go protocol.handleCreateStats(packet)
+			case MethodGetOrCreateStats:
+				go protocol.handleGetOrCreateStats(packet)
+			case MethodResetStats:
+				go protocol.handleResetStats(packet)
+			default:
+				go globals.RespondNotImplemented(packet, ProtocolID)
+				fmt.Printf("Unsupported MatchmakeReferee method ID: %#v\n", request.MethodID())
+			}
+		}
+	})
+}
+
+// NewMatchmakeRefereeProtocol returns a new MatchmakeRefereeProtocol
+func NewMatchmakeRefereeProtocol(server *nex.Server) *MatchmakeRefereeProtocol {
+	protocol := &MatchmakeRefereeProtocol{Server: server}
+
+	protocol.Setup()
+
+	return protocol
+}

--- a/matchmake-referee/protocol.go
+++ b/matchmake-referee/protocol.go
@@ -57,12 +57,12 @@ const (
 type MatchmakeRefereeProtocol struct {
 	Server                       *nex.Server
 	StartRoundHandler            func(err error, client *nex.Client, callID uint32, param *matchmake_referee_types.MatchmakeRefereeStartRoundParam)
-	GetStartRoundParamHandler    func(err error, client *nex.Client, callID uint32, roundId uint64)
+	GetStartRoundParamHandler    func(err error, client *nex.Client, callID uint32, roundID uint64)
 	EndRoundHandler              func(err error, client *nex.Client, callID uint32, endRoundParam *matchmake_referee_types.MatchmakeRefereeEndRoundParam)
-	EndRoundWithoutReportHandler func(err error, client *nex.Client, callID uint32, roundId uint64)
-	GetRoundParticipantsHandler  func(err error, client *nex.Client, callID uint32, roundId uint64)
+	EndRoundWithoutReportHandler func(err error, client *nex.Client, callID uint32, roundID uint64)
+	GetRoundParticipantsHandler  func(err error, client *nex.Client, callID uint32, roundID uint64)
 	GetNotSummarizedRoundHandler func(err error, client *nex.Client, callID uint32)
-	GetRoundHandler              func(err error, client *nex.Client, callID uint32, roundId uint64)
+	GetRoundHandler              func(err error, client *nex.Client, callID uint32, roundID uint64)
 	GetStatsPrimaryHandler       func(err error, client *nex.Client, callID uint32, target *matchmake_referee_types.MatchmakeRefereeStatsTarget)
 	GetStatsPrimariesHandler     func(err error, client *nex.Client, callID uint32, targets []*matchmake_referee_types.MatchmakeRefereeStatsTarget)
 	GetStatsAllHandler           func(err error, client *nex.Client, callID uint32, target *matchmake_referee_types.MatchmakeRefereeStatsTarget)

--- a/matchmake-referee/reset_stats.go
+++ b/matchmake-referee/reset_stats.go
@@ -1,0 +1,27 @@
+// Package matchmake_referee implements the Matchmake Referee NEX protocol
+package matchmake_referee
+
+import (
+	nex "github.com/PretendoNetwork/nex-go"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+)
+
+// ResetStats sets the ResetStats handler function
+func (protocol *MatchmakeRefereeProtocol) ResetStats(handler func(err error, client *nex.Client, callID uint32)) {
+	protocol.ResetStatsHandler = handler
+}
+
+func (protocol *MatchmakeRefereeProtocol) handleResetStats(packet nex.PacketInterface) {
+	if protocol.ResetStatsHandler == nil {
+		globals.Logger.Warning("MatchmakeReferee::ResetStats not implemented")
+		go globals.RespondNotImplemented(packet, ProtocolID)
+		return
+	}
+
+	client := packet.Sender()
+	request := packet.RMCRequest()
+
+	callID := request.CallID()
+
+	go protocol.ResetStatsHandler(nil, client, callID)
+}

--- a/matchmake-referee/start_round.go
+++ b/matchmake-referee/start_round.go
@@ -1,0 +1,39 @@
+// Package matchmake_referee implements the Matchmake Referee NEX protocol
+package matchmake_referee
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+	matchmake_referee_types "github.com/PretendoNetwork/nex-protocols-go/matchmake-referee/types"
+)
+
+// StartRound sets the StartRound handler function
+func (protocol *MatchmakeRefereeProtocol) StartRound(handler func(err error, client *nex.Client, callID uint32, param *matchmake_referee_types.MatchmakeRefereeStartRoundParam)) {
+	protocol.StartRoundHandler = handler
+}
+
+func (protocol *MatchmakeRefereeProtocol) handleStartRound(packet nex.PacketInterface) {
+	if protocol.StartRoundHandler == nil {
+		globals.Logger.Warning("MatchmakeReferee::StartRound not implemented")
+		go globals.RespondNotImplemented(packet, ProtocolID)
+		return
+	}
+
+	client := packet.Sender()
+	request := packet.RMCRequest()
+
+	callID := request.CallID()
+	parameters := request.Parameters()
+
+	parametersStream := nex.NewStreamIn(parameters, protocol.Server)
+
+	param, err := parametersStream.ReadStructure(matchmake_referee_types.NewMatchmakeRefereeStartRoundParam())
+	if err != nil {
+		go protocol.StartRoundHandler(fmt.Errorf("Failed to read param from parameters. %s", err.Error()), client, callID, nil)
+		return
+	}
+
+	go protocol.StartRoundHandler(nil, client, callID, param.(*matchmake_referee_types.MatchmakeRefereeStartRoundParam))
+}

--- a/matchmake-referee/types/matchmake_referee_end_round_param.go
+++ b/matchmake-referee/types/matchmake_referee_end_round_param.go
@@ -12,13 +12,13 @@ import (
 type MatchmakeRefereeEndRoundParam struct {
 	nex.Structure
 	*nex.Data
-	RoundId              uint64
+	RoundID              uint64
 	PersonalRoundResults []*MatchmakeRefereePersonalRoundResult
 }
 
 // Bytes encodes the MatchmakeRefereeEndRoundParam and returns a byte array
 func (matchmakeRefereeEndRoundParam *MatchmakeRefereeEndRoundParam) Bytes(stream *nex.StreamOut) []byte {
-	stream.WriteUInt64LE(matchmakeRefereeEndRoundParam.RoundId)
+	stream.WriteUInt64LE(matchmakeRefereeEndRoundParam.RoundID)
 	stream.WriteListStructure(matchmakeRefereeEndRoundParam.PersonalRoundResults)
 
 	return stream.Bytes()
@@ -28,9 +28,9 @@ func (matchmakeRefereeEndRoundParam *MatchmakeRefereeEndRoundParam) Bytes(stream
 func (matchmakeRefereeEndRoundParam *MatchmakeRefereeEndRoundParam) ExtractFromStream(stream *nex.StreamIn) error {
 	var err error
 
-	matchmakeRefereeEndRoundParam.RoundId, err = stream.ReadUInt64LE()
+	matchmakeRefereeEndRoundParam.RoundID, err = stream.ReadUInt64LE()
 	if err != nil {
-		return fmt.Errorf("Failed to extract MatchmakeRefereeEndRoundParam.RoundId. %s", err.Error())
+		return fmt.Errorf("Failed to extract MatchmakeRefereeEndRoundParam.RoundID. %s", err.Error())
 	}
 
 	resultList, err := stream.ReadListStructure(NewMatchmakeRefereePersonalRoundResult())
@@ -50,7 +50,7 @@ func (matchmakeRefereeEndRoundParam *MatchmakeRefereeEndRoundParam) Copy() nex.S
 	copied.Data = matchmakeRefereeEndRoundParam.ParentType().Copy().(*nex.Data)
 	copied.SetParentType(copied.Data)
 
-	copied.RoundId = matchmakeRefereeEndRoundParam.RoundId
+	copied.RoundID = matchmakeRefereeEndRoundParam.RoundID
 
 	copied.PersonalRoundResults = make([]*MatchmakeRefereePersonalRoundResult, len(matchmakeRefereeEndRoundParam.PersonalRoundResults))
 	for i := 0; i < len(matchmakeRefereeEndRoundParam.PersonalRoundResults); i++ {
@@ -68,7 +68,7 @@ func (matchmakeRefereeEndRoundParam *MatchmakeRefereeEndRoundParam) Equals(struc
 		return false
 	}
 
-	if matchmakeRefereeEndRoundParam.RoundId != other.RoundId {
+	if matchmakeRefereeEndRoundParam.RoundID != other.RoundID {
 		return false
 	}
 
@@ -106,7 +106,7 @@ func (matchmakeRefereeEndRoundParam *MatchmakeRefereeEndRoundParam) FormatToStri
 
 	b.WriteString("MatchmakeRefereeEndRoundParam{\n")
 	b.WriteString(fmt.Sprintf("%sstructureVersion: %d,\n", indentationValues, matchmakeRefereeEndRoundParam.StructureVersion()))
-	b.WriteString(fmt.Sprintf("%sRoundId: %d,\n", indentationValues, matchmakeRefereeEndRoundParam.RoundId))
+	b.WriteString(fmt.Sprintf("%sRoundID: %d,\n", indentationValues, matchmakeRefereeEndRoundParam.RoundID))
 	if len(matchmakeRefereeEndRoundParam.PersonalRoundResults) == 0 {
 		b.WriteString(fmt.Sprintf("%sPersonalRoundResults: [],\n", indentationValues))
 	} else {

--- a/matchmake-referee/types/matchmake_referee_end_round_param.go
+++ b/matchmake-referee/types/matchmake_referee_end_round_param.go
@@ -1,0 +1,134 @@
+// Package matchmake_referee_types implements all the types used by the Matchmake Referee protocol
+package matchmake_referee_types
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go"
+)
+
+// MatchmakeRefereeEndRoundParam contains the results of a round
+type MatchmakeRefereeEndRoundParam struct {
+	nex.Structure
+	*nex.Data
+	RoundId              uint64
+	PersonalRoundResults []*MatchmakeRefereePersonalRoundResult
+}
+
+// Bytes encodes the MatchmakeRefereeEndRoundParam and returns a byte array
+func (matchmakeRefereeEndRoundParam *MatchmakeRefereeEndRoundParam) Bytes(stream *nex.StreamOut) []byte {
+	stream.WriteUInt64LE(matchmakeRefereeEndRoundParam.RoundId)
+	stream.WriteListStructure(matchmakeRefereeEndRoundParam.PersonalRoundResults)
+
+	return stream.Bytes()
+}
+
+// ExtractFromStream extracts a MatchmakeRefereeEndRoundParam structure from a stream
+func (matchmakeRefereeEndRoundParam *MatchmakeRefereeEndRoundParam) ExtractFromStream(stream *nex.StreamIn) error {
+	var err error
+
+	matchmakeRefereeEndRoundParam.RoundId, err = stream.ReadUInt64LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeEndRoundParam.RoundId. %s", err.Error())
+	}
+
+	resultList, err := stream.ReadListStructure(NewMatchmakeRefereePersonalRoundResult())
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeEndRoundParam.PersonalRoundResults. %s", err.Error())
+	}
+
+	matchmakeRefereeEndRoundParam.PersonalRoundResults = resultList.([]*MatchmakeRefereePersonalRoundResult)
+
+	return nil
+}
+
+// Copy returns a new copied instance of MatchmakeRefereeEndRoundParam
+func (matchmakeRefereeEndRoundParam *MatchmakeRefereeEndRoundParam) Copy() nex.StructureInterface {
+	copied := NewMatchmakeRefereeEndRoundParam()
+
+	copied.Data = matchmakeRefereeEndRoundParam.ParentType().Copy().(*nex.Data)
+	copied.SetParentType(copied.Data)
+
+	copied.RoundId = matchmakeRefereeEndRoundParam.RoundId
+
+	copied.PersonalRoundResults = make([]*MatchmakeRefereePersonalRoundResult, len(matchmakeRefereeEndRoundParam.PersonalRoundResults))
+	for i := 0; i < len(matchmakeRefereeEndRoundParam.PersonalRoundResults); i++ {
+		copied.PersonalRoundResults[i] = matchmakeRefereeEndRoundParam.PersonalRoundResults[i].Copy().(*MatchmakeRefereePersonalRoundResult)
+	}
+
+	return copied
+}
+
+// Equals checks if the passed Structure contains the same data as the current instance
+func (matchmakeRefereeEndRoundParam *MatchmakeRefereeEndRoundParam) Equals(structure nex.StructureInterface) bool {
+	other := structure.(*MatchmakeRefereeEndRoundParam)
+
+	if !matchmakeRefereeEndRoundParam.ParentType().Equals(other.ParentType()) {
+		return false
+	}
+
+	if matchmakeRefereeEndRoundParam.RoundId != other.RoundId {
+		return false
+	}
+
+	if matchmakeRefereeEndRoundParam.PersonalRoundResults != nil && other.PersonalRoundResults != nil {
+		if len(matchmakeRefereeEndRoundParam.PersonalRoundResults) != len(other.PersonalRoundResults) {
+			return false
+		}
+
+		for i := 0; i < len(matchmakeRefereeEndRoundParam.PersonalRoundResults); i++ {
+			if !matchmakeRefereeEndRoundParam.PersonalRoundResults[i].Equals(other.PersonalRoundResults[i]) {
+				return false
+			}
+		}
+	} else if matchmakeRefereeEndRoundParam.PersonalRoundResults == nil {
+		return false
+	} else if other.PersonalRoundResults == nil {
+		return false
+	}
+
+	return true
+}
+
+// String returns a string representation of the struct
+func (matchmakeRefereeEndRoundParam *MatchmakeRefereeEndRoundParam) String() string {
+	return matchmakeRefereeEndRoundParam.FormatToString(0)
+}
+
+// FormatToString pretty-prints the struct data using the provided indentation level
+func (matchmakeRefereeEndRoundParam *MatchmakeRefereeEndRoundParam) FormatToString(indentationLevel int) string {
+	indentationValues := strings.Repeat("\t", indentationLevel+1)
+	indentationListValues := strings.Repeat("\t", indentationLevel+2)
+	indentationEnd := strings.Repeat("\t", indentationLevel)
+
+	var b strings.Builder
+
+	b.WriteString("MatchmakeRefereeEndRoundParam{\n")
+	b.WriteString(fmt.Sprintf("%sstructureVersion: %d,\n", indentationValues, matchmakeRefereeEndRoundParam.StructureVersion()))
+	b.WriteString(fmt.Sprintf("%sRoundId: %d,\n", indentationValues, matchmakeRefereeEndRoundParam.RoundId))
+	if len(matchmakeRefereeEndRoundParam.PersonalRoundResults) == 0 {
+		b.WriteString(fmt.Sprintf("%sPersonalRoundResults: [],\n", indentationValues))
+	} else {
+		b.WriteString(fmt.Sprintf("%sPersonalRoundResults: [\n", indentationValues))
+
+		for i := 0; i < len(matchmakeRefereeEndRoundParam.PersonalRoundResults); i++ {
+			str := matchmakeRefereeEndRoundParam.PersonalRoundResults[i].FormatToString(indentationLevel + 2)
+			if i == len(matchmakeRefereeEndRoundParam.PersonalRoundResults)-1 {
+				b.WriteString(fmt.Sprintf("%s%s\n", indentationListValues, str))
+			} else {
+				b.WriteString(fmt.Sprintf("%s%s,\n", indentationListValues, str))
+			}
+		}
+
+		b.WriteString(fmt.Sprintf("%s]\n", indentationValues))
+	}
+	b.WriteString(fmt.Sprintf("%s}", indentationEnd))
+
+	return b.String()
+}
+
+// NewMatchmakeRefereeEndRoundParam returns a new MatchmakeRefereeEndRoundParam
+func NewMatchmakeRefereeEndRoundParam() *MatchmakeRefereeEndRoundParam {
+	return &MatchmakeRefereeEndRoundParam{}
+}

--- a/matchmake-referee/types/matchmake_referee_personal_round_result.go
+++ b/matchmake-referee/types/matchmake_referee_personal_round_result.go
@@ -1,0 +1,141 @@
+// Package matchmake_referee_types implements all the types used by the Matchmake Referee protocol
+package matchmake_referee_types
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go"
+)
+
+// MatchmakeRefereePersonalRoundResult contains the results of a round
+type MatchmakeRefereePersonalRoundResult struct {
+	nex.Structure
+	*nex.Data
+	PID                     uint32
+	PersonalRoundResultFlag uint32
+	RoundWinLoss            uint32
+	RatingValueChange       int32
+	Buffer                  []byte
+}
+
+// Bytes encodes the MatchmakeRefereePersonalRoundResult and returns a byte array
+func (matchmakeRefereePersonalRoundResult *MatchmakeRefereePersonalRoundResult) Bytes(stream *nex.StreamOut) []byte {
+	stream.WriteUInt32LE(matchmakeRefereePersonalRoundResult.PID)
+	stream.WriteUInt32LE(matchmakeRefereePersonalRoundResult.PersonalRoundResultFlag)
+	stream.WriteUInt32LE(matchmakeRefereePersonalRoundResult.RoundWinLoss)
+	stream.WriteInt32LE(matchmakeRefereePersonalRoundResult.RatingValueChange)
+	stream.WriteQBuffer(matchmakeRefereePersonalRoundResult.Buffer)
+
+	return stream.Bytes()
+}
+
+// ExtractFromStream extracts a MatchmakeRefereePersonalRoundResult structure from a stream
+func (matchmakeRefereePersonalRoundResult *MatchmakeRefereePersonalRoundResult) ExtractFromStream(stream *nex.StreamIn) error {
+	var err error
+
+	matchmakeRefereePersonalRoundResult.PID, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereePersonalRoundResult.PID. %s", err.Error())
+	}
+
+	matchmakeRefereePersonalRoundResult.PersonalRoundResultFlag, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereePersonalRoundResult.PersonalRoundResultFlag. %s", err.Error())
+	}
+
+	matchmakeRefereePersonalRoundResult.RoundWinLoss, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereePersonalRoundResult.RoundWinLoss. %s", err.Error())
+	}
+
+	matchmakeRefereePersonalRoundResult.RatingValueChange, err = stream.ReadInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereePersonalRoundResult.RatingValueChange. %s", err.Error())
+	}
+
+	matchmakeRefereePersonalRoundResult.Buffer, err = stream.ReadQBuffer()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereePersonalRoundResult.Buffer. %s", err.Error())
+	}
+
+	return nil
+}
+
+// Copy returns a new copied instance of MatchmakeRefereePersonalRoundResult
+func (matchmakeRefereePersonalRoundResult *MatchmakeRefereePersonalRoundResult) Copy() nex.StructureInterface {
+	copied := NewMatchmakeRefereePersonalRoundResult()
+
+	copied.Data = matchmakeRefereePersonalRoundResult.ParentType().Copy().(*nex.Data)
+	copied.SetParentType(copied.Data)
+
+	copied.PID = matchmakeRefereePersonalRoundResult.PID
+	copied.PersonalRoundResultFlag = matchmakeRefereePersonalRoundResult.PersonalRoundResultFlag
+	copied.RoundWinLoss = matchmakeRefereePersonalRoundResult.RoundWinLoss
+	copied.RatingValueChange = matchmakeRefereePersonalRoundResult.RatingValueChange
+	copied.Buffer = make([]byte, len(matchmakeRefereePersonalRoundResult.Buffer))
+	copy(copied.Buffer, matchmakeRefereePersonalRoundResult.Buffer)
+
+	return copied
+}
+
+// Equals checks if the passed Structure contains the same data as the current instance
+func (matchmakeRefereePersonalRoundResult *MatchmakeRefereePersonalRoundResult) Equals(structure nex.StructureInterface) bool {
+	other := structure.(*MatchmakeRefereePersonalRoundResult)
+
+	if !matchmakeRefereePersonalRoundResult.ParentType().Equals(other.ParentType()) {
+		return false
+	}
+
+	if matchmakeRefereePersonalRoundResult.PID != other.PID {
+		return false
+	}
+
+	if matchmakeRefereePersonalRoundResult.PersonalRoundResultFlag != other.PersonalRoundResultFlag {
+		return false
+	}
+
+	if matchmakeRefereePersonalRoundResult.RoundWinLoss != other.RoundWinLoss {
+		return false
+	}
+
+	if matchmakeRefereePersonalRoundResult.RatingValueChange != other.RatingValueChange {
+		return false
+	}
+
+	if !bytes.Equal(matchmakeRefereePersonalRoundResult.Buffer, other.Buffer) {
+		return false
+	}
+
+	return true
+}
+
+// String returns a string representation of the struct
+func (matchmakeRefereePersonalRoundResult *MatchmakeRefereePersonalRoundResult) String() string {
+	return matchmakeRefereePersonalRoundResult.FormatToString(0)
+}
+
+// FormatToString pretty-prints the struct data using the provided indentation level
+func (matchmakeRefereePersonalRoundResult *MatchmakeRefereePersonalRoundResult) FormatToString(indentationLevel int) string {
+	indentationValues := strings.Repeat("\t", indentationLevel+1)
+	indentationEnd := strings.Repeat("\t", indentationLevel)
+
+	var b strings.Builder
+
+	b.WriteString("MatchmakeRefereePersonalRoundResult{\n")
+	b.WriteString(fmt.Sprintf("%sstructureVersion: %d,\n", indentationValues, matchmakeRefereePersonalRoundResult.StructureVersion()))
+	b.WriteString(fmt.Sprintf("%sPID: %d,\n", indentationValues, matchmakeRefereePersonalRoundResult.PID))
+	b.WriteString(fmt.Sprintf("%sPersonalRoundResultFlag: %d,\n", indentationValues, matchmakeRefereePersonalRoundResult.PersonalRoundResultFlag))
+	b.WriteString(fmt.Sprintf("%sRoundWinLoss: %d,\n", indentationValues, matchmakeRefereePersonalRoundResult.RoundWinLoss))
+	b.WriteString(fmt.Sprintf("%sRatingValueChange: %d,\n", indentationValues, matchmakeRefereePersonalRoundResult.RatingValueChange))
+	b.WriteString(fmt.Sprintf("%sBuffer: %x\n", indentationValues, matchmakeRefereePersonalRoundResult.Buffer))
+	b.WriteString(fmt.Sprintf("%s}", indentationEnd))
+
+	return b.String()
+}
+
+// NewMatchmakeRefereePersonalRoundResult returns a new MatchmakeRefereePersonalRoundResult
+func NewMatchmakeRefereePersonalRoundResult() *MatchmakeRefereePersonalRoundResult {
+	return &MatchmakeRefereePersonalRoundResult{}
+}

--- a/matchmake-referee/types/matchmake_referee_round.go
+++ b/matchmake-referee/types/matchmake_referee_round.go
@@ -12,7 +12,7 @@ import (
 type MatchmakeRefereeRound struct {
 	nex.Structure
 	*nex.Data
-	RoundId                        uint64
+	RoundID                        uint64
 	GID                            uint32
 	State                          uint32
 	PersonalDataCategory           uint32
@@ -21,7 +21,7 @@ type MatchmakeRefereeRound struct {
 
 // Bytes encodes the MatchmakeRefereeRound and returns a byte array
 func (matchmakeRefereeRound *MatchmakeRefereeRound) Bytes(stream *nex.StreamOut) []byte {
-	stream.WriteUInt64LE(matchmakeRefereeRound.RoundId)
+	stream.WriteUInt64LE(matchmakeRefereeRound.RoundID)
 	stream.WriteUInt32LE(matchmakeRefereeRound.GID)
 	stream.WriteUInt32LE(matchmakeRefereeRound.State)
 	stream.WriteUInt32LE(matchmakeRefereeRound.PersonalDataCategory)
@@ -34,9 +34,9 @@ func (matchmakeRefereeRound *MatchmakeRefereeRound) Bytes(stream *nex.StreamOut)
 func (matchmakeRefereeRound *MatchmakeRefereeRound) ExtractFromStream(stream *nex.StreamIn) error {
 	var err error
 
-	matchmakeRefereeRound.RoundId, err = stream.ReadUInt64LE()
+	matchmakeRefereeRound.RoundID, err = stream.ReadUInt64LE()
 	if err != nil {
-		return fmt.Errorf("Failed to extract MatchmakeRefereeRound.RoundId. %s", err.Error())
+		return fmt.Errorf("Failed to extract MatchmakeRefereeRound.RoundID. %s", err.Error())
 	}
 
 	matchmakeRefereeRound.GID, err = stream.ReadUInt32LE()
@@ -71,7 +71,7 @@ func (matchmakeRefereeRound *MatchmakeRefereeRound) Copy() nex.StructureInterfac
 	copied.Data = matchmakeRefereeRound.ParentType().Copy().(*nex.Data)
 	copied.SetParentType(copied.Data)
 
-	copied.RoundId = matchmakeRefereeRound.RoundId
+	copied.RoundID = matchmakeRefereeRound.RoundID
 	copied.GID = matchmakeRefereeRound.GID
 	copied.State = matchmakeRefereeRound.State
 	copied.PersonalDataCategory = matchmakeRefereeRound.PersonalDataCategory
@@ -92,7 +92,7 @@ func (matchmakeRefereeRound *MatchmakeRefereeRound) Equals(structure nex.Structu
 		return false
 	}
 
-	if matchmakeRefereeRound.RoundId != other.RoundId {
+	if matchmakeRefereeRound.RoundID != other.RoundID {
 		return false
 	}
 
@@ -142,7 +142,7 @@ func (matchmakeRefereeRound *MatchmakeRefereeRound) FormatToString(indentationLe
 
 	b.WriteString("MatchmakeRefereeRound{\n")
 	b.WriteString(fmt.Sprintf("%sstructureVersion: %d,\n", indentationValues, matchmakeRefereeRound.StructureVersion()))
-	b.WriteString(fmt.Sprintf("%sRoundId: %d,\n", indentationValues, matchmakeRefereeRound.RoundId))
+	b.WriteString(fmt.Sprintf("%sRoundID: %d,\n", indentationValues, matchmakeRefereeRound.RoundID))
 	b.WriteString(fmt.Sprintf("%sGID: %d,\n", indentationValues, matchmakeRefereeRound.GID))
 	b.WriteString(fmt.Sprintf("%sState: %d,\n", indentationValues, matchmakeRefereeRound.State))
 	b.WriteString(fmt.Sprintf("%sPersonalDataCategory: %d,\n", indentationValues, matchmakeRefereeRound.PersonalDataCategory))

--- a/matchmake-referee/types/matchmake_referee_round.go
+++ b/matchmake-referee/types/matchmake_referee_round.go
@@ -1,0 +1,173 @@
+// Package matchmake_referee_types implements all the types used by the Matchmake Referee protocol
+package matchmake_referee_types
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go"
+)
+
+// MatchmakeRefereeRound contains the results of a round
+type MatchmakeRefereeRound struct {
+	nex.Structure
+	*nex.Data
+	RoundId                        uint64
+	GID                            uint32
+	State                          uint32
+	PersonalDataCategory           uint32
+	NormalizedPersonalRoundResults []*MatchmakeRefereePersonalRoundResult
+}
+
+// Bytes encodes the MatchmakeRefereeRound and returns a byte array
+func (matchmakeRefereeRound *MatchmakeRefereeRound) Bytes(stream *nex.StreamOut) []byte {
+	stream.WriteUInt64LE(matchmakeRefereeRound.RoundId)
+	stream.WriteUInt32LE(matchmakeRefereeRound.GID)
+	stream.WriteUInt32LE(matchmakeRefereeRound.State)
+	stream.WriteUInt32LE(matchmakeRefereeRound.PersonalDataCategory)
+	stream.WriteListStructure(matchmakeRefereeRound.NormalizedPersonalRoundResults)
+
+	return stream.Bytes()
+}
+
+// ExtractFromStream extracts a MatchmakeRefereeRound structure from a stream
+func (matchmakeRefereeRound *MatchmakeRefereeRound) ExtractFromStream(stream *nex.StreamIn) error {
+	var err error
+
+	matchmakeRefereeRound.RoundId, err = stream.ReadUInt64LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeRound.RoundId. %s", err.Error())
+	}
+
+	matchmakeRefereeRound.GID, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeRound.GID. %s", err.Error())
+	}
+
+	matchmakeRefereeRound.State, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeRound.State. %s", err.Error())
+	}
+
+	matchmakeRefereeRound.PersonalDataCategory, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeRound.PersonalDataCategory. %s", err.Error())
+	}
+
+	resultList, err := stream.ReadListStructure(NewMatchmakeRefereePersonalRoundResult())
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeRound.NormalizedPersonalRoundResults. %s", err.Error())
+	}
+
+	matchmakeRefereeRound.NormalizedPersonalRoundResults = resultList.([]*MatchmakeRefereePersonalRoundResult)
+
+	return nil
+}
+
+// Copy returns a new copied instance of MatchmakeRefereeRound
+func (matchmakeRefereeRound *MatchmakeRefereeRound) Copy() nex.StructureInterface {
+	copied := NewMatchmakeRefereeRound()
+
+	copied.Data = matchmakeRefereeRound.ParentType().Copy().(*nex.Data)
+	copied.SetParentType(copied.Data)
+
+	copied.RoundId = matchmakeRefereeRound.RoundId
+	copied.GID = matchmakeRefereeRound.GID
+	copied.State = matchmakeRefereeRound.State
+	copied.PersonalDataCategory = matchmakeRefereeRound.PersonalDataCategory
+
+	copied.NormalizedPersonalRoundResults = make([]*MatchmakeRefereePersonalRoundResult, len(matchmakeRefereeRound.NormalizedPersonalRoundResults))
+	for i := 0; i < len(matchmakeRefereeRound.NormalizedPersonalRoundResults); i++ {
+		copied.NormalizedPersonalRoundResults[i] = matchmakeRefereeRound.NormalizedPersonalRoundResults[i].Copy().(*MatchmakeRefereePersonalRoundResult)
+	}
+
+	return copied
+}
+
+// Equals checks if the passed Structure contains the same data as the current instance
+func (matchmakeRefereeRound *MatchmakeRefereeRound) Equals(structure nex.StructureInterface) bool {
+	other := structure.(*MatchmakeRefereeRound)
+
+	if !matchmakeRefereeRound.ParentType().Equals(other.ParentType()) {
+		return false
+	}
+
+	if matchmakeRefereeRound.RoundId != other.RoundId {
+		return false
+	}
+
+	if matchmakeRefereeRound.GID != other.GID {
+		return false
+	}
+
+	if matchmakeRefereeRound.State != other.State {
+		return false
+	}
+
+	if matchmakeRefereeRound.PersonalDataCategory != other.PersonalDataCategory {
+		return false
+	}
+
+	if matchmakeRefereeRound.NormalizedPersonalRoundResults != nil && other.NormalizedPersonalRoundResults != nil {
+		if len(matchmakeRefereeRound.NormalizedPersonalRoundResults) != len(other.NormalizedPersonalRoundResults) {
+			return false
+		}
+
+		for i := 0; i < len(matchmakeRefereeRound.NormalizedPersonalRoundResults); i++ {
+			if !matchmakeRefereeRound.NormalizedPersonalRoundResults[i].Equals(other.NormalizedPersonalRoundResults[i]) {
+				return false
+			}
+		}
+	} else if matchmakeRefereeRound.NormalizedPersonalRoundResults == nil {
+		return false
+	} else if other.NormalizedPersonalRoundResults == nil {
+		return false
+	}
+
+	return true
+}
+
+// String returns a string representation of the struct
+func (matchmakeRefereeRound *MatchmakeRefereeRound) String() string {
+	return matchmakeRefereeRound.FormatToString(0)
+}
+
+// FormatToString pretty-prints the struct data using the provided indentation level
+func (matchmakeRefereeRound *MatchmakeRefereeRound) FormatToString(indentationLevel int) string {
+	indentationValues := strings.Repeat("\t", indentationLevel+1)
+	indentationListValues := strings.Repeat("\t", indentationLevel+2)
+	indentationEnd := strings.Repeat("\t", indentationLevel)
+
+	var b strings.Builder
+
+	b.WriteString("MatchmakeRefereeRound{\n")
+	b.WriteString(fmt.Sprintf("%sstructureVersion: %d,\n", indentationValues, matchmakeRefereeRound.StructureVersion()))
+	b.WriteString(fmt.Sprintf("%sRoundId: %d,\n", indentationValues, matchmakeRefereeRound.RoundId))
+	b.WriteString(fmt.Sprintf("%sGID: %d,\n", indentationValues, matchmakeRefereeRound.GID))
+	b.WriteString(fmt.Sprintf("%sState: %d,\n", indentationValues, matchmakeRefereeRound.State))
+	b.WriteString(fmt.Sprintf("%sPersonalDataCategory: %d,\n", indentationValues, matchmakeRefereeRound.PersonalDataCategory))
+	if len(matchmakeRefereeRound.NormalizedPersonalRoundResults) == 0 {
+		b.WriteString(fmt.Sprintf("%sPersonalRoundResults: [],\n", indentationValues))
+	} else {
+		b.WriteString(fmt.Sprintf("%sPersonalRoundResults: [\n", indentationValues))
+
+		for i := 0; i < len(matchmakeRefereeRound.NormalizedPersonalRoundResults); i++ {
+			str := matchmakeRefereeRound.NormalizedPersonalRoundResults[i].FormatToString(indentationLevel + 2)
+			if i == len(matchmakeRefereeRound.NormalizedPersonalRoundResults)-1 {
+				b.WriteString(fmt.Sprintf("%s%s\n", indentationListValues, str))
+			} else {
+				b.WriteString(fmt.Sprintf("%s%s,\n", indentationListValues, str))
+			}
+		}
+
+		b.WriteString(fmt.Sprintf("%s]\n", indentationValues))
+	}
+	b.WriteString(fmt.Sprintf("%s}", indentationEnd))
+
+	return b.String()
+}
+
+// NewMatchmakeRefereeRound returns a new MatchmakeRefereeRound
+func NewMatchmakeRefereeRound() *MatchmakeRefereeRound {
+	return &MatchmakeRefereeRound{}
+}

--- a/matchmake-referee/types/matchmake_referee_start_round_param.go
+++ b/matchmake-referee/types/matchmake_referee_start_round_param.go
@@ -1,0 +1,131 @@
+// Package matchmake_referee_types implements all the types used by the Matchmake Referee protocol
+package matchmake_referee_types
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go"
+	"golang.org/x/exp/slices"
+)
+
+// MatchmakeRefereeStartRoundParam contains the results of a round
+type MatchmakeRefereeStartRoundParam struct {
+	nex.Structure
+	*nex.Data
+	PersonalDataCategory uint32
+	GID                  uint32
+	PIDs                 []uint32
+}
+
+// Bytes encodes the MatchmakeRefereeStartRoundParam and returns a byte array
+func (matchmakeRefereeStartRoundParam *MatchmakeRefereeStartRoundParam) Bytes(stream *nex.StreamOut) []byte {
+	stream.WriteUInt32LE(matchmakeRefereeStartRoundParam.PersonalDataCategory)
+	stream.WriteUInt32LE(matchmakeRefereeStartRoundParam.GID)
+	stream.WriteListUInt32LE(matchmakeRefereeStartRoundParam.PIDs)
+
+	return stream.Bytes()
+}
+
+// ExtractFromStream extracts a MatchmakeRefereeStartRoundParam structure from a stream
+func (matchmakeRefereeStartRoundParam *MatchmakeRefereeStartRoundParam) ExtractFromStream(stream *nex.StreamIn) error {
+	var err error
+
+	matchmakeRefereeStartRoundParam.PersonalDataCategory, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStartRoundParam.PersonalDataCategory. %s", err.Error())
+	}
+
+	matchmakeRefereeStartRoundParam.GID, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStartRoundParam.GID. %s", err.Error())
+	}
+
+	matchmakeRefereeStartRoundParam.PIDs, err = stream.ReadListUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStartRoundParam.PIDs. %s", err.Error())
+	}
+
+	return nil
+}
+
+// Copy returns a new copied instance of MatchmakeRefereeStartRoundParam
+func (matchmakeRefereeStartRoundParam *MatchmakeRefereeStartRoundParam) Copy() nex.StructureInterface {
+	copied := NewMatchmakeRefereeStartRoundParam()
+
+	copied.Data = matchmakeRefereeStartRoundParam.ParentType().Copy().(*nex.Data)
+	copied.SetParentType(copied.Data)
+
+	copied.PersonalDataCategory = matchmakeRefereeStartRoundParam.PersonalDataCategory
+	copied.GID = matchmakeRefereeStartRoundParam.GID
+	copied.PIDs = make([]uint32, len(matchmakeRefereeStartRoundParam.PIDs))
+	copy(copied.PIDs, matchmakeRefereeStartRoundParam.PIDs)
+
+	return copied
+}
+
+// Equals checks if the passed Structure contains the same data as the current instance
+func (matchmakeRefereeStartRoundParam *MatchmakeRefereeStartRoundParam) Equals(structure nex.StructureInterface) bool {
+	other := structure.(*MatchmakeRefereeStartRoundParam)
+
+	if !matchmakeRefereeStartRoundParam.ParentType().Equals(other.ParentType()) {
+		return false
+	}
+
+	if matchmakeRefereeStartRoundParam.PersonalDataCategory != other.PersonalDataCategory {
+		return false
+	}
+
+	if matchmakeRefereeStartRoundParam.GID != other.GID {
+		return false
+	}
+
+	if !slices.Equal(matchmakeRefereeStartRoundParam.PIDs, other.PIDs) {
+		return false
+	}
+
+	return true
+}
+
+// String returns a string representation of the struct
+func (matchmakeRefereeStartRoundParam *MatchmakeRefereeStartRoundParam) String() string {
+	return matchmakeRefereeStartRoundParam.FormatToString(0)
+}
+
+// FormatToString pretty-prints the struct data using the provided indentation level
+func (matchmakeRefereeStartRoundParam *MatchmakeRefereeStartRoundParam) FormatToString(indentationLevel int) string {
+	indentationValues := strings.Repeat("\t", indentationLevel+1)
+	indentationListValues := strings.Repeat("\t", indentationLevel+2)
+	indentationEnd := strings.Repeat("\t", indentationLevel)
+
+	var b strings.Builder
+
+	b.WriteString("MatchmakeRefereeStartRoundParam{\n")
+	b.WriteString(fmt.Sprintf("%sstructureVersion: %d,\n", indentationValues, matchmakeRefereeStartRoundParam.StructureVersion()))
+	b.WriteString(fmt.Sprintf("%sPID: %d,\n", indentationValues, matchmakeRefereeStartRoundParam.PersonalDataCategory))
+	b.WriteString(fmt.Sprintf("%sPersonalRoundResultFlag: %d,\n", indentationValues, matchmakeRefereeStartRoundParam.GID))
+	if len(matchmakeRefereeStartRoundParam.PIDs) == 0 {
+		b.WriteString(fmt.Sprintf("%sPIDs: [],\n", indentationValues))
+	} else {
+		b.WriteString(fmt.Sprintf("%sPIDs: [\n", indentationValues))
+
+		for i := 0; i < len(matchmakeRefereeStartRoundParam.PIDs); i++ {
+			str := fmt.Sprintf("%d", matchmakeRefereeStartRoundParam.PIDs[i])
+			if i == len(matchmakeRefereeStartRoundParam.PIDs)-1 {
+				b.WriteString(fmt.Sprintf("%s%s\n", indentationListValues, str))
+			} else {
+				b.WriteString(fmt.Sprintf("%s%s,\n", indentationListValues, str))
+			}
+		}
+
+		b.WriteString(fmt.Sprintf("%s]\n", indentationValues))
+	}
+	b.WriteString(fmt.Sprintf("%s}", indentationEnd))
+
+	return b.String()
+}
+
+// NewMatchmakeRefereeStartRoundParam returns a new MatchmakeRefereeStartRoundParam
+func NewMatchmakeRefereeStartRoundParam() *MatchmakeRefereeStartRoundParam {
+	return &MatchmakeRefereeStartRoundParam{}
+}

--- a/matchmake-referee/types/matchmake_referee_stats.go
+++ b/matchmake-referee/types/matchmake_referee_stats.go
@@ -1,0 +1,282 @@
+// Package matchmake_referee_types implements all the types used by the Matchmake Referee protocol
+package matchmake_referee_types
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go"
+)
+
+// MatchmakeRefereeStats contains the results of a round
+type MatchmakeRefereeStats struct {
+	nex.Structure
+	*nex.Data
+	UniqueId            uint64
+	Category            uint32
+	PID                 uint32
+	RecentDisconnection uint32
+	RecentViolation     uint32
+	RecentMismatch      uint32
+	RecentWin           uint32
+	RecentLoss          uint32
+	RecentDraw          uint32
+	TotalDisconnect     uint32
+	TotalViolation      uint32
+	TotalMismatch       uint32
+	TotalWin            uint32
+	TotalLoss           uint32
+	TotalDraw           uint32
+	RatingValue         uint32
+}
+
+// Bytes encodes the MatchmakeRefereeStats and returns a byte array
+func (matchmakeRefereeStats *MatchmakeRefereeStats) Bytes(stream *nex.StreamOut) []byte {
+	stream.WriteUInt64LE(matchmakeRefereeStats.UniqueId)
+	stream.WriteUInt32LE(matchmakeRefereeStats.Category)
+	stream.WriteUInt32LE(matchmakeRefereeStats.PID)
+	stream.WriteUInt32LE(matchmakeRefereeStats.RecentDisconnection)
+	stream.WriteUInt32LE(matchmakeRefereeStats.RecentViolation)
+	stream.WriteUInt32LE(matchmakeRefereeStats.RecentMismatch)
+	stream.WriteUInt32LE(matchmakeRefereeStats.RecentWin)
+	stream.WriteUInt32LE(matchmakeRefereeStats.RecentLoss)
+	stream.WriteUInt32LE(matchmakeRefereeStats.RecentDraw)
+	stream.WriteUInt32LE(matchmakeRefereeStats.TotalDisconnect)
+	stream.WriteUInt32LE(matchmakeRefereeStats.TotalViolation)
+	stream.WriteUInt32LE(matchmakeRefereeStats.TotalMismatch)
+	stream.WriteUInt32LE(matchmakeRefereeStats.TotalWin)
+	stream.WriteUInt32LE(matchmakeRefereeStats.TotalLoss)
+	stream.WriteUInt32LE(matchmakeRefereeStats.TotalDraw)
+	stream.WriteUInt32LE(matchmakeRefereeStats.RatingValue)
+
+	return stream.Bytes()
+}
+
+// ExtractFromStream extracts a MatchmakeRefereeStats structure from a stream
+func (matchmakeRefereeStats *MatchmakeRefereeStats) ExtractFromStream(stream *nex.StreamIn) error {
+	var err error
+
+	matchmakeRefereeStats.UniqueId, err = stream.ReadUInt64LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.UniqueId. %s", err.Error())
+	}
+
+	matchmakeRefereeStats.Category, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.Category. %s", err.Error())
+	}
+
+	matchmakeRefereeStats.PID, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.PID. %s", err.Error())
+	}
+
+	matchmakeRefereeStats.RecentDisconnection, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.RecentDisconnection. %s", err.Error())
+	}
+
+	matchmakeRefereeStats.RecentViolation, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.RecentViolation. %s", err.Error())
+	}
+
+	matchmakeRefereeStats.RecentMismatch, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.RecentMismatch. %s", err.Error())
+	}
+
+	matchmakeRefereeStats.RecentWin, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.RecentWin. %s", err.Error())
+	}
+
+	matchmakeRefereeStats.RecentLoss, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.RecentLoss. %s", err.Error())
+	}
+
+	matchmakeRefereeStats.RecentDraw, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.RecentDraw. %s", err.Error())
+	}
+
+	matchmakeRefereeStats.TotalDisconnect, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.TotalDisconnect. %s", err.Error())
+	}
+
+	matchmakeRefereeStats.TotalViolation, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.TotalViolation. %s", err.Error())
+	}
+
+	matchmakeRefereeStats.TotalMismatch, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.TotalMismatch. %s", err.Error())
+	}
+
+	matchmakeRefereeStats.TotalWin, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.TotalWin. %s", err.Error())
+	}
+
+	matchmakeRefereeStats.TotalLoss, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.TotalLoss. %s", err.Error())
+	}
+
+	matchmakeRefereeStats.TotalDraw, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.TotalDraw. %s", err.Error())
+	}
+
+	matchmakeRefereeStats.RatingValue, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.RatingValue. %s", err.Error())
+	}
+
+	return nil
+}
+
+// Copy returns a new copied instance of MatchmakeRefereeStats
+func (matchmakeRefereeStats *MatchmakeRefereeStats) Copy() nex.StructureInterface {
+	copied := NewMatchmakeRefereeStats()
+
+	copied.Data = matchmakeRefereeStats.ParentType().Copy().(*nex.Data)
+	copied.SetParentType(copied.Data)
+
+	copied.UniqueId = matchmakeRefereeStats.UniqueId
+	copied.Category = matchmakeRefereeStats.Category
+	copied.PID = matchmakeRefereeStats.PID
+	copied.RecentDisconnection = matchmakeRefereeStats.RecentDisconnection
+	copied.RecentViolation = matchmakeRefereeStats.RecentViolation
+	copied.RecentMismatch = matchmakeRefereeStats.RecentMismatch
+	copied.RecentWin = matchmakeRefereeStats.RecentWin
+	copied.RecentLoss = matchmakeRefereeStats.RecentLoss
+	copied.RecentDraw = matchmakeRefereeStats.RecentDraw
+	copied.TotalDisconnect = matchmakeRefereeStats.TotalDisconnect
+	copied.TotalViolation = matchmakeRefereeStats.TotalViolation
+	copied.TotalMismatch = matchmakeRefereeStats.TotalMismatch
+	copied.TotalWin = matchmakeRefereeStats.TotalWin
+	copied.TotalLoss = matchmakeRefereeStats.TotalLoss
+	copied.TotalDraw = matchmakeRefereeStats.TotalDraw
+	copied.RatingValue = matchmakeRefereeStats.RatingValue
+
+	return copied
+}
+
+// Equals checks if the passed Structure contains the same data as the current instance
+func (matchmakeRefereeStats *MatchmakeRefereeStats) Equals(structure nex.StructureInterface) bool {
+	other := structure.(*MatchmakeRefereeStats)
+
+	if !matchmakeRefereeStats.ParentType().Equals(other.ParentType()) {
+		return false
+	}
+
+	if matchmakeRefereeStats.UniqueId != other.UniqueId {
+		return false
+	}
+
+	if matchmakeRefereeStats.Category != other.Category {
+		return false
+	}
+
+	if matchmakeRefereeStats.PID != other.PID {
+		return false
+	}
+
+	if matchmakeRefereeStats.RecentDisconnection != other.RecentDisconnection {
+		return false
+	}
+
+	if matchmakeRefereeStats.RecentViolation != other.RecentViolation {
+		return false
+	}
+
+	if matchmakeRefereeStats.RecentMismatch != other.RecentMismatch {
+		return false
+	}
+
+	if matchmakeRefereeStats.RecentWin != other.RecentWin {
+		return false
+	}
+
+	if matchmakeRefereeStats.RecentLoss != other.RecentLoss {
+		return false
+	}
+
+	if matchmakeRefereeStats.RecentDraw != other.RecentDraw {
+		return false
+	}
+
+	if matchmakeRefereeStats.TotalDisconnect != other.TotalDisconnect {
+		return false
+	}
+
+	if matchmakeRefereeStats.TotalViolation != other.TotalViolation {
+		return false
+	}
+
+	if matchmakeRefereeStats.TotalMismatch != other.TotalMismatch {
+		return false
+	}
+
+	if matchmakeRefereeStats.TotalWin != other.TotalWin {
+		return false
+	}
+
+	if matchmakeRefereeStats.TotalLoss != other.TotalLoss {
+		return false
+	}
+
+	if matchmakeRefereeStats.TotalDraw != other.TotalDraw {
+		return false
+	}
+
+	if matchmakeRefereeStats.RatingValue != other.RatingValue {
+		return false
+	}
+
+	return true
+}
+
+// String returns a string representation of the struct
+func (matchmakeRefereeStats *MatchmakeRefereeStats) String() string {
+	return matchmakeRefereeStats.FormatToString(0)
+}
+
+// FormatToString pretty-prints the struct data using the provided indentation level
+func (matchmakeRefereeStats *MatchmakeRefereeStats) FormatToString(indentationLevel int) string {
+	indentationValues := strings.Repeat("\t", indentationLevel+1)
+	indentationEnd := strings.Repeat("\t", indentationLevel)
+
+	var b strings.Builder
+
+	b.WriteString("MatchmakeRefereeStats{\n")
+	b.WriteString(fmt.Sprintf("%sstructureVersion: %d,\n", indentationValues, matchmakeRefereeStats.StructureVersion()))
+	b.WriteString(fmt.Sprintf("%sUniqueId: %d,\n", indentationValues, matchmakeRefereeStats.UniqueId))
+	b.WriteString(fmt.Sprintf("%sCategory: %d,\n", indentationValues, matchmakeRefereeStats.Category))
+	b.WriteString(fmt.Sprintf("%sPID: %d,\n", indentationValues, matchmakeRefereeStats.PID))
+	b.WriteString(fmt.Sprintf("%sRecentDisconnection: %d,\n", indentationValues, matchmakeRefereeStats.RecentDisconnection))
+	b.WriteString(fmt.Sprintf("%sRecentViolation: %d,\n", indentationValues, matchmakeRefereeStats.RecentViolation))
+	b.WriteString(fmt.Sprintf("%sRecentMismatch: %d,\n", indentationValues, matchmakeRefereeStats.RecentMismatch))
+	b.WriteString(fmt.Sprintf("%sRecentWin: %d,\n", indentationValues, matchmakeRefereeStats.RecentWin))
+	b.WriteString(fmt.Sprintf("%sRecentLoss: %d,\n", indentationValues, matchmakeRefereeStats.RecentLoss))
+	b.WriteString(fmt.Sprintf("%sRecentDraw: %d,\n", indentationValues, matchmakeRefereeStats.RecentDraw))
+	b.WriteString(fmt.Sprintf("%sTotalDisconnect: %d,\n", indentationValues, matchmakeRefereeStats.TotalDisconnect))
+	b.WriteString(fmt.Sprintf("%sTotalViolation: %d,\n", indentationValues, matchmakeRefereeStats.TotalViolation))
+	b.WriteString(fmt.Sprintf("%sTotalMismatch: %d,\n", indentationValues, matchmakeRefereeStats.TotalMismatch))
+	b.WriteString(fmt.Sprintf("%sTotalWin: %d,\n", indentationValues, matchmakeRefereeStats.TotalWin))
+	b.WriteString(fmt.Sprintf("%sTotalLoss: %d,\n", indentationValues, matchmakeRefereeStats.TotalLoss))
+	b.WriteString(fmt.Sprintf("%sTotalDraw: %d,\n", indentationValues, matchmakeRefereeStats.TotalDraw))
+	b.WriteString(fmt.Sprintf("%sRatingValue: %d,\n", indentationValues, matchmakeRefereeStats.RatingValue))
+	b.WriteString(fmt.Sprintf("%s}", indentationEnd))
+
+	return b.String()
+}
+
+// NewMatchmakeRefereeStats returns a new MatchmakeRefereeStats
+func NewMatchmakeRefereeStats() *MatchmakeRefereeStats {
+	return &MatchmakeRefereeStats{}
+}

--- a/matchmake-referee/types/matchmake_referee_stats.go
+++ b/matchmake-referee/types/matchmake_referee_stats.go
@@ -12,7 +12,7 @@ import (
 type MatchmakeRefereeStats struct {
 	nex.Structure
 	*nex.Data
-	UniqueId            uint64
+	UniqueID            uint64
 	Category            uint32
 	PID                 uint32
 	RecentDisconnection uint32
@@ -32,7 +32,7 @@ type MatchmakeRefereeStats struct {
 
 // Bytes encodes the MatchmakeRefereeStats and returns a byte array
 func (matchmakeRefereeStats *MatchmakeRefereeStats) Bytes(stream *nex.StreamOut) []byte {
-	stream.WriteUInt64LE(matchmakeRefereeStats.UniqueId)
+	stream.WriteUInt64LE(matchmakeRefereeStats.UniqueID)
 	stream.WriteUInt32LE(matchmakeRefereeStats.Category)
 	stream.WriteUInt32LE(matchmakeRefereeStats.PID)
 	stream.WriteUInt32LE(matchmakeRefereeStats.RecentDisconnection)
@@ -56,9 +56,9 @@ func (matchmakeRefereeStats *MatchmakeRefereeStats) Bytes(stream *nex.StreamOut)
 func (matchmakeRefereeStats *MatchmakeRefereeStats) ExtractFromStream(stream *nex.StreamIn) error {
 	var err error
 
-	matchmakeRefereeStats.UniqueId, err = stream.ReadUInt64LE()
+	matchmakeRefereeStats.UniqueID, err = stream.ReadUInt64LE()
 	if err != nil {
-		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.UniqueId. %s", err.Error())
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.UniqueID. %s", err.Error())
 	}
 
 	matchmakeRefereeStats.Category, err = stream.ReadUInt32LE()
@@ -146,7 +146,7 @@ func (matchmakeRefereeStats *MatchmakeRefereeStats) Copy() nex.StructureInterfac
 	copied.Data = matchmakeRefereeStats.ParentType().Copy().(*nex.Data)
 	copied.SetParentType(copied.Data)
 
-	copied.UniqueId = matchmakeRefereeStats.UniqueId
+	copied.UniqueID = matchmakeRefereeStats.UniqueID
 	copied.Category = matchmakeRefereeStats.Category
 	copied.PID = matchmakeRefereeStats.PID
 	copied.RecentDisconnection = matchmakeRefereeStats.RecentDisconnection
@@ -174,7 +174,7 @@ func (matchmakeRefereeStats *MatchmakeRefereeStats) Equals(structure nex.Structu
 		return false
 	}
 
-	if matchmakeRefereeStats.UniqueId != other.UniqueId {
+	if matchmakeRefereeStats.UniqueID != other.UniqueID {
 		return false
 	}
 
@@ -255,7 +255,7 @@ func (matchmakeRefereeStats *MatchmakeRefereeStats) FormatToString(indentationLe
 
 	b.WriteString("MatchmakeRefereeStats{\n")
 	b.WriteString(fmt.Sprintf("%sstructureVersion: %d,\n", indentationValues, matchmakeRefereeStats.StructureVersion()))
-	b.WriteString(fmt.Sprintf("%sUniqueId: %d,\n", indentationValues, matchmakeRefereeStats.UniqueId))
+	b.WriteString(fmt.Sprintf("%sUniqueID: %d,\n", indentationValues, matchmakeRefereeStats.UniqueID))
 	b.WriteString(fmt.Sprintf("%sCategory: %d,\n", indentationValues, matchmakeRefereeStats.Category))
 	b.WriteString(fmt.Sprintf("%sPID: %d,\n", indentationValues, matchmakeRefereeStats.PID))
 	b.WriteString(fmt.Sprintf("%sRecentDisconnection: %d,\n", indentationValues, matchmakeRefereeStats.RecentDisconnection))

--- a/matchmake-referee/types/matchmake_referee_stats_init_param.go
+++ b/matchmake-referee/types/matchmake_referee_stats_init_param.go
@@ -1,0 +1,100 @@
+// Package matchmake_referee_types implements all the types used by the Matchmake Referee protocol
+package matchmake_referee_types
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go"
+)
+
+// MatchmakeRefereeStatsInitParam contains the results of a round
+type MatchmakeRefereeStatsInitParam struct {
+	nex.Structure
+	*nex.Data
+	Category           uint32
+	InitialRatingValue uint32
+}
+
+// Bytes encodes the MatchmakeRefereeStatsInitParam and returns a byte array
+func (matchmakeRefereeStatsInitParam *MatchmakeRefereeStatsInitParam) Bytes(stream *nex.StreamOut) []byte {
+	stream.WriteUInt32LE(matchmakeRefereeStatsInitParam.Category)
+	stream.WriteUInt32LE(matchmakeRefereeStatsInitParam.InitialRatingValue)
+
+	return stream.Bytes()
+}
+
+// ExtractFromStream extracts a MatchmakeRefereeStatsInitParam structure from a stream
+func (matchmakeRefereeStatsInitParam *MatchmakeRefereeStatsInitParam) ExtractFromStream(stream *nex.StreamIn) error {
+	var err error
+
+	matchmakeRefereeStatsInitParam.Category, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStatsInitParam.Category. %s", err.Error())
+	}
+
+	matchmakeRefereeStatsInitParam.InitialRatingValue, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStatsInitParam.InitialRatingValue. %s", err.Error())
+	}
+
+	return nil
+}
+
+// Copy returns a new copied instance of MatchmakeRefereeStatsInitParam
+func (matchmakeRefereeStatsInitParam *MatchmakeRefereeStatsInitParam) Copy() nex.StructureInterface {
+	copied := NewMatchmakeRefereeStatsInitParam()
+
+	copied.Data = matchmakeRefereeStatsInitParam.ParentType().Copy().(*nex.Data)
+	copied.SetParentType(copied.Data)
+
+	copied.Category = matchmakeRefereeStatsInitParam.Category
+	copied.InitialRatingValue = matchmakeRefereeStatsInitParam.InitialRatingValue
+
+	return copied
+}
+
+// Equals checks if the passed Structure contains the same data as the current instance
+func (matchmakeRefereeStatsInitParam *MatchmakeRefereeStatsInitParam) Equals(structure nex.StructureInterface) bool {
+	other := structure.(*MatchmakeRefereeStatsInitParam)
+
+	if !matchmakeRefereeStatsInitParam.ParentType().Equals(other.ParentType()) {
+		return false
+	}
+
+	if matchmakeRefereeStatsInitParam.Category != other.Category {
+		return false
+	}
+
+	if matchmakeRefereeStatsInitParam.InitialRatingValue != other.InitialRatingValue {
+		return false
+	}
+
+	return true
+}
+
+// String returns a string representation of the struct
+func (matchmakeRefereeStatsInitParam *MatchmakeRefereeStatsInitParam) String() string {
+	return matchmakeRefereeStatsInitParam.FormatToString(0)
+}
+
+// FormatToString pretty-prints the struct data using the provided indentation level
+func (matchmakeRefereeStatsInitParam *MatchmakeRefereeStatsInitParam) FormatToString(indentationLevel int) string {
+	indentationValues := strings.Repeat("\t", indentationLevel+1)
+	indentationEnd := strings.Repeat("\t", indentationLevel)
+
+	var b strings.Builder
+
+	b.WriteString("MatchmakeRefereeStatsInitParam{\n")
+	b.WriteString(fmt.Sprintf("%sstructureVersion: %d,\n", indentationValues, matchmakeRefereeStatsInitParam.StructureVersion()))
+	b.WriteString(fmt.Sprintf("%sCategory: %d,\n", indentationValues, matchmakeRefereeStatsInitParam.Category))
+	b.WriteString(fmt.Sprintf("%sInitialRatingValue: %d,\n", indentationValues, matchmakeRefereeStatsInitParam.InitialRatingValue))
+	b.WriteString(fmt.Sprintf("%s}", indentationEnd))
+
+	return b.String()
+}
+
+// NewMatchmakeRefereeStatsInitParam returns a new MatchmakeRefereeStatsInitParam
+func NewMatchmakeRefereeStatsInitParam() *MatchmakeRefereeStatsInitParam {
+	return &MatchmakeRefereeStatsInitParam{}
+}

--- a/matchmake-referee/types/matchmake_referee_stats_target.go
+++ b/matchmake-referee/types/matchmake_referee_stats_target.go
@@ -1,0 +1,100 @@
+// Package matchmake_referee_types implements all the types used by the Matchmake Referee protocol
+package matchmake_referee_types
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go"
+)
+
+// MatchmakeRefereeStatsTarget contains the results of a round
+type MatchmakeRefereeStatsTarget struct {
+	nex.Structure
+	*nex.Data
+	PID      uint32
+	Category uint32
+}
+
+// Bytes encodes the MatchmakeRefereeStatsTarget and returns a byte array
+func (matchmakeRefereeStatsTarget *MatchmakeRefereeStatsTarget) Bytes(stream *nex.StreamOut) []byte {
+	stream.WriteUInt32LE(matchmakeRefereeStatsTarget.PID)
+	stream.WriteUInt32LE(matchmakeRefereeStatsTarget.Category)
+
+	return stream.Bytes()
+}
+
+// ExtractFromStream extracts a MatchmakeRefereeStatsTarget structure from a stream
+func (matchmakeRefereeStatsTarget *MatchmakeRefereeStatsTarget) ExtractFromStream(stream *nex.StreamIn) error {
+	var err error
+
+	matchmakeRefereeStatsTarget.PID, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStatsTarget.PID. %s", err.Error())
+	}
+
+	matchmakeRefereeStatsTarget.Category, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract MatchmakeRefereeStatsTarget.Category. %s", err.Error())
+	}
+
+	return nil
+}
+
+// Copy returns a new copied instance of MatchmakeRefereeStatsTarget
+func (matchmakeRefereeStatsTarget *MatchmakeRefereeStatsTarget) Copy() nex.StructureInterface {
+	copied := NewMatchmakeRefereeStatsTarget()
+
+	copied.Data = matchmakeRefereeStatsTarget.ParentType().Copy().(*nex.Data)
+	copied.SetParentType(copied.Data)
+
+	copied.PID = matchmakeRefereeStatsTarget.PID
+	copied.Category = matchmakeRefereeStatsTarget.Category
+
+	return copied
+}
+
+// Equals checks if the passed Structure contains the same data as the current instance
+func (matchmakeRefereeStatsTarget *MatchmakeRefereeStatsTarget) Equals(structure nex.StructureInterface) bool {
+	other := structure.(*MatchmakeRefereeStatsTarget)
+
+	if !matchmakeRefereeStatsTarget.ParentType().Equals(other.ParentType()) {
+		return false
+	}
+
+	if matchmakeRefereeStatsTarget.PID != other.PID {
+		return false
+	}
+
+	if matchmakeRefereeStatsTarget.Category != other.Category {
+		return false
+	}
+
+	return true
+}
+
+// String returns a string representation of the struct
+func (matchmakeRefereeStatsTarget *MatchmakeRefereeStatsTarget) String() string {
+	return matchmakeRefereeStatsTarget.FormatToString(0)
+}
+
+// FormatToString pretty-prints the struct data using the provided indentation level
+func (matchmakeRefereeStatsTarget *MatchmakeRefereeStatsTarget) FormatToString(indentationLevel int) string {
+	indentationValues := strings.Repeat("\t", indentationLevel+1)
+	indentationEnd := strings.Repeat("\t", indentationLevel)
+
+	var b strings.Builder
+
+	b.WriteString("MatchmakeRefereeStatsTarget{\n")
+	b.WriteString(fmt.Sprintf("%sstructureVersion: %d,\n", indentationValues, matchmakeRefereeStatsTarget.StructureVersion()))
+	b.WriteString(fmt.Sprintf("%sPID: %d,\n", indentationValues, matchmakeRefereeStatsTarget.PID))
+	b.WriteString(fmt.Sprintf("%sCategory: %d,\n", indentationValues, matchmakeRefereeStatsTarget.Category))
+	b.WriteString(fmt.Sprintf("%s}", indentationEnd))
+
+	return b.String()
+}
+
+// NewMatchmakeRefereeStatsTarget returns a new MatchmakeRefereeStatsTarget
+func NewMatchmakeRefereeStatsTarget() *MatchmakeRefereeStatsTarget {
+	return &MatchmakeRefereeStatsTarget{}
+}


### PR DESCRIPTION
Adds the full protocol, types included. Proper testing could not be performed since I've only encountered one function used in a game so far (Smash 4), but this code is heavily based upon existing code and should work just fine.