### PR TITLE
Add missing fields on MatchmakeSessionSearchCriteria

### DIFF
--- a/matchmake-extension/auto_matchmake_with_gathering_id_postpone.go
+++ b/matchmake-extension/auto_matchmake_with_gathering_id_postpone.go
@@ -2,7 +2,6 @@
 package protocol
 
 import (
-	"encoding/hex"
 	"fmt"
 
 	nex "github.com/PretendoNetwork/nex-go"
@@ -28,7 +27,6 @@ func (protocol *Protocol) handleAutoMatchmakeWithGatheringIDPostpone(packet nex.
 
 	callID := request.CallID()
 	parameters := request.Parameters()
-	globals.Logger.Info(hex.EncodeToString(parameters))
 
 	parametersStream := nex.NewStreamIn(parameters, protocol.Server)
 

--- a/matchmake-extension/auto_matchmake_with_search_criteria_postpone.go
+++ b/matchmake-extension/auto_matchmake_with_search_criteria_postpone.go
@@ -2,7 +2,6 @@
 package protocol
 
 import (
-	"encoding/hex"
 	"fmt"
 
 	nex "github.com/PretendoNetwork/nex-go"
@@ -29,7 +28,6 @@ func (protocol *Protocol) handleAutoMatchmakeWithSearchCriteriaPostpone(packet n
 
 	callID := request.CallID()
 	parameters := request.Parameters()
-	globals.Logger.Info(hex.EncodeToString(parameters))
 
 	parametersStream := nex.NewStreamIn(parameters, protocol.Server)
 


### PR DESCRIPTION
These fields weren't being read on the server which causes issues with
games that use modern versions of NEX (specifically version 3.6 or later).