### PR TITLE
Add Ranking (Legacy) protocol

### DIFF
--- a/ranking/legacy/get_specific_period_data_list.go
+++ b/ranking/legacy/get_specific_period_data_list.go
@@ -1,0 +1,104 @@
+// Package protocol implements the Ranking (Legacy) protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+)
+
+func (protocol *Protocol) handleGetSpecificPeriodDataList(packet nex.PacketInterface) {
+	var errorCode uint32
+
+	if protocol.GetSpecificPeriodDataList == nil {
+		globals.Logger.Warning("RankingLegacy::GetSpecificPeriodDataList not implemented")
+		globals.RespondError(packet, ProtocolID, nex.Errors.Core.NotImplemented)
+		return
+	}
+
+	request := packet.RMCMessage()
+
+	callID := request.CallID
+	parameters := request.Parameters
+
+	parametersStream := nex.NewStreamIn(parameters, protocol.server)
+
+	uniqueID, err := parametersStream.ReadUInt32LE()
+	if err != nil {
+		_, errorCode = protocol.GetSpecificPeriodDataList(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	category, err := parametersStream.ReadUInt32LE()
+	if err != nil {
+		_, errorCode = protocol.GetSpecificPeriodDataList(fmt.Errorf("Failed to read category from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown1, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.GetSpecificPeriodDataList(fmt.Errorf("Failed to read unknown1 from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown2, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.GetSpecificPeriodDataList(fmt.Errorf("Failed to read unknown2 from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown3, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.GetSpecificPeriodDataList(fmt.Errorf("Failed to read unknown3 from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	offset, err := parametersStream.ReadUInt32LE()
+	if err != nil {
+		_, errorCode = protocol.GetSpecificPeriodDataList(fmt.Errorf("Failed to read offset from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	length, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.GetSpecificPeriodDataList(fmt.Errorf("Failed to read length from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	rmcMessage, errorCode := protocol.GetSpecificPeriodDataList(nil, packet, callID, uniqueID, category, unknown1, unknown2, unknown3, offset, length)
+	if errorCode != 0 {
+		globals.RespondError(packet, ProtocolID, errorCode)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/get_specific_period_total.go
+++ b/ranking/legacy/get_specific_period_total.go
@@ -1,0 +1,44 @@
+// Package protocol implements the Ranking (Legacy) protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+)
+
+func (protocol *Protocol) handleGetSpecificPeriodTotal(packet nex.PacketInterface) {
+	var errorCode uint32
+
+	if protocol.GetSpecificPeriodTotal == nil {
+		globals.Logger.Warning("RankingLegacy::GetSpecificPeriodTotal not implemented")
+		globals.RespondError(packet, ProtocolID, nex.Errors.Core.NotImplemented)
+		return
+	}
+
+	request := packet.RMCMessage()
+
+	callID := request.CallID
+	parameters := request.Parameters
+
+	parametersStream := nex.NewStreamIn(parameters, protocol.server)
+
+	category, err := parametersStream.ReadUInt32LE()
+	if err != nil {
+		_, errorCode = protocol.GetSpecificPeriodTotal(fmt.Errorf("Failed to read category from parameters. %s", err.Error()), packet, callID, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	rmcMessage, errorCode := protocol.GetSpecificPeriodTotal(nil, packet, callID, category)
+	if errorCode != 0 {
+		globals.RespondError(packet, ProtocolID, errorCode)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/get_total.go
+++ b/ranking/legacy/get_total.go
@@ -1,0 +1,84 @@
+// Package protocol implements the Ranking (Legacy) protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+)
+
+func (protocol *Protocol) handleGetTotal(packet nex.PacketInterface) {
+	var errorCode uint32
+
+	if protocol.GetTotal == nil {
+		globals.Logger.Warning("RankingLegacy::GetTotal not implemented")
+		globals.RespondError(packet, ProtocolID, nex.Errors.Core.NotImplemented)
+		return
+	}
+
+	request := packet.RMCMessage()
+
+	callID := request.CallID
+	parameters := request.Parameters
+
+	parametersStream := nex.NewStreamIn(parameters, protocol.server)
+
+	category, err := parametersStream.ReadUInt32LE()
+	if err != nil {
+		_, errorCode = protocol.GetTotal(fmt.Errorf("Failed to read category from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown1, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.GetTotal(fmt.Errorf("Failed to read unknown1 from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown2, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.GetTotal(fmt.Errorf("Failed to read unknown2 from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown3, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.GetTotal(fmt.Errorf("Failed to read unknown3 from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown4, err := parametersStream.ReadUInt32LE()
+	if err != nil {
+		_, errorCode = protocol.GetTotal(fmt.Errorf("Failed to read unknown6 from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	rmcMessage, errorCode := protocol.GetTotal(nil, packet, callID, category, unknown1, unknown2, unknown3, unknown4)
+	if errorCode != 0 {
+		globals.RespondError(packet, ProtocolID, errorCode)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/protocol.go
+++ b/ranking/legacy/protocol.go
@@ -1,0 +1,163 @@
+// Package protocol implements the Ranking (Legacy) protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+)
+
+const (
+	// ProtocolID is the protocol ID for the Ranking (Legacy) protocol
+	ProtocolID = 0x70
+
+	// MethodUploadCommonData is the method ID for method UploadCommonData
+	MethodUploadCommonData = 0x5
+
+	// MethodUnknown0xE is the method ID for unknown method 0xE
+	MethodUnknown0xE = 0xE
+
+	// MethodUnknown0xF is the method ID for unknown method 0xF
+	MethodUnknown0xF = 0xF
+
+	// MethodGetTotal is the method ID for method GetTotal
+	MethodGetTotal = 0x10
+
+	// MethodUploadScoreWithLimit is the method ID for method UploadScoreWithLimit
+	MethodUploadScoreWithLimit = 0x11
+
+	// MethodUploadSpecificPeriodScore is the method ID for method UploadSpecificPeriodScore
+	MethodUploadSpecificPeriodScore = 0x14
+
+	// MethodGetSpecificPeriodDataList is the method ID for method GetSpecificPeriodDataList
+	MethodGetSpecificPeriodDataList = 0x16
+
+	// MethodGetSpecificPeriodTotal is the method ID for method GetSpecificPeriodTotal
+	MethodGetSpecificPeriodTotal = 0x19
+)
+
+// Protocol stores all the RMC method handlers for the Ranking (Legacy) protocol and listens for requests
+type Protocol struct {
+	server                    nex.ServerInterface
+	UploadCommonData          func(err error, packet nex.PacketInterface, callID uint32, uniqueID uint32, commonData []byte) (*nex.RMCMessage, uint32)
+	Unknown0xE                func(err error, packet nex.PacketInterface, callID uint32, rankingMode uint8, category uint32, scoreIndex uint8, unknown1 uint8, unknown2 uint8, unknown3 uint8, unknown4 uint8, unknown5 uint8, unknown6 uint32, offset uint32, length uint8) (*nex.RMCMessage, uint32)
+	Unknown0xF                func(err error, packet nex.PacketInterface, callID uint32, uniqueID uint32, category uint32, scoreIndex uint8, unknown1 uint8, unknown2 uint8, unknown3 uint8, unknown4 uint8, unknown5 uint8, unknown6 uint32, length uint8) (*nex.RMCMessage, uint32)
+	GetTotal                  func(err error, packet nex.PacketInterface, callID uint32, category uint32, unknown1 uint8, unknown2 uint8, unknown3 uint8, unknown4 uint32) (*nex.RMCMessage, uint32)
+	UploadScoreWithLimit      func(err error, packet nex.PacketInterface, callID uint32, uniqueID uint32, category uint32, scores []uint32, unknown1 uint8, unknown2 uint32, unknown3 uint16) (*nex.RMCMessage, uint32)
+	UploadSpecificPeriodScore func(err error, packet nex.PacketInterface, callID uint32, uniqueID uint32, category uint32, score uint32, unknown1 uint8, unknown2 uint32, unknown3 uint16) (*nex.RMCMessage, uint32)
+	GetSpecificPeriodDataList func(err error, packet nex.PacketInterface, callID uint32, uniqueID uint32, category uint32, unknown1 uint8, unknown2 uint8, unknown3 uint8, offset uint32, length uint8) (*nex.RMCMessage, uint32)
+	GetSpecificPeriodTotal    func(err error, packet nex.PacketInterface, callID uint32, category uint32) (*nex.RMCMessage, uint32)
+}
+
+type Interface interface {
+	Server() nex.ServerInterface
+	SetServer(server nex.ServerInterface)
+	SetHandlerUploadCommonData(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID uint32, commonData []byte) (*nex.RMCMessage, uint32))
+	SetHandlerUnknown0xE(handler func(err error, packet nex.PacketInterface, callID uint32, rankingMode uint8, category uint32, scoreIndex uint8, unknown1 uint8, unknown2 uint8, unknown3 uint8, unknown4 uint8, unknown5 uint8, unknown6 uint32, offset uint32, length uint8) (*nex.RMCMessage, uint32))
+	SetHandlerUnknown0xF(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID uint32, category uint32, scoreIndex uint8, unknown1 uint8, unknown2 uint8, unknown3 uint8, unknown4 uint8, unknown5 uint8, unknown6 uint32, length uint8) (*nex.RMCMessage, uint32))
+	SetHandlerGetTotal(handler func(err error, packet nex.PacketInterface, callID uint32, category uint32, unknown1 uint8, unknown2 uint8, unknown3 uint8, unknown4 uint32) (*nex.RMCMessage, uint32))
+	SetHandlerUploadScoreWithLimit(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID uint32, category uint32, scores []uint32, unknown1 uint8, unknown2 uint32, unknown3 uint16) (*nex.RMCMessage, uint32))
+	SetHandlerUploadSpecificPeriodScore(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID uint32, category uint32, score uint32, unknown1 uint8, unknown2 uint32, unknown3 uint16) (*nex.RMCMessage, uint32))
+	SetHandlerGetSpecificPeriodDataList(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID uint32, category uint32, unknown1 uint8, unknown2 uint8, unknown3 uint8, offset uint32, length uint8) (*nex.RMCMessage, uint32))
+	SetHandlerGetSpecificPeriodTotal(handler func(err error, packet nex.PacketInterface, callID uint32, category uint32) (*nex.RMCMessage, uint32))
+}
+
+// Server returns the server implementing the protocol
+func (protocol *Protocol) Server() nex.ServerInterface {
+	return protocol.server
+}
+
+// SetServer sets the server implementing the protocol
+func (protocol *Protocol) SetServer(server nex.ServerInterface) {
+	protocol.server = server
+}
+
+// SetHandlerUploadCommonData sets the handler for the UploadCommonData method
+func (protocol *Protocol) SetHandlerUploadCommonData(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID uint32, commonData []byte) (*nex.RMCMessage, uint32)) {
+	protocol.UploadCommonData = handler
+}
+
+// SetHandlerUUnknown0xE sets the handler for the Unknown0xE method
+func (protocol *Protocol) SetHandlerUnknown0xE(handler func(err error, packet nex.PacketInterface, callID uint32, rankingMode uint8, category uint32, scoreIndex uint8, unknown1 uint8, unknown2 uint8, unknown3 uint8, unknown4 uint8, unknown5 uint8, unknown6 uint32, offset uint32, length uint8) (*nex.RMCMessage, uint32)) {
+	protocol.Unknown0xE = handler
+}
+
+// SetHandlerUUnknown0xF sets the handler for the Unknown0xF method
+func (protocol *Protocol) SetHandlerUnknown0xF(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID uint32, category uint32, scoreIndex uint8, unknown1 uint8, unknown2 uint8, unknown3 uint8, unknown4 uint8, unknown5 uint8, unknown6 uint32, length uint8) (*nex.RMCMessage, uint32)) {
+	protocol.Unknown0xF = handler
+}
+
+// SetHandlerGetTotal sets the handler for the GetTotal method
+func (protocol *Protocol) SetHandlerGetTotal(handler func(err error, packet nex.PacketInterface, callID uint32, category uint32, unknown1 uint8, unknown2 uint8, unknown3 uint8, unknown4 uint32) (*nex.RMCMessage, uint32)) {
+	protocol.GetTotal = handler
+}
+
+// SetHandlerUploadScoreWithLimit sets the handler for the UploadScoreWithLimit method
+func (protocol *Protocol) SetHandlerUploadScoreWithLimit(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID uint32, category uint32, scores []uint32, unknown1 uint8, unknown2 uint32, unknown3 uint16) (*nex.RMCMessage, uint32)) {
+	protocol.UploadScoreWithLimit = handler
+}
+
+// SetHandlerUploadSpecificPeriodScore sets the handler for the UploadSpecificPeriodScore method
+func (protocol *Protocol) SetHandlerUploadSpecificPeriodScore(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID uint32, category uint32, score uint32, unknown1 uint8, unknown2 uint32, unknown3 uint16) (*nex.RMCMessage, uint32)) {
+	protocol.UploadSpecificPeriodScore = handler
+}
+
+// SetHandlerGetSpecificPeriodDataList sets the handler for the GetSpecificPeriodDataList method
+func (protocol *Protocol) SetHandlerGetSpecificPeriodDataList(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID uint32, category uint32, unknown1 uint8, unknown2 uint8, unknown3 uint8, offset uint32, length uint8) (*nex.RMCMessage, uint32)) {
+	protocol.GetSpecificPeriodDataList = handler
+}
+
+// SetHandlerGetSpecificPeriodTotal sets the handler for the GetSpecificPeriodTotal method
+func (protocol *Protocol) SetHandlerGetSpecificPeriodTotal(handler func(err error, packet nex.PacketInterface, callID uint32, category uint32) (*nex.RMCMessage, uint32)) {
+	protocol.GetSpecificPeriodTotal = handler
+}
+
+// Setup initializes the protocol
+func (protocol *Protocol) Setup() {
+	protocol.server.OnData(func(packet nex.PacketInterface) {
+		message := packet.RMCMessage()
+
+		if message.IsRequest && message.ProtocolID == ProtocolID {
+			protocol.HandlePacket(packet)
+		}
+	})
+}
+
+// HandlePacket sends the packet to the correct RMC method handler
+func (protocol *Protocol) HandlePacket(packet nex.PacketInterface) {
+	request := packet.RMCMessage()
+
+	if request.ProtocolID == ProtocolID {
+		switch request.MethodID {
+		case MethodUploadCommonData:
+			protocol.handleUploadCommonData(packet)
+		case MethodUnknown0xE:
+			protocol.handleUnknown0xE(packet)
+		case MethodUnknown0xF:
+			protocol.handleUnknown0xF(packet)
+		case MethodGetTotal:
+			protocol.handleGetTotal(packet)
+		case MethodUploadScoreWithLimit:
+			protocol.handleUploadScoreWithLimit(packet)
+		case MethodUploadSpecificPeriodScore:
+			protocol.handleUploadSpecificPeriodScore(packet)
+		case MethodGetSpecificPeriodDataList:
+			protocol.handleGetSpecificPeriodDataList(packet)
+		case MethodGetSpecificPeriodTotal:
+			protocol.handleGetSpecificPeriodTotal(packet)
+		default:
+			globals.RespondError(packet, ProtocolID, nex.Errors.Core.NotImplemented)
+			fmt.Printf("Unsupported Ranking (Legacy) method ID: %#v\n", request.MethodID)
+		}
+	}
+}
+
+// NewProtocol returns a new Ranking (Legacy) protocol
+func NewProtocol(server nex.ServerInterface) *Protocol {
+	protocol := &Protocol{server: server}
+
+	protocol.Setup()
+
+	return protocol
+}

--- a/ranking/legacy/types/ranking_data.go
+++ b/ranking/legacy/types/ranking_data.go
@@ -1,0 +1,184 @@
+// Package types implements all the types used by the Ranking (Legacy) protocol
+package types
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go"
+)
+
+// RankingData holds information about a rank
+type RankingData struct {
+	nex.Structure
+	UniqueID   uint32
+	PID        *nex.PID
+	Order      uint32
+	Category   uint32
+	Scores     []uint32
+	Unknown1   uint8
+	Unknown2   uint32
+	CommonData []byte
+}
+
+// ExtractFromStream extracts a RankingData structure from a stream
+func (rankingData *RankingData) ExtractFromStream(stream *nex.StreamIn) error {
+	var err error
+
+	rankingData.UniqueID, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingData.UniqueID from stream. %s", err.Error())
+	}
+
+	rankingData.PID, err = stream.ReadPID()
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingData.PID from stream. %s", err.Error())
+	}
+
+	rankingData.Order, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingData.Order from stream. %s", err.Error())
+	}
+
+	rankingData.Category, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingData.Category from stream. %s", err.Error())
+	}
+
+	rankingData.Scores, err = stream.ReadListUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingData.Scores from stream. %s", err.Error())
+	}
+
+	rankingData.Unknown1, err = stream.ReadUInt8()
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingData.Unknown1 from stream. %s", err.Error())
+	}
+
+	rankingData.Unknown2, err = stream.ReadUInt32LE()
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingData.Unknown2 from stream. %s", err.Error())
+	}
+
+	rankingData.CommonData, err = stream.ReadBuffer()
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingData.CommonData from stream. %s", err.Error())
+	}
+
+	return nil
+}
+
+// Bytes encodes the RankingData and returns a byte array
+func (rankingData *RankingData) Bytes(stream *nex.StreamOut) []byte {
+	stream.WriteUInt32LE(rankingData.UniqueID)
+	stream.WritePID(rankingData.PID)
+	stream.WriteUInt32LE(rankingData.Order)
+	stream.WriteUInt32LE(rankingData.Category)
+	stream.WriteListUInt32LE(rankingData.Scores)
+	stream.WriteUInt8(rankingData.Unknown1)
+	stream.WriteUInt32LE(rankingData.Unknown2)
+	stream.WriteBuffer(rankingData.CommonData)
+
+	return stream.Bytes()
+}
+
+// Copy returns a new copied instance of RankingData
+func (rankingData *RankingData) Copy() nex.StructureInterface {
+	copied := NewRankingData()
+
+	copied.SetStructureVersion(rankingData.StructureVersion())
+
+	copied.UniqueID = rankingData.UniqueID
+	copied.PID = rankingData.PID.Copy()
+	copied.Order = rankingData.Order
+	copied.Category = rankingData.Category
+	copied.Scores = make([]uint32, len(rankingData.Scores))
+
+	copy(copied.Scores, rankingData.Scores)
+
+	copied.Unknown1 = rankingData.Unknown1
+	copied.Unknown2 = rankingData.Unknown2
+	copied.CommonData = make([]byte, len(rankingData.CommonData))
+
+	copy(copied.CommonData, rankingData.CommonData)
+
+	return copied
+}
+
+// Equals checks if the passed Structure contains the same data as the current instance
+func (rankingData *RankingData) Equals(structure nex.StructureInterface) bool {
+	other := structure.(*RankingData)
+
+	if rankingData.StructureVersion() != other.StructureVersion() {
+		return false
+	}
+
+	if rankingData.UniqueID != other.UniqueID {
+		return false
+	}
+
+	if !rankingData.PID.Equals(other.PID) {
+		return false
+	}
+
+	if rankingData.Order != other.Order {
+		return false
+	}
+
+	if rankingData.Category != other.Category {
+		return false
+	}
+
+	if len(rankingData.Scores) != len(other.Scores) {
+		return false
+	}
+
+	for i := 0; i < len(rankingData.Scores); i++ {
+		if rankingData.Scores[i] != other.Scores[i] {
+			return false
+		}
+	}
+
+	if rankingData.Unknown1 != other.Unknown1 {
+		return false
+	}
+
+	if rankingData.Unknown2 != other.Unknown2 {
+		return false
+	}
+
+	return bytes.Equal(rankingData.CommonData, other.CommonData)
+}
+
+// String returns a string representation of the struct
+func (rankingData *RankingData) String() string {
+	return rankingData.FormatToString(0)
+}
+
+// FormatToString pretty-prints the struct data using the provided indentation level
+func (rankingData *RankingData) FormatToString(indentationLevel int) string {
+	indentationValues := strings.Repeat("\t", indentationLevel+1)
+	indentationEnd := strings.Repeat("\t", indentationLevel)
+
+	var b strings.Builder
+
+	b.WriteString("RankingData{\n")
+	b.WriteString(fmt.Sprintf("%sstructureVersion: %d,\n", indentationValues, rankingData.StructureVersion()))
+	b.WriteString(fmt.Sprintf("%sUniqueID: %d,\n", indentationValues, rankingData.UniqueID))
+	b.WriteString(fmt.Sprintf("%sPID: %d,\n", indentationValues, rankingData.PID))
+	b.WriteString(fmt.Sprintf("%sOrder: %d,\n", indentationValues, rankingData.Order))
+	b.WriteString(fmt.Sprintf("%sCategory: %d,\n", indentationValues, rankingData.Category))
+	b.WriteString(fmt.Sprintf("%sScores: %v,\n", indentationValues, rankingData.Scores))
+	b.WriteString(fmt.Sprintf("%sUnknown1: %d,\n", indentationValues, rankingData.Unknown1))
+	b.WriteString(fmt.Sprintf("%sUnknown2: %d,\n", indentationValues, rankingData.Unknown2))
+	b.WriteString(fmt.Sprintf("%sCommonData: %x,\n", indentationValues, rankingData.CommonData))
+	b.WriteString(fmt.Sprintf("%s}", indentationEnd))
+
+	return b.String()
+}
+
+// NewRankingData returns a new RankingData
+func NewRankingData() *RankingData {
+	return &RankingData{}
+}

--- a/ranking/legacy/unknown_0xe.go
+++ b/ranking/legacy/unknown_0xe.go
@@ -1,0 +1,144 @@
+// Package protocol implements the Ranking (Legacy) protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+)
+
+func (protocol *Protocol) handleUnknown0xE(packet nex.PacketInterface) {
+	var errorCode uint32
+
+	if protocol.Unknown0xE == nil {
+		globals.Logger.Warning("RankingLegacy::Unknown0xE not implemented")
+		globals.RespondError(packet, ProtocolID, nex.Errors.Core.NotImplemented)
+		return
+	}
+
+	request := packet.RMCMessage()
+
+	callID := request.CallID
+	parameters := request.Parameters
+
+	parametersStream := nex.NewStreamIn(parameters, protocol.server)
+
+	rankingMode, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.Unknown0xE(fmt.Errorf("Failed to read rankingMode from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	category, err := parametersStream.ReadUInt32LE()
+	if err != nil {
+		_, errorCode = protocol.Unknown0xE(fmt.Errorf("Failed to read category from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	scoreIndex, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.Unknown0xE(fmt.Errorf("Failed to read scoreIndex from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown1, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.Unknown0xE(fmt.Errorf("Failed to read unknown1 from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown2, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.Unknown0xE(fmt.Errorf("Failed to read unknown2 from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown3, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.Unknown0xE(fmt.Errorf("Failed to read unknown3 from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown4, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.Unknown0xE(fmt.Errorf("Failed to read unknown4 from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown5, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.Unknown0xE(fmt.Errorf("Failed to read unknown5 from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown6, err := parametersStream.ReadUInt32LE()
+	if err != nil {
+		_, errorCode = protocol.Unknown0xE(fmt.Errorf("Failed to read unknown6 from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	offset, err := parametersStream.ReadUInt32LE()
+	if err != nil {
+		_, errorCode = protocol.Unknown0xE(fmt.Errorf("Failed to read offset from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	length, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.Unknown0xE(fmt.Errorf("Failed to read length from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	rmcMessage, errorCode := protocol.Unknown0xE(nil, packet, callID, rankingMode, category, scoreIndex, unknown1, unknown2, unknown3, unknown4, unknown5, unknown6, offset, length)
+	if errorCode != 0 {
+		globals.RespondError(packet, ProtocolID, errorCode)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/unknown_0xf.go
+++ b/ranking/legacy/unknown_0xf.go
@@ -1,0 +1,134 @@
+// Package protocol implements the Ranking (Legacy) protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+)
+
+func (protocol *Protocol) handleUnknown0xF(packet nex.PacketInterface) {
+	var errorCode uint32
+
+	if protocol.Unknown0xF == nil {
+		globals.Logger.Warning("RankingLegacy::Unknown0xF not implemented")
+		globals.RespondError(packet, ProtocolID, nex.Errors.Core.NotImplemented)
+		return
+	}
+
+	request := packet.RMCMessage()
+
+	callID := request.CallID
+	parameters := request.Parameters
+
+	parametersStream := nex.NewStreamIn(parameters, protocol.server)
+
+	uniqueID, err := parametersStream.ReadUInt32LE()
+	if err != nil {
+		_, errorCode = protocol.Unknown0xF(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	category, err := parametersStream.ReadUInt32LE()
+	if err != nil {
+		_, errorCode = protocol.Unknown0xF(fmt.Errorf("Failed to read category from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	scoreIndex, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.Unknown0xF(fmt.Errorf("Failed to read scoreIndex from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown1, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.Unknown0xF(fmt.Errorf("Failed to read unknown1 from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown2, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.Unknown0xF(fmt.Errorf("Failed to read unknown2 from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown3, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.Unknown0xF(fmt.Errorf("Failed to read unknown3 from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown4, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.Unknown0xF(fmt.Errorf("Failed to read unknown4 from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown5, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.Unknown0xF(fmt.Errorf("Failed to read unknown5 from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown6, err := parametersStream.ReadUInt32LE()
+	if err != nil {
+		_, errorCode = protocol.Unknown0xF(fmt.Errorf("Failed to read unknown6 from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	length, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.Unknown0xF(fmt.Errorf("Failed to read length from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	rmcMessage, errorCode := protocol.Unknown0xF(nil, packet, callID, uniqueID, category, scoreIndex, unknown1, unknown2, unknown3, unknown4, unknown5, unknown6, length)
+	if errorCode != 0 {
+		globals.RespondError(packet, ProtocolID, errorCode)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/upload_common_data.go
+++ b/ranking/legacy/upload_common_data.go
@@ -1,0 +1,54 @@
+// Package protocol implements the Ranking (Legacy) protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+)
+
+func (protocol *Protocol) handleUploadCommonData(packet nex.PacketInterface) {
+	var errorCode uint32
+
+	if protocol.UploadCommonData == nil {
+		globals.Logger.Warning("RankingLegacy::UploadCommonData not implemented")
+		globals.RespondError(packet, ProtocolID, nex.Errors.Core.NotImplemented)
+		return
+	}
+
+	request := packet.RMCMessage()
+
+	callID := request.CallID
+	parameters := request.Parameters
+
+	parametersStream := nex.NewStreamIn(parameters, protocol.server)
+
+	uniqueID, err := parametersStream.ReadUInt32LE()
+	if err != nil {
+		_, errorCode = protocol.UploadCommonData(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, 0, nil)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	commonData, err := parametersStream.ReadBuffer()
+	if err != nil {
+		_, errorCode = protocol.UploadCommonData(fmt.Errorf("Failed to read commonData from parameters. %s", err.Error()), packet, callID, 0, nil)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	rmcMessage, errorCode := protocol.UploadCommonData(nil, packet, callID, uniqueID, commonData)
+	if errorCode != 0 {
+		globals.RespondError(packet, ProtocolID, errorCode)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/upload_score_with_limit.go
+++ b/ranking/legacy/upload_score_with_limit.go
@@ -1,0 +1,94 @@
+// Package protocol implements the Ranking (Legacy) protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+)
+
+func (protocol *Protocol) handleUploadScoreWithLimit(packet nex.PacketInterface) {
+	var errorCode uint32
+
+	if protocol.UploadScoreWithLimit == nil {
+		globals.Logger.Warning("RankingLegacy::UploadScoreWithLimit not implemented")
+		globals.RespondError(packet, ProtocolID, nex.Errors.Core.NotImplemented)
+		return
+	}
+
+	request := packet.RMCMessage()
+
+	callID := request.CallID
+	parameters := request.Parameters
+
+	parametersStream := nex.NewStreamIn(parameters, protocol.server)
+
+	uniqueID, err := parametersStream.ReadUInt32LE()
+	if err != nil {
+		_, errorCode = protocol.UploadScoreWithLimit(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, 0, 0, nil, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	category, err := parametersStream.ReadUInt32LE()
+	if err != nil {
+		_, errorCode = protocol.UploadScoreWithLimit(fmt.Errorf("Failed to read category from parameters. %s", err.Error()), packet, callID, 0, 0, nil, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	scores, err := parametersStream.ReadListUInt32LE()
+	if err != nil {
+		_, errorCode = protocol.UploadScoreWithLimit(fmt.Errorf("Failed to read scores from parameters. %s", err.Error()), packet, callID, 0, 0, nil, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown1, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.UploadScoreWithLimit(fmt.Errorf("Failed to read unknown1 from parameters. %s", err.Error()), packet, callID, 0, 0, nil, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown2, err := parametersStream.ReadUInt32LE()
+	if err != nil {
+		_, errorCode = protocol.UploadScoreWithLimit(fmt.Errorf("Failed to read unknown2 from parameters. %s", err.Error()), packet, callID, 0, 0, nil, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown3, err := parametersStream.ReadUInt16LE()
+	if err != nil {
+		_, errorCode = protocol.UploadScoreWithLimit(fmt.Errorf("Failed to read unknown3 from parameters. %s", err.Error()), packet, callID, 0, 0, nil, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	rmcMessage, errorCode := protocol.UploadScoreWithLimit(nil, packet, callID, uniqueID, category, scores, unknown1, unknown2, unknown3)
+	if errorCode != 0 {
+		globals.RespondError(packet, ProtocolID, errorCode)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/upload_specific_period_score.go
+++ b/ranking/legacy/upload_specific_period_score.go
@@ -1,0 +1,94 @@
+// Package protocol implements the Ranking (Legacy) protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go"
+	"github.com/PretendoNetwork/nex-protocols-go/globals"
+)
+
+func (protocol *Protocol) handleUploadSpecificPeriodScore(packet nex.PacketInterface) {
+	var errorCode uint32
+
+	if protocol.UploadSpecificPeriodScore == nil {
+		globals.Logger.Warning("RankingLegacy::UploadSpecificPeriodScore not implemented")
+		globals.RespondError(packet, ProtocolID, nex.Errors.Core.NotImplemented)
+		return
+	}
+
+	request := packet.RMCMessage()
+
+	callID := request.CallID
+	parameters := request.Parameters
+
+	parametersStream := nex.NewStreamIn(parameters, protocol.server)
+
+	uniqueID, err := parametersStream.ReadUInt32LE()
+	if err != nil {
+		_, errorCode = protocol.UploadSpecificPeriodScore(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	category, err := parametersStream.ReadUInt32LE()
+	if err != nil {
+		_, errorCode = protocol.UploadSpecificPeriodScore(fmt.Errorf("Failed to read category from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	score, err := parametersStream.ReadUInt32LE()
+	if err != nil {
+		_, errorCode = protocol.UploadSpecificPeriodScore(fmt.Errorf("Failed to read scores from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown1, err := parametersStream.ReadUInt8()
+	if err != nil {
+		_, errorCode = protocol.UploadSpecificPeriodScore(fmt.Errorf("Failed to read unknown1 from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown2, err := parametersStream.ReadUInt32LE()
+	if err != nil {
+		_, errorCode = protocol.UploadSpecificPeriodScore(fmt.Errorf("Failed to read unknown2 from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	unknown3, err := parametersStream.ReadUInt16LE()
+	if err != nil {
+		_, errorCode = protocol.UploadSpecificPeriodScore(fmt.Errorf("Failed to read unknown3 from parameters. %s", err.Error()), packet, callID, 0, 0, 0, 0, 0, 0)
+		if errorCode != 0 {
+			globals.RespondError(packet, ProtocolID, errorCode)
+		}
+
+		return
+	}
+
+	rmcMessage, errorCode := protocol.UploadSpecificPeriodScore(nil, packet, callID, uniqueID, category, score, unknown1, unknown2, unknown3)
+	if errorCode != 0 {
+		globals.RespondError(packet, ProtocolID, errorCode)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}


### PR DESCRIPTION
This protocol is the original version of the Ranking protocol, which was used before NEX 3.x. While the protocol is inside the `ranking` directory, it doesn't have any connections with the modern Ranking protocol.

The protocol is largely undocumented, due to the servers having disabled the Debug protocol and the lack of code symbols for the 3DS (which are where the protocol is used). Because of that, some parameter types may be inaccurate.

The only references we have are the Mario Kart 7 symbols, and we have various method names thanks to them.