### PR TITLE
datastore/pokemon-gen6: Add missing handler for PrepareUploadPokemon

### DIFF
--- a/datastore/pokemon-gen6/prepare_upload_pokemon.go
+++ b/datastore/pokemon-gen6/prepare_upload_pokemon.go
@@ -1,0 +1,28 @@
+package protocol
+
+import (
+	nex "github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+)
+
+func (protocol *Protocol) handlePrepareUploadPokemon(packet nex.PacketInterface) {
+	if protocol.PrepareUploadPokemon == nil {
+		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "DataStorePokemonGen6::PrepareUploadPokemon not implemented")
+
+		globals.Logger.Warning(err.Message)
+		globals.RespondError(packet, ProtocolID, err)
+
+		return
+	}
+
+	request := packet.RMCMessage()
+	callID := request.CallID
+
+	rmcMessage, rmcError := protocol.PrepareUploadPokemon(nil, packet, callID)
+	if rmcError != nil {
+		globals.RespondError(packet, ProtocolID, rmcError)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/datastore/pokemon-gen6/protocol.go
+++ b/datastore/pokemon-gen6/protocol.go
@@ -15,6 +15,9 @@ const (
 	// ProtocolID is the Protocol ID for the DataStore (Pokemon Gen6) protocol
 	ProtocolID = 0x73
 
+	// MethodPrepareUploadPokemon is the method ID for the PrepareUploadPokemon method
+	MethodPrepareUploadPokemon = 0x28
+
 	// MethodUploadPokemon is the method ID for the UploadPokemon method
 	MethodUploadPokemon = 0x29
 
@@ -38,6 +41,7 @@ const (
 )
 
 var patchedMethods = []uint32{
+	MethodPrepareUploadPokemon,
 	MethodUploadPokemon,
 	MethodSearchPokemon,
 	MethodPrepareTradePokemon,
@@ -54,6 +58,7 @@ type dataStoreProtocol = datastore.Protocol
 type Protocol struct {
 	endpoint nex.EndpointInterface
 	dataStoreProtocol
+	PrepareUploadPokemon func(err error, packet nex.PacketInterface, callID uint32) (*nex.RMCMessage, *nex.Error)
 	UploadPokemon        func(err error, packet nex.PacketInterface, callID uint32, param *datastore_pokemon_gen6_types.GlobalTradeStationUploadPokemonParam) (*nex.RMCMessage, *nex.Error)
 	SearchPokemon        func(err error, packet nex.PacketInterface, callID uint32, param *datastore_pokemon_gen6_types.GlobalTradeStationSearchPokemonParam) (*nex.RMCMessage, *nex.Error)
 	PrepareTradePokemon  func(err error, packet nex.PacketInterface, callID uint32, param *datastore_pokemon_gen6_types.GlobalTradeStationPrepareTradePokemonParam) (*nex.RMCMessage, *nex.Error)
@@ -77,6 +82,8 @@ func (protocol *Protocol) HandlePacket(packet nex.PacketInterface) {
 	}
 
 	switch message.MethodID {
+	case MethodPrepareUploadPokemon:
+		protocol.handlePrepareUploadPokemon(packet)
 	case MethodUploadPokemon:
 		protocol.handleUploadPokemon(packet)
 	case MethodSearchPokemon:


### PR DESCRIPTION
hello! I'm new to all this... from what I can understand these are just **handlers** and just pass things to the actual function implementation.

Reference: https://github.com/kinnay/NintendoClients/wiki/Data-Store-Protocol-(Pokemon-XY)#40-prepareuploadpokemon