### PR TITLE
fix(match-making): Account for StructureVersion in JoinMatchmakeSessionParam

### DIFF
--- a/match-making/types/join_matchmake_session_param.go
+++ b/match-making/types/join_matchmake_session_param.go
@@ -21,7 +21,7 @@ type JoinMatchmakeSessionParam struct {
 	StrSystemPassword            *types.String
 	JoinMessage                  *types.String
 	ParticipationCount           *types.PrimitiveU16
-	ExtraParticipants            *types.PrimitiveU16
+	ExtraParticipants            *types.PrimitiveU16 // * Revision 1 or NEX v4.0
 	BlockListParam               *MatchmakeBlockListParam // * NEX v4.0
 }
 
@@ -41,7 +41,10 @@ func (jmsp *JoinMatchmakeSessionParam) WriteTo(writable types.Writable) {
 	jmsp.StrSystemPassword.WriteTo(contentWritable)
 	jmsp.JoinMessage.WriteTo(contentWritable)
 	jmsp.ParticipationCount.WriteTo(contentWritable)
-	jmsp.ExtraParticipants.WriteTo(contentWritable)
+
+	if jmsp.StructureVersion >= 1 || libraryVersion.GreaterOrEqual("4.0") {
+		jmsp.ExtraParticipants.WriteTo(contentWritable)
+	}
 
 	if libraryVersion.GreaterOrEqual("4.0") {
 		jmsp.BlockListParam.WriteTo(contentWritable)
@@ -111,9 +114,11 @@ func (jmsp *JoinMatchmakeSessionParam) ExtractFrom(readable types.Readable) erro
 		return fmt.Errorf("Failed to extract JoinMatchmakeSessionParam.ParticipationCount. %s", err.Error())
 	}
 
-	err = jmsp.ExtraParticipants.ExtractFrom(readable)
-	if err != nil {
-		return fmt.Errorf("Failed to extract JoinMatchmakeSessionParam.ExtraParticipants. %s", err.Error())
+	if jmsp.StructureVersion >= 1 || libraryVersion.GreaterOrEqual("4.0") {
+		err = jmsp.ExtraParticipants.ExtractFrom(readable)
+		if err != nil {
+			return fmt.Errorf("Failed to extract JoinMatchmakeSessionParam.ExtraParticipants. %s", err.Error())
+		}
 	}
 
 	if libraryVersion.GreaterOrEqual("4.0") {


### PR DESCRIPTION
### Changes:

Accounts for StructureVersion in JoinMatchmakeSessionParam. This was [handled in v1](https://github.com/PretendoNetwork/nex-protocols-go/blob/v1.0.58/match-making/types/join_matchmake_session_param.go#L81) but got lost in the transition.
Needed for Splatoon.

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.