### PR TITLE
feat(gathering_flags): Add more gathering flags

### DIFF
--- a/match-making/gathering_flags.go
+++ b/match-making/gathering_flags.go
@@ -2,14 +2,24 @@
 package protocol
 
 type gatheringFlags struct {
-	DisconnectChangeOwner uint32 // TODO - Does this really only happen when a disconnect happens, or can the owner change at other times?
-	Unknown1              uint32
-	Unknown2              uint32
+	PersistentGathering                   uint32
+	DisconnectChangeOwner                 uint32
+	Unknown1                              uint32
+	PersistentGatheringLeaveParticipation uint32
+	PersistentGatheringAllowZeroUsers     uint32
+	ParticipantsChangeOwner               uint32
+	VerboseParticipants                   uint32
+	VerboseParticipantsEx                 uint32
 }
 
 // GatheringFlags is an enum of the possible flags for a gathering
 var GatheringFlags = gatheringFlags{
-	DisconnectChangeOwner: 0x10,
-	Unknown1:              0x20,
-	Unknown2:              0x200,
+	PersistentGathering:                   0x1,
+	DisconnectChangeOwner:                 0x10,
+	Unknown1:                              0x20,
+	PersistentGatheringLeaveParticipation: 0x40,
+	PersistentGatheringAllowZeroUsers:     0x80,
+	ParticipantsChangeOwner:               0x200,
+	VerboseParticipants:                   0x400,
+	VerboseParticipantsEx:                 0x800,
 }


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

Adds more previously undocumented gathering flags to the flags list. These flags are used on the matchmaking rewrite.

- `ParticipantsChangeOwner`: Imported from Rambo's MK8 server, determines if the participants of a gathering can change the owner
- `VerboseParticipants`: If set, all participation notification events are sent to *every participant* in the gathering
- `VerboseParticipantsEx`: Same as above, but when a new participant joins, it also sends `NewParticipant` notification events about every participant connected in the gathering

The `Ex` naming is probably not the best, but I'm not sure of better names to use. Open to suggestions

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.