### PR TITLE
fix(match-making): Check for NEX version over 2.0

### DIFF
--- a/match-making/types/matchmake_session_search_criteria.go
+++ b/match-making/types/matchmake_session_search_criteria.go
@@ -14,8 +14,8 @@ type MatchmakeSessionSearchCriteria struct {
 	types.Structure
 	Attribs                  *types.List[*types.String]
 	GameMode                 *types.String
-	MinParticipants          *types.String
-	MaxParticipants          *types.String
+	MinParticipants          *types.String        // * NEX v2.0.0
+	MaxParticipants          *types.String        // * NEX v2.0.0
 	MatchmakeSystemType      *types.String
 	VacantOnly               *types.PrimitiveBool
 	ExcludeLocked            *types.PrimitiveBool
@@ -39,8 +39,15 @@ func (mssc *MatchmakeSessionSearchCriteria) WriteTo(writable types.Writable) {
 
 	mssc.Attribs.WriteTo(contentWritable)
 	mssc.GameMode.WriteTo(contentWritable)
-	mssc.MinParticipants.WriteTo(contentWritable)
-	mssc.MaxParticipants.WriteTo(contentWritable)
+
+	if libraryVersion.GreaterOrEqual("2.0.0") {
+		mssc.MinParticipants.WriteTo(contentWritable)
+	}
+
+	if libraryVersion.GreaterOrEqual("2.0.0") {
+		mssc.MaxParticipants.WriteTo(contentWritable)
+	}
+
 	mssc.MatchmakeSystemType.WriteTo(contentWritable)
 	mssc.VacantOnly.WriteTo(contentWritable)
 	mssc.ExcludeLocked.WriteTo(contentWritable)
@@ -107,14 +114,18 @@ func (mssc *MatchmakeSessionSearchCriteria) ExtractFrom(readable types.Readable)
 		return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.GameMode. %s", err.Error())
 	}
 
-	err = mssc.MinParticipants.ExtractFrom(readable)
-	if err != nil {
-		return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.MinParticipants. %s", err.Error())
+	if libraryVersion.GreaterOrEqual("2.0.0") {
+		err = mssc.MinParticipants.ExtractFrom(readable)
+		if err != nil {
+			return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.MinParticipants. %s", err.Error())
+		}
 	}
 
-	err = mssc.MaxParticipants.ExtractFrom(readable)
-	if err != nil {
-		return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.MaxParticipants. %s", err.Error())
+	if libraryVersion.GreaterOrEqual("2.0.0") {
+		err = mssc.MaxParticipants.ExtractFrom(readable)
+		if err != nil {
+			return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.MaxParticipants. %s", err.Error())
+		}
 	}
 
 	err = mssc.MatchmakeSystemType.ExtractFrom(readable)


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

Based on https://github.com/PretendoNetwork/nintendo-wiki/pull/28 , add checks to `MatchmakeSessionSearchCriteria` for NEX version 2 or newer on `MinParticipants` and `MaxParticipants`

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.