### PR TITLE
fix(messaging/types): Handle types versioning

### DIFF
--- a/init.go
+++ b/init.go
@@ -8,6 +8,7 @@ import (
 	"github.com/PretendoNetwork/nex-go/v2/types"
 	account_management_types "github.com/PretendoNetwork/nex-protocols-go/v2/account-management/types"
 	match_making_types "github.com/PretendoNetwork/nex-protocols-go/v2/match-making/types"
+	messaging_types "github.com/PretendoNetwork/nex-protocols-go/v2/messaging/types"
 	ticket_granting_types "github.com/PretendoNetwork/nex-protocols-go/v2/ticket-granting/types"
 )
 
@@ -18,4 +19,7 @@ func init() {
 	types.RegisterObjectHolderType(ticket_granting_types.NewAuthenticationInfo())
 	types.RegisterObjectHolderType(match_making_types.NewGathering())
 	types.RegisterObjectHolderType(match_making_types.NewMatchmakeSession())
+	types.RegisterObjectHolderType(messaging_types.NewUserMessage())
+	types.RegisterObjectHolderType(messaging_types.NewTextMessage())
+	types.RegisterObjectHolderType(messaging_types.NewBinaryMessage())
 }

--- a/messaging/types/binary_message.go
+++ b/messaging/types/binary_message.go
@@ -15,6 +15,16 @@ type BinaryMessage struct {
 	BinaryBody types.QBuffer
 }
 
+// ObjectID returns the object identifier of the type
+func (bm BinaryMessage) ObjectID() types.RVType {
+	return bm.DataObjectID()
+}
+
+// DataObjectID returns the object identifier of the type embedding Data
+func (bm BinaryMessage) DataObjectID() types.RVType {
+	return types.NewString("BinaryMessage")
+}
+
 // WriteTo writes the BinaryMessage to the given writable
 func (bm BinaryMessage) WriteTo(writable types.Writable) {
 	bm.UserMessage.WriteTo(writable)

--- a/messaging/types/text_message.go
+++ b/messaging/types/text_message.go
@@ -15,6 +15,16 @@ type TextMessage struct {
 	StrTextBody types.String
 }
 
+// ObjectID returns the object identifier of the type
+func (tm TextMessage) ObjectID() types.RVType {
+	return tm.DataObjectID()
+}
+
+// DataObjectID returns the object identifier of the type embedding Data
+func (tm TextMessage) DataObjectID() types.RVType {
+	return types.NewString("TextMessage")
+}
+
 // WriteTo writes the TextMessage to the given writable
 func (tm TextMessage) WriteTo(writable types.Writable) {
 	tm.UserMessage.WriteTo(writable)


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

The messaging types were assuming a version belonging to NEX 4.0 or later. However, the types have various differences in older versions, like the recipient ID not being split or the UserMessage inlining the MessageRecipient fields.

In order to solve these differences, store all types in the structures and let the implementations handle the version differences. Also register the UserMessage derived types as object holders inheriting Data.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.