### PR TITLE
Add all known DataStore constants, enums, and flags

### DIFF
--- a/datastore/constants/comparison_flag.go
+++ b/datastore/constants/comparison_flag.go
@@ -1,0 +1,51 @@
+package constants
+
+// ComparisonFlag indicates the flags set on comparisonFlag of DataStoreChangeMetaCompareParam.
+// These flags tell the server what values to use when comparing
+// objects during search
+type ComparisonFlag uint16
+
+const (
+	// ComparisonFlagNone means that no fields should be compared
+	ComparisonFlagNone ComparisonFlag = 0x0
+
+	// ComparisonFlagName means that the DataStoreChangeMetaCompareParam.name
+	// field should be compared
+	ComparisonFlagName ComparisonFlag = 0x1
+
+	// ComparisonFlagAccessPermission means that the DataStoreChangeMetaCompareParam.permission
+	// field should be compared
+	ComparisonFlagAccessPermission ComparisonFlag = 0x2
+
+	// ComparisonFlagUpdatePermission means that the DataStoreChangeMetaCompareParam.delPermission
+	// field should be compared
+	ComparisonFlagUpdatePermission ComparisonFlag = 0x4
+
+	// ComparisonFlagPeriod means that the DataStoreChangeMetaCompareParam.period
+	// field should be compared
+	ComparisonFlagPeriod ComparisonFlag = 0x8
+
+	// ComparisonFlagMetaBinary means that the DataStoreChangeMetaCompareParam.metaBinary
+	// field should be compared
+	ComparisonFlagMetaBinary ComparisonFlag = 0x10
+
+	// ComparisonFlagTags means that the DataStoreChangeMetaCompareParam.tags
+	// field should be compared
+	ComparisonFlagTags ComparisonFlag = 0x20
+
+	// ComparisonFlagDataType means that the DataStoreChangeMetaCompareParam.dataType
+	// field should be compared
+	ComparisonFlagDataType ComparisonFlag = 0x40
+
+	// ComparisonFlagReferredCount means that the DataStoreChangeMetaCompareParam.referredCnt
+	// field should be compared
+	ComparisonFlagReferredCount ComparisonFlag = 0x80
+
+	// ComparisonFlagStatus means that the DataStoreChangeMetaCompareParam.status
+	// field should be compared
+	ComparisonFlagStatus ComparisonFlag = 0x100
+
+	// ComparisonFlagAll means that all fields should be compared.
+	// Equivalent to setting each of the previous flags individually
+	ComparisonFlagAll ComparisonFlag = 0xFFFF
+)

--- a/datastore/constants/data_flag.go
+++ b/datastore/constants/data_flag.go
@@ -29,9 +29,9 @@ const (
 	// notification
 	DataFlagUseNotificationOnPost DataFlag = 0x8
 
-	// DataFlagUseNotificationOnPost means that when an object is created and it's
-	// access permission is not set to PermissionPublic or PermissionPrivate, then
-	// all users who have access permission for the object receive a DataStore
+	// DataFlagUseNotificationOnPost means that when an existing object is updated
+	// and it's access permission is not set to PermissionPublic or PermissionPrivate,
+	// then all users who have access permission for the object receive a DataStore
 	// notification
 	DataFlagUseNotificationOnUpdate DataFlag = 0x10
 

--- a/datastore/constants/data_flag.go
+++ b/datastore/constants/data_flag.go
@@ -1,0 +1,46 @@
+package constants
+
+// DataFlag sets different configuration flags for uploaded objects.
+// Stored in the objects DataStoreMetaInfo.flag field
+type DataFlag uint8
+
+const (
+	// DataFlagNone means no extra configurations
+	DataFlagNone DataFlag = 0x0
+
+	// DataFlagNeedReview means that the object status should be set to
+	// DataStatusPending and can only be seen by the owner until reviewed.
+	// Trying to query for objects under review will result in DataStore::UnderReviewing
+	DataFlagNeedReview DataFlag = 0x1
+
+	// DataFlagPeriodFromLastReferred means that the object should have it's expiration
+	// time increased by the objects DataStoreMetaInfo.period days when directly interacted
+	// with (searched for by ID, touched with TouchObject, etc.).
+	// If this flag is not set, objects will expire after DataStoreMetaInfo.period days and
+	// be removed from the game/storage server
+	DataFlagPeriodFromLastReferred DataFlag = 0x2
+
+	// DataFlagUseReadLock has an unknown use. Seems to do nothing, likely unused?
+	DataFlagUseReadLock DataFlag = 0x4
+
+	// DataFlagUseNotificationOnPost means that all users who are given access through via
+	// recipientIds are sent DataStore notifications when the data is published. Does not seem
+	// to send a notification if the object is set to be public?
+	DataFlagUseNotificationOnPost DataFlag = 0x8
+
+	// DataFlagUseNotificationOnPost means that all users who are given access through via
+	// recipientIds are sent DataStore notifications when the data is updated. Does not seem
+	// to send a notification if the object is set to be public?
+	DataFlagUseNotificationOnUpdate DataFlag = 0x10
+
+	// DataFlagNotUseFileServer means the entry in the game server has no physical object in the
+	// storage (s3) server. Setting this flag when uploading an object will throw DataStore::InvalidArgument.
+	// Flag is automatically set on entries when uploading just a MetaBinary
+	DataFlagNotUseFileServer DataFlag = 0x20
+
+	// DataFlagNeedCompletion means "completion" must be called when uploading/updating an object.
+	// If uploading an object, CompletePostObjectV1/CompletePostObject MUST be called.
+	// If updating an object, CompleteUpdateObject MUST be called. Until an object is completed
+	// it is treated as non-existent (DataStore::NotFound)
+	DataFlagNeedCompletion DataFlag = 0x40
+)

--- a/datastore/constants/data_flag.go
+++ b/datastore/constants/data_flag.go
@@ -23,14 +23,16 @@ const (
 	// DataFlagUseReadLock has an unknown use. Seems to do nothing, likely unused?
 	DataFlagUseReadLock DataFlag = 0x4
 
-	// DataFlagUseNotificationOnPost means that all users who are given access through via
-	// recipientIds are sent DataStore notifications when the data is published. Does not seem
-	// to send a notification if the object is set to be public?
+	// DataFlagUseNotificationOnPost means that when an object is created and it's
+	// access permission is not set to PermissionPublic or PermissionPrivate, then
+	// all users who have access permission for the object receive a DataStore
+	// notification
 	DataFlagUseNotificationOnPost DataFlag = 0x8
 
-	// DataFlagUseNotificationOnPost means that all users who are given access through via
-	// recipientIds are sent DataStore notifications when the data is updated. Does not seem
-	// to send a notification if the object is set to be public?
+	// DataFlagUseNotificationOnPost means that when an object is created and it's
+	// access permission is not set to PermissionPublic or PermissionPrivate, then
+	// all users who have access permission for the object receive a DataStore
+	// notification
 	DataFlagUseNotificationOnUpdate DataFlag = 0x10
 
 	// DataFlagNotUseFileServer means the entry in the game server has no physical object in the

--- a/datastore/constants/data_status.go
+++ b/datastore/constants/data_status.go
@@ -1,0 +1,24 @@
+package constants
+
+// DataStatus indicates the availablity status of an object.
+// If an object has a status other than DataStatusNone, it is
+// not available to anyone besides the owner and only under
+// certain circumstances
+type DataStatus uint8
+
+const (
+
+	// DataStatusNone means the object is uploaded and
+	// visible to those who have access permissions
+	DataStatusNone DataStatus = 0
+
+	// DataStatusPending means the object is uploaded but
+	// pending review. The can only be seen by the owner until reviewed.
+	// Trying to query for objects under review will result in DataStore::UnderReviewing
+	DataStatusPending DataStatus = 2
+
+	// DataStatusRejected means the object is uploaded but
+	// is not available to the public. Likely means rejected
+	// from review
+	DataStatusRejected DataStatus = 5
+)

--- a/datastore/constants/data_status.go
+++ b/datastore/constants/data_status.go
@@ -7,7 +7,6 @@ package constants
 type DataStatus uint8
 
 const (
-
 	// DataStatusNone means the object is uploaded and
 	// visible to those who have access permissions
 	DataStatusNone DataStatus = 0

--- a/datastore/constants/data_status.go
+++ b/datastore/constants/data_status.go
@@ -12,8 +12,9 @@ const (
 	DataStatusNone DataStatus = 0
 
 	// DataStatusPending means the object is uploaded but
-	// pending review. The can only be seen by the owner until reviewed.
-	// Trying to query for objects under review will result in DataStore::UnderReviewing
+	// pending review. The object can only be seen by the
+	// owner until reviewed. Trying to query for objects
+	// under review will result in DataStore::UnderReviewing
 	DataStatusPending DataStatus = 2
 
 	// DataStatusRejected means the object is uploaded but

--- a/datastore/constants/modification_flag.go
+++ b/datastore/constants/modification_flag.go
@@ -19,8 +19,8 @@ const (
 	// ModificationFlagPeriod means that the object data expiration period has changed
 	ModificationFlagPeriod ModificationFlag = 0x8
 
-	// ModificationFlagMetabinary means that the object MetaBinary has changed
-	ModificationFlagMetabinary ModificationFlag = 0x10
+	// ModificationFlagMetaBinary means that the object MetaBinary has changed
+	ModificationFlagMetaBinary ModificationFlag = 0x10
 
 	// ModificationFlagTags means that the object tags have changed.
 	// Tags are replaced, not appended

--- a/datastore/constants/modification_flag.go
+++ b/datastore/constants/modification_flag.go
@@ -1,0 +1,42 @@
+package constants
+
+// ModificationFlag indicates what fields of an object have been modified
+type ModificationFlag uint16
+
+const (
+
+	// ModificationFlagNone means that nothing has changed
+	ModificationFlagNone ModificationFlag = 0x0
+
+	// ModificationFlagName means that the object name has changed
+	ModificationFlagName ModificationFlag = 0x1
+
+	// ModificationFlagAccessPermission means that the object access permission has changed
+	ModificationFlagAccessPermission ModificationFlag = 0x2
+
+	// ModificationFlagUpdatePermission means that the object update permission has changed
+	ModificationFlagUpdatePermission ModificationFlag = 0x4
+
+	// ModificationFlagPeriod means that the object data epiration period has changed
+	ModificationFlagPeriod ModificationFlag = 0x8
+
+	// ModificationFlagMetabinary means that the object MetaBinary has changed
+	ModificationFlagMetabinary ModificationFlag = 0x10
+
+	// ModificationFlagTags means that the object tags have changed.
+	// Tags are replaced, not appended
+	ModificationFlagTags ModificationFlag = 0x20
+
+	// ModificationFlagUpdatedTime means that the object itself has been updated.
+	// This updates the object "updated" timestamp and refreshes the expiration date
+	ModificationFlagUpdatedTime ModificationFlag = 0x40
+
+	// ModificationFlagDataType means that the object data type has changed
+	ModificationFlagDataType ModificationFlag = 0x80
+
+	// ModificationFlagReferredCount means that the object referred count has changed
+	ModificationFlagReferredCount ModificationFlag = 0x100
+
+	// ModificationFlagStatus means that the object status has changed
+	ModificationFlagStatus ModificationFlag = 0x200
+)

--- a/datastore/constants/modification_flag.go
+++ b/datastore/constants/modification_flag.go
@@ -16,7 +16,7 @@ const (
 	// ModificationFlagUpdatePermission means that the object update permission has changed
 	ModificationFlagUpdatePermission ModificationFlag = 0x4
 
-	// ModificationFlagPeriod means that the object data epiration period has changed
+	// ModificationFlagPeriod means that the object data expiration period has changed
 	ModificationFlagPeriod ModificationFlag = 0x8
 
 	// ModificationFlagMetabinary means that the object MetaBinary has changed

--- a/datastore/constants/modification_flag.go
+++ b/datastore/constants/modification_flag.go
@@ -4,7 +4,6 @@ package constants
 type ModificationFlag uint16
 
 const (
-
 	// ModificationFlagNone means that nothing has changed
 	ModificationFlagNone ModificationFlag = 0x0
 

--- a/datastore/constants/permission.go
+++ b/datastore/constants/permission.go
@@ -1,0 +1,31 @@
+package constants
+
+// Permission defines what users can perform access and update
+// operations for an object. Access and update operations are
+// stored separately
+type Permission uint8
+
+const (
+
+	// PermissionPublic means that anyone is allowed
+	// to perform the operation
+	PermissionPublic Permission = iota
+
+	// PermissionFriend means that only the owner and
+	// their friends are allowed to perform the operation
+	PermissionFriend
+
+	// PermissionSpecified means that only the owner and
+	// the users whose PIDs are specified are allowed to
+	// perform the operation
+	PermissionSpecified
+
+	// PermissionPrivate means that only the owner is allowed
+	// to perform the operation
+	PermissionPrivate
+
+	// PermissionSpecifiedFriend means that only the owner and
+	// friends of the owner whose PIDs are specified are allowed
+	// to perform the operation
+	PermissionSpecifiedFriend
+)

--- a/datastore/constants/permission.go
+++ b/datastore/constants/permission.go
@@ -6,7 +6,6 @@ package constants
 type Permission uint8
 
 const (
-
 	// PermissionPublic means that anyone is allowed
 	// to perform the operation
 	PermissionPublic Permission = iota

--- a/datastore/constants/rating_flag.go
+++ b/datastore/constants/rating_flag.go
@@ -1,0 +1,26 @@
+package constants
+
+// RatingFlag indicates how the server should handle
+// user ratings for object rating slots
+type RatingFlag uint8
+
+const (
+
+	// RatingFlagModifiable means that if a user rates an object
+	// rating slot more than once, update the existing rating
+	// rather than create a new one. If this flag is set, ratings
+	// to slots with existing ratings from the user do not count
+	// towards the rating count. If this flag is not set, ratings
+	// to slots with existing ratings from the user are treated
+	// as separate ratings and the rating count is incremented
+	RatingFlagModifiable RatingFlag = 0x4
+
+	// RatingFlagRoundMinus means that any rating value smaller
+	// than 0 is rounded up to 0 before being handled
+	RatingFlagRoundMinus RatingFlag = 0x8
+
+	// RatingFlagDisableSelfRating means that a user cannot rate
+	// an object that they own. If this flag is set and a user
+	// tries to rate an object they own, DataStore::OperationNotAllowed is thrown
+	RatingFlagDisableSelfRating RatingFlag = 0x10
+)

--- a/datastore/constants/rating_flag.go
+++ b/datastore/constants/rating_flag.go
@@ -5,7 +5,6 @@ package constants
 type RatingFlag uint8
 
 const (
-
 	// RatingFlagModifiable means that if a user rates an object
 	// rating slot more than once, update the existing rating
 	// rather than create a new one. If this flag is set, ratings

--- a/datastore/constants/rating_internal_flag.go
+++ b/datastore/constants/rating_internal_flag.go
@@ -5,7 +5,6 @@ package constants
 type RatingInternalFlag uint8
 
 const (
-
 	// RatingInternalFlagUseRangeMin means that the DataStoreRatingInitParam.rangeMin
 	// value should be respected. If this flag is not set, the minimum value is ignored.
 	// If this flag is set and a rating is below the minimum, `DataStore::InvalidArgument`

--- a/datastore/constants/rating_internal_flag.go
+++ b/datastore/constants/rating_internal_flag.go
@@ -1,0 +1,20 @@
+package constants
+
+// RatingInternalFlag indicates whether or not a minimum or
+// maximum rating value should be set
+type RatingInternalFlag uint8
+
+const (
+
+	// RatingInternalFlagUseRangeMin means that the DataStoreRatingInitParam.rangeMin
+	// value should be respected. If this flag is not set, the minimum value is ignored.
+	// If this flag is set and a rating is below the minimum, `DataStore::InvalidArgument`
+	// is thrown
+	RatingInternalFlagUseRangeMin RatingInternalFlag = 0x2
+
+	// RatingInternalFlagUseRangeMax means that the DataStoreRatingInitParam.rangeMax
+	// value should be respected. If this flag is not set, the maximum value is ignored.
+	// If this flag is set and a rating is above the maximum, `DataStore::InvalidArgument`
+	// is thrown
+	RatingInternalFlagUseRangeMax RatingInternalFlag = 0x4
+)

--- a/datastore/constants/rating_lock_period.go
+++ b/datastore/constants/rating_lock_period.go
@@ -2,7 +2,7 @@ package constants
 
 // RatingLockPeriod tells the rating slot locks what day
 // the lock should expire
-type RatingLockPeriod int
+type RatingLockPeriod int16
 
 const (
 	// RatingLockPeriodDay1 means the day the lock will expire

--- a/datastore/constants/rating_lock_period.go
+++ b/datastore/constants/rating_lock_period.go
@@ -1,0 +1,40 @@
+package constants
+
+// RatingLockPeriod tells the rating slot locks what day
+// the lock should expire
+type RatingLockPeriod int
+
+const (
+
+	// RatingLockPeriodDay1 means the day the lock will expire
+	// is the 1st of the following month
+	RatingLockPeriodDay1 RatingLockPeriod = -17
+
+	// RatingLockPeriodSun means the day the lock will expire
+	// is the Sunday of the following week
+	RatingLockPeriodSun RatingLockPeriod = -7
+
+	// RatingLockPeriodSat means the day the lock will expire
+	// is the Saturday of the following week
+	RatingLockPeriodSat RatingLockPeriod = -6
+
+	// RatingLockPeriodFri means the day the lock will expire
+	// is the Friday of the following week
+	RatingLockPeriodFri RatingLockPeriod = -5
+
+	// RatingLockPeriodThu means the day the lock will expire
+	// is the Thursday of the following week
+	RatingLockPeriodThu RatingLockPeriod = -4
+
+	// RatingLockPeriodWed means the day the lock will expire
+	// is the Wednesday of the following week
+	RatingLockPeriodWed RatingLockPeriod = -3
+
+	// RatingLockPeriodTue means the day the lock will expire
+	// is the Tuesday of the following week
+	RatingLockPeriodTue RatingLockPeriod = -2
+
+	// RatingLockPeriodMon means the day the lock will expire
+	// is the Monday of the following week
+	RatingLockPeriodMon RatingLockPeriod = -1
+)

--- a/datastore/constants/rating_lock_period.go
+++ b/datastore/constants/rating_lock_period.go
@@ -5,7 +5,6 @@ package constants
 type RatingLockPeriod int
 
 const (
-
 	// RatingLockPeriodDay1 means the day the lock will expire
 	// is the 1st of the following month
 	RatingLockPeriodDay1 RatingLockPeriod = -17

--- a/datastore/constants/rating_lock_type.go
+++ b/datastore/constants/rating_lock_type.go
@@ -1,12 +1,11 @@
 package constants
 
-// RatingLockType represents the type of lock applied to object ratings.
+// RatingLockType indicates the type of lock applied to object ratings.
 // Locks are applied per-user, not per-object. If a user tries to rate
 // an object while a lock is in place, DataStore::OperationNotAllowed is thrown
 type RatingLockType uint8
 
 const (
-
 	// RatingLockNone means that the ratings should have no locks
 	RatingLockNone RatingLockType = iota
 

--- a/datastore/constants/rating_lock_type.go
+++ b/datastore/constants/rating_lock_type.go
@@ -1,0 +1,34 @@
+package constants
+
+// RatingLockType represents the type of lock applied to object ratings.
+// Locks are applied per-user, not per-object. If a user tries to rate
+// an object while a lock is in place, DataStore::OperationNotAllowed is thrown
+type RatingLockType uint8
+
+const (
+
+	// RatingLockNone means that the ratings should have no locks
+	RatingLockNone RatingLockType = iota
+
+	// RatingLockInterval locks the user from rating the slot again for
+	// DataStoreRatingInitParam.periodDuration seconds
+	RatingLockInterval
+
+	// RatingLockPeriod locks the user from rating the slot again until
+	// a specific date/time. The way this locks expiration is calculated
+	// depends on DataStoreRatingInitParam.periodDuration. The value must be
+	// a RatingLockPeriod value.
+	// If periodDuration is RatingLockPeriodDay1, the expiration day is set
+	// to the 1st of the following month regardless of what day that is.
+	// If periodDuration is set to the other day-of-the-week values, the
+	// expiration day is set to that day of the week of the following week.
+	// DataStoreRatingInitParam.periodHour sets the hour, 0-23, of the selected
+	// day for when the lock should expire.
+	// For example, if periodDuration is set to RatingLockPeriodTue and periodHour
+	// is set to 0, and a user rates the slot on March 7th 2024, the lock expiration
+	// is set to 12-3-2024 0:00:00 (the following Tuesday at midnight)
+	RatingLockPeriod
+
+	// RatingLockPermanent locks the user from rating the slot again forever
+	RatingLockPermanent
+)

--- a/datastore/constants/result_flag.go
+++ b/datastore/constants/result_flag.go
@@ -5,7 +5,6 @@ package constants
 type ResultFlag uint8
 
 const (
-
 	// ResultFlagTags means the object tags should be populated
 	ResultFlagTags ResultFlag = 0x1
 

--- a/datastore/constants/result_flag.go
+++ b/datastore/constants/result_flag.go
@@ -11,8 +11,8 @@ const (
 	// ResultFlagRatings means the object ratings should be populated
 	ResultFlagRatings ResultFlag = 0x2
 
-	// ResultFlagMetabinary means the object MetaBinary should be populated
-	ResultFlagMetabinary ResultFlag = 0x4
+	// ResultFlagMetaBinary means the object MetaBinary should be populated
+	ResultFlagMetaBinary ResultFlag = 0x4
 
 	// ResultFlagPermittedIDs means the object permissions should be populated
 	ResultFlagPermittedIDs ResultFlag = 0x8

--- a/datastore/constants/result_flag.go
+++ b/datastore/constants/result_flag.go
@@ -1,0 +1,20 @@
+package constants
+
+// ResultFlag tells the server what fields to populate in responses
+// to object searches
+type ResultFlag uint8
+
+const (
+
+	// ResultFlagTags means the object tags should be populated
+	ResultFlagTags ResultFlag = 0x1
+
+	// ResultFlagRatings means the object ratings should be populated
+	ResultFlagRatings ResultFlag = 0x2
+
+	// ResultFlagMetabinary means the object MetaBinary should be populated
+	ResultFlagMetabinary ResultFlag = 0x4
+
+	// ResultFlagPermittedIDs means the object permissions should be populated
+	ResultFlagPermittedIDs ResultFlag = 0x8
+)

--- a/datastore/constants/search_result_total_count_type.go
+++ b/datastore/constants/search_result_total_count_type.go
@@ -1,0 +1,25 @@
+package constants
+
+// SearchResultTotalCountType indicates how the client should interpret the
+// DataStoreSearchResult.totalCount value when counting search results
+type SearchResultTotalCountType uint8
+
+const (
+
+	// SearchResultTotalExact means the returned count is the
+	// exact number of objects which match the search criteria
+	SearchResultTotalExact SearchResultTotalCountType = iota
+
+	// SearchResultTotalMinimum means the returned count is the
+	// mininum number of objects which match the search criteria.
+	// There are more objects beyond this count
+	SearchResultTotalMinimum
+
+	// SearchResultTotalEstimate means the returned count is an
+	// estimate of the number of objects which match the search
+	// criteria
+	SearchResultTotalEstimate
+
+	// SearchResultTotalDisabled means there is no returned count
+	SearchResultTotalDisabled
+)

--- a/datastore/constants/search_result_total_count_type.go
+++ b/datastore/constants/search_result_total_count_type.go
@@ -5,7 +5,6 @@ package constants
 type SearchResultTotalCountType uint8
 
 const (
-
 	// SearchResultTotalExact means the returned count is the
 	// exact number of objects which match the search criteria
 	SearchResultTotalExact SearchResultTotalCountType = iota

--- a/datastore/constants/search_sort_column.go
+++ b/datastore/constants/search_sort_column.go
@@ -5,7 +5,6 @@ package constants
 type SearchSortColumn uint8
 
 const (
-
 	// SearchSortColumnDataID means the objects should be sorted based on the objects DataIDs
 	SearchSortColumnDataID SearchSortColumn = iota
 
@@ -29,7 +28,6 @@ const (
 )
 
 const (
-
 	// SearchSortColumnRating0 means the objects should be sorted based on total combined ratings of slot 0
 	SearchSortColumnRating0 SearchSortColumn = iota + 64
 
@@ -80,7 +78,6 @@ const (
 )
 
 const (
-
 	// SearchSortColumnRatingAverage0 means the objects should be sorted based on the average value of ratings of slot 0
 	SearchSortColumnRatingAverage0 SearchSortColumn = iota + 96
 

--- a/datastore/constants/search_sort_column.go
+++ b/datastore/constants/search_sort_column.go
@@ -1,0 +1,131 @@
+package constants
+
+// SearchSortColumn tells the server which database column to use as the input
+// for the ordering of returned object searches
+type SearchSortColumn uint8
+
+const (
+
+	// SearchSortColumnDataID means the objects should be sorted based on the objects DataIDs
+	SearchSortColumnDataID SearchSortColumn = iota
+
+	// SearchSortColumnSize means the objects should be sorted based on the objects sizes
+	SearchSortColumnSize
+
+	// SearchSortColumnNameAlphabetical means the objects should be sorted based on the objects names
+	SearchSortColumnNameAlphabetical
+
+	// SearchSortColumnDataType means the objects should be sorted based on the objects data types
+	SearchSortColumnDataType
+
+	// SearchSortColumnReferredCount means the objects should be sorted based on the objects referred counts
+	SearchSortColumnReferredCount // * Mostly a guess. Modern DataStore seems to not use refer counts anymore? Guessed based on similar positions in other enums
+
+	// SearchSortColumnCreatedTime means the objects should be sorted based on the objects created times
+	SearchSortColumnCreatedTime
+
+	// SearchSortColumnUpdatedTime means the objects should be sorted based on the objects update times
+	SearchSortColumnUpdatedTime
+)
+
+const (
+
+	// SearchSortColumnRating0 means the objects should be sorted based on total combined ratings of slot 0
+	SearchSortColumnRating0 SearchSortColumn = iota + 64
+
+	// SearchSortColumnRating1 means the objects should be sorted based on total combined ratings of slot 1
+	SearchSortColumnRating1
+
+	// SearchSortColumnRating2 means the objects should be sorted based on total combined ratings of slot 2
+	SearchSortColumnRating2
+
+	// SearchSortColumnRating3 means the objects should be sorted based on total combined ratings of slot 3
+	SearchSortColumnRating3
+
+	// SearchSortColumnRating4 means the objects should be sorted based on total combined ratings of slot 4
+	SearchSortColumnRating4
+
+	// SearchSortColumnRating5 means the objects should be sorted based on total combined ratings of slot 5
+	SearchSortColumnRating5
+
+	// SearchSortColumnRating6 means the objects should be sorted based on total combined ratings of slot 6
+	SearchSortColumnRating6
+
+	// SearchSortColumnRating7 means the objects should be sorted based on total combined ratings of slot 7
+	SearchSortColumnRating7
+
+	// SearchSortColumnRating8 means the objects should be sorted based on total combined ratings of slot 8
+	SearchSortColumnRating8
+
+	// SearchSortColumnRating9 means the objects should be sorted based on total combined ratings of slot 9
+	SearchSortColumnRating9
+
+	// SearchSortColumnRating10 means the objects should be sorted based on total combined ratings of slot 10
+	SearchSortColumnRating10
+
+	// SearchSortColumnRating11 means the objects should be sorted based on total combined ratings of slot 11
+	SearchSortColumnRating11
+
+	// SearchSortColumnRating12 means the objects should be sorted based on total combined ratings of slot 12
+	SearchSortColumnRating12
+
+	// SearchSortColumnRating13 means the objects should be sorted based on total combined ratings of slot 13
+	SearchSortColumnRating13
+
+	// SearchSortColumnRating14 means the objects should be sorted based on total combined ratings of slot 14
+	SearchSortColumnRating14
+
+	// SearchSortColumnRating15 means the objects should be sorted based on total combined ratings of slot 15
+	SearchSortColumnRating15
+)
+
+const (
+
+	// SearchSortColumnRatingAverage0 means the objects should be sorted based on the average value of ratings of slot 0
+	SearchSortColumnRatingAverage0 SearchSortColumn = iota + 96
+
+	// SearchSortColumnRatingAverage1 means the objects should be sorted based on the average value of ratings of slot 1
+	SearchSortColumnRatingAverage1
+
+	// SearchSortColumnRatingAverage2 means the objects should be sorted based on the average value of ratings of slot 2
+	SearchSortColumnRatingAverage2
+
+	// SearchSortColumnRatingAverage3 means the objects should be sorted based on the average value of ratings of slot 3
+	SearchSortColumnRatingAverage3
+
+	// SearchSortColumnRatingAverage4 means the objects should be sorted based on the average value of ratings of slot 4
+	SearchSortColumnRatingAverage4
+
+	// SearchSortColumnRatingAverage5 means the objects should be sorted based on the average value of ratings of slot 5
+	SearchSortColumnRatingAverage5
+
+	// SearchSortColumnRatingAverage6 means the objects should be sorted based on the average value of ratings of slot 6
+	SearchSortColumnRatingAverage6
+
+	// SearchSortColumnRatingAverage7 means the objects should be sorted based on the average value of ratings of slot 7
+	SearchSortColumnRatingAverage7
+
+	// SearchSortColumnRatingAverage8 means the objects should be sorted based on the average value of ratings of slot 8
+	SearchSortColumnRatingAverage8
+
+	// SearchSortColumnRatingAverage9 means the objects should be sorted based on the average value of ratings of slot 9
+	SearchSortColumnRatingAverage9
+
+	// SearchSortColumnRatingAverage10 means the objects should be sorted based on the average value of ratings of slot 10
+	SearchSortColumnRatingAverage10
+
+	// SearchSortColumnRatingAverage11 means the objects should be sorted based on the average value of ratings of slot 11
+	SearchSortColumnRatingAverage11
+
+	// SearchSortColumnRatingAverage12 means the objects should be sorted based on the average value of ratings of slot 12
+	SearchSortColumnRatingAverage12
+
+	// SearchSortColumnRatingAverage13 means the objects should be sorted based on the average value of ratings of slot 13
+	SearchSortColumnRatingAverage13
+
+	// SearchSortColumnRatingAverage14 means the objects should be sorted based on the average value of ratings of slot 14
+	SearchSortColumnRatingAverage14
+
+	// SearchSortColumnRatingAverage15 means the objects should be sorted based on the average value of ratings of slot 15
+	SearchSortColumnRatingAverage15
+)

--- a/datastore/constants/search_sort_order.go
+++ b/datastore/constants/search_sort_order.go
@@ -4,7 +4,6 @@ package constants
 type SearchSortOrder uint8
 
 const (
-
 	// SearchSortOrderAsc means the results should be ordered in ascending order
 	SearchSortOrderAsc SearchSortOrder = iota
 

--- a/datastore/constants/search_sort_order.go
+++ b/datastore/constants/search_sort_order.go
@@ -1,0 +1,13 @@
+package constants
+
+// SearchSortOrder tells the server in what direction to order search results
+type SearchSortOrder uint8
+
+const (
+
+	// SearchSortOrderAsc means the results should be ordered in ascending order
+	SearchSortOrderAsc SearchSortOrder = iota
+
+	// SearchSortOrderDesc means the results should be ordered in descending order
+	SearchSortOrderDesc
+)

--- a/datastore/constants/search_target.go
+++ b/datastore/constants/search_target.go
@@ -1,0 +1,19 @@
+package constants
+
+// SearchTarget represents the type of user who owns an object.
+// Not to be confused with DataStoreSearchParam.searchTarget,
+// this is actually stored in DataStoreSearchParam.ownertype.
+// Used to narrow search results based on owner type
+type SearchTarget uint8
+
+const (
+	// SearchTargetAnybody selects objects owned by anyone
+	SearchTargetAnybody SearchTarget = iota
+
+	// SearchTargetFriend selects objects owned by the users friends
+	SearchTargetFriend
+
+	// SearchTargetAnybodyExcludeSpecified selects objects owned by anyone
+	// EXCEPT those set in DataStoreSearchParam.ownerIds
+	SearchTargetAnybodyExcludeSpecified
+)

--- a/datastore/constants/search_type.go
+++ b/datastore/constants/search_type.go
@@ -1,0 +1,69 @@
+package constants
+
+// SearchType represents the type of user who can access an object.
+// This is stored in DataStoreSearchParam.searchTarget.
+// Used to narrow search results based on access rights
+type SearchType uint8
+
+const (
+
+	// SearchTypePublic selects objects whose access permission
+	// is set to PermissionPublic
+	SearchTypePublic SearchType = iota + 1
+
+	// SearchTypeSendFriend selects objects owned by the current
+	// user and whose access permission is set to PermissionFriend
+	SearchTypeSendFriend
+
+	// SearchTypeSendSpecified selects objects owned by the current
+	// user and whose access permission is set to PermissionSpecified
+	SearchTypeSendSpecified
+
+	// SearchTypeSendSpecifiedFriend selects objects owned by the current
+	// user and whose access permission is set to PermissionSpecifiedFriend
+	SearchTypeSendSpecifiedFriend
+
+	// SearchTypeSend selects objects owned by the current
+	// user and whose access permission is set to one of
+	// PermissionFriend, PermissionSpecified or
+	// PermissionSpecifiedFriend
+	SearchTypeSend
+
+	// SearchTypeFriend selects objects owned by the friends of the
+	// current user whose access permission is set to PermissionFriend
+	SearchTypeFriend
+
+	// SearchTypeReceivedSpecified selects objects whose access permission
+	// is set to either PermissionSpecified or PermissionSpecifiedFriend
+	// and which the current user is in the recipient IDs list
+	SearchTypeReceivedSpecified
+
+	// SearchTypeReceived selects objects who match the criteria of either
+	// (or both) SearchTypeFriend/SearchTypeReceivedSpecified
+	SearchTypeReceived
+
+	// SearchTypePrivate selects objects owned by the current user and  whose
+	// access permission is set to PermissionPrivate
+	SearchTypePrivate
+
+	// SearchTypeOwn selects objects owned by the current user and whose
+	// status is set to DataStatusNone
+	SearchTypeOwn
+
+	// SearchTypePublicExcludeOwnAndFriends selects objects whose access
+	// permission is set to PermissionPublic but excludes objects owned
+	// by the current user and their friends
+	SearchTypePublicExcludeOwnAndFriends
+
+	// SearchTypeOwnPending selects objects owned by the current user and whose
+	// status is set to DataStatusPending
+	SearchTypeOwnPending
+
+	// SearchTypeOwnRejected selects objects owned by the current user and whose
+	// status is set to DataStatusRejected
+	SearchTypeOwnRejected
+
+	// SearchTypeOwnAll selects objects owned by the current user regardless of
+	// status or access permission
+	SearchTypeOwnAll
+)

--- a/datastore/constants/search_type.go
+++ b/datastore/constants/search_type.go
@@ -6,7 +6,6 @@ package constants
 type SearchType uint8
 
 const (
-
 	// SearchTypePublic selects objects whose access permission
 	// is set to PermissionPublic
 	SearchTypePublic SearchType = iota + 1


### PR DESCRIPTION
Resolves #XXX

### Changes:

This was finished at like 3am, I expect there to be issues. Add all known DataStore constants, enums, and flags as well as detailed comments for how they operate

The names were taken from a mix of https://github.com/tech-ticks/RTDXTools/blob/232a7797e01369e9c12704f58fdde65dd3ac1c32/Assets/Scripts/Stubs/Generated/Assembly-CSharp/NexPlugin/DataStore.cs and using my own notes to fill in the gaps of missing values in the C# decomp

Comments are based off my own testing/notes which were supplemented with the added context provided by the real names from the C# decomp

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.