### PR TITLE
fix(datastore): solve redeclaration of RatingLockPeriod

### DIFF
--- a/datastore/constants/rating_lock_period.go
+++ b/datastore/constants/rating_lock_period.go
@@ -1,39 +1,44 @@
 package constants
 
 // RatingLockPeriod tells the rating slot locks what day
-// the lock should expire
-type RatingLockPeriodType int16
+// the lock should expire.
+//
+// NOTE: Original name is RatingLockPeriod, changed to
+// RatingLockPeriodDay as that conflicts with
+// RatingLockType.RatingLockPeriod, and these values
+// represent the "day" a period lock ends.
+type RatingLockPeriodDay int16
 
 const (
 	// RatingLockPeriodDay1 means the day the lock will expire
 	// is the 1st of the following month
-	RatingLockPeriodDay1 RatingLockPeriodType = -17
+	RatingLockPeriodDay1 RatingLockPeriodDay = -17
 
 	// RatingLockPeriodSun means the day the lock will expire
 	// is the Sunday of the following week
-	RatingLockPeriodSun RatingLockPeriodType = -7
+	RatingLockPeriodSun RatingLockPeriodDay = -7
 
 	// RatingLockPeriodSat means the day the lock will expire
 	// is the Saturday of the following week
-	RatingLockPeriodSat RatingLockPeriodType = -6
+	RatingLockPeriodSat RatingLockPeriodDay = -6
 
 	// RatingLockPeriodFri means the day the lock will expire
 	// is the Friday of the following week
-	RatingLockPeriodFri RatingLockPeriodType = -5
+	RatingLockPeriodFri RatingLockPeriodDay = -5
 
 	// RatingLockPeriodThu means the day the lock will expire
 	// is the Thursday of the following week
-	RatingLockPeriodThu RatingLockPeriodType = -4
+	RatingLockPeriodThu RatingLockPeriodDay = -4
 
 	// RatingLockPeriodWed means the day the lock will expire
 	// is the Wednesday of the following week
-	RatingLockPeriodWed RatingLockPeriodType = -3
+	RatingLockPeriodWed RatingLockPeriodDay = -3
 
 	// RatingLockPeriodTue means the day the lock will expire
 	// is the Tuesday of the following week
-	RatingLockPeriodTue RatingLockPeriodType = -2
+	RatingLockPeriodTue RatingLockPeriodDay = -2
 
 	// RatingLockPeriodMon means the day the lock will expire
 	// is the Monday of the following week
-	RatingLockPeriodMon RatingLockPeriodType = -1
+	RatingLockPeriodMon RatingLockPeriodDay = -1
 )

--- a/datastore/constants/rating_lock_period.go
+++ b/datastore/constants/rating_lock_period.go
@@ -2,38 +2,38 @@ package constants
 
 // RatingLockPeriod tells the rating slot locks what day
 // the lock should expire
-type RatingLockPeriod int16
+type RatingLockPeriodType int16
 
 const (
 	// RatingLockPeriodDay1 means the day the lock will expire
 	// is the 1st of the following month
-	RatingLockPeriodDay1 RatingLockPeriod = -17
+	RatingLockPeriodDay1 RatingLockPeriodType = -17
 
 	// RatingLockPeriodSun means the day the lock will expire
 	// is the Sunday of the following week
-	RatingLockPeriodSun RatingLockPeriod = -7
+	RatingLockPeriodSun RatingLockPeriodType = -7
 
 	// RatingLockPeriodSat means the day the lock will expire
 	// is the Saturday of the following week
-	RatingLockPeriodSat RatingLockPeriod = -6
+	RatingLockPeriodSat RatingLockPeriodType = -6
 
 	// RatingLockPeriodFri means the day the lock will expire
 	// is the Friday of the following week
-	RatingLockPeriodFri RatingLockPeriod = -5
+	RatingLockPeriodFri RatingLockPeriodType = -5
 
 	// RatingLockPeriodThu means the day the lock will expire
 	// is the Thursday of the following week
-	RatingLockPeriodThu RatingLockPeriod = -4
+	RatingLockPeriodThu RatingLockPeriodType = -4
 
 	// RatingLockPeriodWed means the day the lock will expire
 	// is the Wednesday of the following week
-	RatingLockPeriodWed RatingLockPeriod = -3
+	RatingLockPeriodWed RatingLockPeriodType = -3
 
 	// RatingLockPeriodTue means the day the lock will expire
 	// is the Tuesday of the following week
-	RatingLockPeriodTue RatingLockPeriod = -2
+	RatingLockPeriodTue RatingLockPeriodType = -2
 
 	// RatingLockPeriodMon means the day the lock will expire
 	// is the Monday of the following week
-	RatingLockPeriodMon RatingLockPeriod = -1
+	RatingLockPeriodMon RatingLockPeriodType = -1
 )


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

Fixes redeclaration of RatingLockPeriod in datastore/constants/rating_lock_period.go and datastore/constants/rating_lock_type.go
This fix is required for compilation in instances where the constants are referenced.

- [X] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [X] I have tested all of my changes.