### PR TITLE
Add missing ObjectHolder methods for notifications

### DIFF
--- a/friends-3ds/types/game_key.go
+++ b/friends-3ds/types/game_key.go
@@ -16,6 +16,16 @@ type GameKey struct {
 	TitleVersion types.UInt16
 }
 
+// ObjectID returns the object identifier of the type
+func (gk GameKey) ObjectID() types.RVType {
+	return gk.DataObjectID()
+}
+
+// DataObjectID returns the object identifier of the type embedding Data
+func (gk GameKey) DataObjectID() types.RVType {
+	return types.NewString("GameKey")
+}
+
 // WriteTo writes the GameKey to the given writable
 func (gk GameKey) WriteTo(writable types.Writable) {
 	gk.Data.WriteTo(writable)

--- a/friends-3ds/types/nintendo_presence.go
+++ b/friends-3ds/types/nintendo_presence.go
@@ -24,6 +24,16 @@ type NintendoPresence struct {
 	ApplicationArg    types.Buffer
 }
 
+// ObjectID returns the object identifier of the type
+func (np NintendoPresence) ObjectID() types.RVType {
+	return np.DataObjectID()
+}
+
+// DataObjectID returns the object identifier of the type embedding Data
+func (np NintendoPresence) DataObjectID() types.RVType {
+	return types.NewString("NintendoPresence")
+}
+
 // WriteTo writes the NintendoPresence to the given writable
 func (np NintendoPresence) WriteTo(writable types.Writable) {
 	np.Data.WriteTo(writable)

--- a/friends-wiiu/types/friend_info.go
+++ b/friends-wiiu/types/friend_info.go
@@ -20,6 +20,16 @@ type FriendInfo struct {
 	Unknown      types.UInt64
 }
 
+// ObjectID returns the object identifier of the type
+func (fi FriendInfo) ObjectID() types.RVType {
+	return fi.DataObjectID()
+}
+
+// DataObjectID returns the object identifier of the type embedding Data
+func (fi FriendInfo) DataObjectID() types.RVType {
+	return types.NewString("FriendInfo")
+}
+
 // WriteTo writes the FriendInfo to the given writable
 func (fi FriendInfo) WriteTo(writable types.Writable) {
 	fi.Data.WriteTo(writable)

--- a/friends-wiiu/types/friend_request.go
+++ b/friends-wiiu/types/friend_request.go
@@ -17,6 +17,16 @@ type FriendRequest struct {
 	SentOn        types.DateTime
 }
 
+// ObjectID returns the object identifier of the type
+func (fr FriendRequest) ObjectID() types.RVType {
+	return fr.DataObjectID()
+}
+
+// DataObjectID returns the object identifier of the type embedding Data
+func (fr FriendRequest) DataObjectID() types.RVType {
+	return types.NewString("FriendRequest")
+}
+
 // WriteTo writes the FriendRequest to the given writable
 func (fr FriendRequest) WriteTo(writable types.Writable) {
 	fr.Data.WriteTo(writable)

--- a/friends-wiiu/types/nintendo_presence_v2.go
+++ b/friends-wiiu/types/nintendo_presence_v2.go
@@ -29,6 +29,16 @@ type NintendoPresenceV2 struct {
 	Unknown7        types.UInt8
 }
 
+// ObjectID returns the object identifier of the type
+func (npv NintendoPresenceV2) ObjectID() types.RVType {
+	return npv.DataObjectID()
+}
+
+// DataObjectID returns the object identifier of the type embedding Data
+func (npv NintendoPresenceV2) DataObjectID() types.RVType {
+	return types.NewString("NintendoPresenceV2")
+}
+
 // WriteTo writes the NintendoPresenceV2 to the given writable
 func (npv NintendoPresenceV2) WriteTo(writable types.Writable) {
 	npv.Data.WriteTo(writable)

--- a/friends-wiiu/types/nna_info.go
+++ b/friends-wiiu/types/nna_info.go
@@ -17,6 +17,16 @@ type NNAInfo struct {
 	Unknown2           types.UInt8
 }
 
+// ObjectID returns the object identifier of the type
+func (nnai NNAInfo) ObjectID() types.RVType {
+	return nnai.DataObjectID()
+}
+
+// DataObjectID returns the object identifier of the type embedding Data
+func (nnai NNAInfo) DataObjectID() types.RVType {
+	return types.NewString("NNAInfo")
+}
+
 // WriteTo writes the NNAInfo to the given writable
 func (nnai NNAInfo) WriteTo(writable types.Writable) {
 	nnai.Data.WriteTo(writable)

--- a/friends-wiiu/types/persistent_notification_list.go
+++ b/friends-wiiu/types/persistent_notification_list.go
@@ -15,6 +15,16 @@ type PersistentNotificationList struct {
 	Notifications types.List[PersistentNotification]
 }
 
+// ObjectID returns the object identifier of the type
+func (pnl PersistentNotificationList) ObjectID() types.RVType {
+	return pnl.DataObjectID()
+}
+
+// DataObjectID returns the object identifier of the type embedding Data
+func (pnl PersistentNotificationList) DataObjectID() types.RVType {
+	return types.NewString("PersistentNotificationList")
+}
+
 // WriteTo writes the PersistentNotificationList to the given writable
 func (pnl PersistentNotificationList) WriteTo(writable types.Writable) {
 	pnl.Data.WriteTo(writable)

--- a/friends-wiiu/types/principal_preference.go
+++ b/friends-wiiu/types/principal_preference.go
@@ -17,6 +17,16 @@ type PrincipalPreference struct {
 	BlockFriendRequests types.Bool
 }
 
+// ObjectID returns the object identifier of the type
+func (pp PrincipalPreference) ObjectID() types.RVType {
+	return pp.DataObjectID()
+}
+
+// DataObjectID returns the object identifier of the type embedding Data
+func (pp PrincipalPreference) DataObjectID() types.RVType {
+	return types.NewString("PrincipalPreference")
+}
+
 // WriteTo writes the PrincipalPreference to the given writable
 func (pp PrincipalPreference) WriteTo(writable types.Writable) {
 	pp.Data.WriteTo(writable)

--- a/init.go
+++ b/init.go
@@ -7,6 +7,8 @@ package nexproto
 import (
 	"github.com/PretendoNetwork/nex-go/v2/types"
 	account_management_types "github.com/PretendoNetwork/nex-protocols-go/v2/account-management/types"
+	friends_3ds_types "github.com/PretendoNetwork/nex-protocols-go/v2/friends-3ds/types"
+	friends_wiiu_types "github.com/PretendoNetwork/nex-protocols-go/v2/friends-wiiu/types"
 	match_making_types "github.com/PretendoNetwork/nex-protocols-go/v2/match-making/types"
 	messaging_types "github.com/PretendoNetwork/nex-protocols-go/v2/messaging/types"
 	nintendo_notifications_types "github.com/PretendoNetwork/nex-protocols-go/v2/nintendo-notifications/types"
@@ -16,12 +18,20 @@ import (
 func init() {
 	types.RegisterObjectHolderType(account_management_types.NewNintendoCreateAccountData())
 	types.RegisterObjectHolderType(account_management_types.NewAccountExtraInfo())
-	types.RegisterObjectHolderType(ticket_granting_types.NewNintendoLoginData())
-	types.RegisterObjectHolderType(ticket_granting_types.NewAuthenticationInfo())
+	types.RegisterObjectHolderType(friends_3ds_types.NewGameKey())
+	types.RegisterObjectHolderType(friends_3ds_types.NewNintendoPresence())
+	types.RegisterObjectHolderType(friends_wiiu_types.NewFriendInfo())
+	types.RegisterObjectHolderType(friends_wiiu_types.NewFriendRequest())
+	types.RegisterObjectHolderType(friends_wiiu_types.NewNintendoPresenceV2())
+	types.RegisterObjectHolderType(friends_wiiu_types.NewNNAInfo())
+	types.RegisterObjectHolderType(friends_wiiu_types.NewPersistentNotificationList())
+	types.RegisterObjectHolderType(friends_wiiu_types.NewPrincipalPreference())
 	types.RegisterObjectHolderType(match_making_types.NewGathering())
 	types.RegisterObjectHolderType(match_making_types.NewMatchmakeSession())
 	types.RegisterObjectHolderType(messaging_types.NewUserMessage())
 	types.RegisterObjectHolderType(messaging_types.NewTextMessage())
 	types.RegisterObjectHolderType(messaging_types.NewBinaryMessage())
 	types.RegisterObjectHolderType(nintendo_notifications_types.NewNintendoNotificationEventGeneral())
+	types.RegisterObjectHolderType(ticket_granting_types.NewNintendoLoginData())
+	types.RegisterObjectHolderType(ticket_granting_types.NewAuthenticationInfo())
 }

--- a/init.go
+++ b/init.go
@@ -9,6 +9,7 @@ import (
 	account_management_types "github.com/PretendoNetwork/nex-protocols-go/v2/account-management/types"
 	match_making_types "github.com/PretendoNetwork/nex-protocols-go/v2/match-making/types"
 	messaging_types "github.com/PretendoNetwork/nex-protocols-go/v2/messaging/types"
+	nintendo_notifications_types "github.com/PretendoNetwork/nex-protocols-go/v2/nintendo-notifications/types"
 	ticket_granting_types "github.com/PretendoNetwork/nex-protocols-go/v2/ticket-granting/types"
 )
 
@@ -22,4 +23,5 @@ func init() {
 	types.RegisterObjectHolderType(messaging_types.NewUserMessage())
 	types.RegisterObjectHolderType(messaging_types.NewTextMessage())
 	types.RegisterObjectHolderType(messaging_types.NewBinaryMessage())
+	types.RegisterObjectHolderType(nintendo_notifications_types.NewNintendoNotificationEventGeneral())
 }

--- a/nintendo-notifications/types/nintendo_notification_event_general.go
+++ b/nintendo-notifications/types/nintendo_notification_event_general.go
@@ -11,6 +11,7 @@ import (
 // NintendoNotificationEventGeneral is a type within the NintendoNotifications protocol
 type NintendoNotificationEventGeneral struct {
 	types.Structure
+	types.Data
 	U32Param  types.UInt32
 	U64Param1 types.UInt64
 	U64Param2 types.UInt64
@@ -29,6 +30,8 @@ func (nneg NintendoNotificationEventGeneral) DataObjectID() types.RVType {
 
 // WriteTo writes the NintendoNotificationEventGeneral to the given writable
 func (nneg NintendoNotificationEventGeneral) WriteTo(writable types.Writable) {
+	nneg.Data.WriteTo(writable)
+
 	contentWritable := writable.CopyNew()
 
 	nneg.U32Param.WriteTo(contentWritable)
@@ -46,6 +49,11 @@ func (nneg NintendoNotificationEventGeneral) WriteTo(writable types.Writable) {
 // ExtractFrom extracts the NintendoNotificationEventGeneral from the given readable
 func (nneg *NintendoNotificationEventGeneral) ExtractFrom(readable types.Readable) error {
 	var err error
+
+	err = nneg.Data.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract NintendoNotificationEventGeneral.Data. %s", err.Error())
+	}
 
 	err = nneg.ExtractHeaderFrom(readable)
 	if err != nil {
@@ -80,6 +88,7 @@ func (nneg NintendoNotificationEventGeneral) Copy() types.RVType {
 	copied := NewNintendoNotificationEventGeneral()
 
 	copied.StructureVersion = nneg.StructureVersion
+	copied.Data = nneg.Data.Copy().(types.Data)
 	copied.U32Param = nneg.U32Param.Copy().(types.UInt32)
 	copied.U64Param1 = nneg.U64Param1.Copy().(types.UInt64)
 	copied.U64Param2 = nneg.U64Param2.Copy().(types.UInt64)
@@ -97,6 +106,10 @@ func (nneg NintendoNotificationEventGeneral) Equals(o types.RVType) bool {
 	other := o.(NintendoNotificationEventGeneral)
 
 	if nneg.StructureVersion != other.StructureVersion {
+		return false
+	}
+
+	if !nneg.Data.Equals(other.Data) {
 		return false
 	}
 
@@ -142,6 +155,7 @@ func (nneg NintendoNotificationEventGeneral) FormatToString(indentationLevel int
 	var b strings.Builder
 
 	b.WriteString("NintendoNotificationEventGeneral{\n")
+	b.WriteString(fmt.Sprintf("%sData (parent): %s,\n", indentationValues, nneg.Data.FormatToString(indentationLevel+1)))
 	b.WriteString(fmt.Sprintf("%sU32Param: %s,\n", indentationValues, nneg.U32Param))
 	b.WriteString(fmt.Sprintf("%sU64Param1: %s,\n", indentationValues, nneg.U64Param1))
 	b.WriteString(fmt.Sprintf("%sU64Param2: %s,\n", indentationValues, nneg.U64Param2))

--- a/nintendo-notifications/types/nintendo_notification_event_general.go
+++ b/nintendo-notifications/types/nintendo_notification_event_general.go
@@ -17,6 +17,16 @@ type NintendoNotificationEventGeneral struct {
 	StrParam  types.String
 }
 
+// ObjectID returns the object identifier of the type
+func (nneg NintendoNotificationEventGeneral) ObjectID() types.RVType {
+	return nneg.DataObjectID()
+}
+
+// DataObjectID returns the object identifier of the type embedding Data
+func (nneg NintendoNotificationEventGeneral) DataObjectID() types.RVType {
+	return types.NewString("NintendoNotificationEventGeneral")
+}
+
 // WriteTo writes the NintendoNotificationEventGeneral to the given writable
 func (nneg NintendoNotificationEventGeneral) WriteTo(writable types.Writable) {
 	contentWritable := writable.CopyNew()


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

Adds missing methods for notifications to make them compatible with AnyObjectHolder. Required for the friends server

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.