### PR TITLE
feat: Implement legacy Ranking

### DIFF
--- a/ranking/legacy/delete_all_score.go
+++ b/ranking/legacy/delete_all_score.go
@@ -1,0 +1,50 @@
+// Package protocol implements the legacy Ranking protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+)
+
+func (protocol *Protocol) handleDeleteAllScore(packet nex.PacketInterface) {
+	if protocol.DeleteAllScore == nil {
+		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::DeleteAllScore not implemented")
+
+		globals.Logger.Warning(err.Message)
+		globals.RespondError(packet, ProtocolID, err)
+
+		return
+	}
+
+	endpoint := packet.Sender().Endpoint()
+
+	request := packet.RMCMessage()
+	callID := request.CallID
+	parameters := request.Parameters
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	var uniqueID types.UInt32
+
+	var err error
+
+	err = uniqueID.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.DeleteAllScore(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	rmcMessage, rmcError := protocol.DeleteAllScore(nil, packet, callID, uniqueID)
+	if rmcError != nil {
+		globals.RespondError(packet, ProtocolID, rmcError)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/delete_common_data.go
+++ b/ranking/legacy/delete_common_data.go
@@ -1,0 +1,50 @@
+// Package protocol implements the legacy Ranking protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+)
+
+func (protocol *Protocol) handleDeleteCommonData(packet nex.PacketInterface) {
+	if protocol.DeleteCommonData == nil {
+		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::DeleteCommonData not implemented")
+
+		globals.Logger.Warning(err.Message)
+		globals.RespondError(packet, ProtocolID, err)
+
+		return
+	}
+
+	endpoint := packet.Sender().Endpoint()
+
+	request := packet.RMCMessage()
+	callID := request.CallID
+	parameters := request.Parameters
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	var uniqueID types.UInt32
+
+	var err error
+
+	err = uniqueID.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.DeleteCommonData(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	rmcMessage, rmcError := protocol.DeleteCommonData(nil, packet, callID, uniqueID)
+	if rmcError != nil {
+		globals.RespondError(packet, ProtocolID, rmcError)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/delete_score.go
+++ b/ranking/legacy/delete_score.go
@@ -1,0 +1,87 @@
+// Package protocol implements the legacy Ranking protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+)
+
+func (protocol *Protocol) handleDeleteScore(packet nex.PacketInterface) {
+	if protocol.DeleteScore == nil {
+		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::DeleteScore not implemented")
+
+		globals.Logger.Warning(err.Message)
+		globals.RespondError(packet, ProtocolID, err)
+
+		return
+	}
+
+	endpoint := packet.Sender().Endpoint()
+	rankingVersion := endpoint.LibraryVersions().Ranking
+
+	request := packet.RMCMessage()
+	callID := request.CallID
+	parameters := request.Parameters
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	var uniqueID types.UInt32
+	var category types.UInt32
+
+	var err error
+
+	err = uniqueID.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.DeleteScore(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, category)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	if rankingVersion.GreaterOrEqual("2.0.0") {
+		err = category.ExtractFrom(parametersStream)
+		if err != nil {
+			_, rmcError := protocol.DeleteScore(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, category)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+	} else {
+		var categories types.List[types.UInt16]
+
+		err = categories.ExtractFrom(parametersStream)
+		if err != nil {
+			_, rmcError := protocol.DeleteScore(fmt.Errorf("Failed to read categories from parameters. %s", err.Error()), packet, callID, uniqueID, category)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+
+		if len(categories) != 1 {
+			_, rmcError := protocol.DeleteScore(fmt.Errorf("Failed to read categories from parameters. Expected length of 1, got %d", len(categories)), packet, callID, uniqueID, category)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+
+		category = types.UInt32(categories[0])
+	}
+
+	rmcMessage, rmcError := protocol.DeleteScore(nil, packet, callID, uniqueID, category)
+	if rmcError != nil {
+		globals.RespondError(packet, ProtocolID, rmcError)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/delete_score.go
+++ b/ranking/legacy/delete_score.go
@@ -45,7 +45,7 @@ func (protocol *Protocol) handleDeleteScore(packet nex.PacketInterface) {
 	if rankingVersion.GreaterOrEqual("2.0.0") {
 		err = category.ExtractFrom(parametersStream)
 		if err != nil {
-			_, rmcError := protocol.DeleteScore(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, category)
+			_, rmcError := protocol.DeleteScore(fmt.Errorf("Failed to read category from parameters. %s", err.Error()), packet, callID, uniqueID, category)
 			if rmcError != nil {
 				globals.RespondError(packet, ProtocolID, rmcError)
 			}

--- a/ranking/legacy/get_common_data.go
+++ b/ranking/legacy/get_common_data.go
@@ -1,0 +1,50 @@
+// Package protocol implements the legacy Ranking protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+)
+
+func (protocol *Protocol) handleGetCommonData(packet nex.PacketInterface) {
+	if protocol.GetCommonData == nil {
+		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::GetCommonData not implemented")
+
+		globals.Logger.Warning(err.Message)
+		globals.RespondError(packet, ProtocolID, err)
+
+		return
+	}
+
+	endpoint := packet.Sender().Endpoint()
+
+	request := packet.RMCMessage()
+	callID := request.CallID
+	parameters := request.Parameters
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	var uniqueID types.UInt32
+
+	var err error
+
+	err = uniqueID.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.GetCommonData(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	rmcMessage, rmcError := protocol.GetCommonData(nil, packet, callID, uniqueID)
+	if rmcError != nil {
+		globals.RespondError(packet, ProtocolID, rmcError)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/get_score.go
+++ b/ranking/legacy/get_score.go
@@ -1,0 +1,121 @@
+// Package protocol implements the legacy Ranking protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+	ranking_types "github.com/PretendoNetwork/nex-protocols-go/v2/ranking/legacy/types"
+)
+
+func (protocol *Protocol) handleGetScore(packet nex.PacketInterface) {
+	if protocol.GetScore == nil {
+		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::GetScore not implemented")
+
+		globals.Logger.Warning(err.Message)
+		globals.RespondError(packet, ProtocolID, err)
+
+		return
+	}
+
+	endpoint := packet.Sender().Endpoint()
+	rankingVersion := endpoint.LibraryVersions().Ranking
+
+	request := packet.RMCMessage()
+	callID := request.CallID
+	parameters := request.Parameters
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	var rankingMode types.UInt8
+	var category types.UInt32
+	orderParam := ranking_types.NewRankingOrderParam()
+	var offset types.UInt32
+	var length types.UInt8
+
+	var err error
+
+	err = rankingMode.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.GetScore(fmt.Errorf("Failed to read rankingMode from parameters. %s", err.Error()), packet, callID, rankingMode, category, orderParam, offset, length)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	if rankingVersion.GreaterOrEqual("2.0.0") {
+		err = category.ExtractFrom(parametersStream)
+		if err != nil {
+			_, rmcError := protocol.GetScore(fmt.Errorf("Failed to read rankingMode from parameters. %s", err.Error()), packet, callID, rankingMode, category, orderParam, offset, length)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+	} else {
+		var categories types.List[types.UInt16]
+
+		err = categories.ExtractFrom(parametersStream)
+		if err != nil {
+			_, rmcError := protocol.GetScore(fmt.Errorf("Failed to read categories from parameters. %s", err.Error()), packet, callID, rankingMode, category, orderParam, offset, length)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+
+		if len(categories) != 1 {
+			_, rmcError := protocol.GetScore(fmt.Errorf("Failed to read categories from parameters. Expected length of 1, got %d", len(categories)), packet, callID, rankingMode, category, orderParam, offset, length)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+
+		category = types.UInt32(categories[0])
+	}
+
+	err = orderParam.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.GetScore(fmt.Errorf("Failed to read orderParam from parameters. %s", err.Error()), packet, callID, rankingMode, category, orderParam, offset, length)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = offset.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.GetScore(fmt.Errorf("Failed to read offset from parameters. %s", err.Error()), packet, callID, rankingMode, category, orderParam, offset, length)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = length.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.GetScore(fmt.Errorf("Failed to read length from parameters. %s", err.Error()), packet, callID, rankingMode, category, orderParam, offset, length)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	rmcMessage, rmcError := protocol.GetScore(nil, packet, callID, rankingMode, category, orderParam, offset, length)
+	if rmcError != nil {
+		globals.RespondError(packet, ProtocolID, rmcError)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/get_score.go
+++ b/ranking/legacy/get_score.go
@@ -30,7 +30,7 @@ func (protocol *Protocol) handleGetScore(packet nex.PacketInterface) {
 
 	var rankingMode types.UInt8
 	var category types.UInt32
-	orderParam := ranking_types.NewRankingOrderParam()
+	var orderParam ranking_types.RankingOrderParam
 	var offset types.UInt32
 	var length types.UInt8
 
@@ -49,7 +49,7 @@ func (protocol *Protocol) handleGetScore(packet nex.PacketInterface) {
 	if rankingVersion.GreaterOrEqual("2.0.0") {
 		err = category.ExtractFrom(parametersStream)
 		if err != nil {
-			_, rmcError := protocol.GetScore(fmt.Errorf("Failed to read rankingMode from parameters. %s", err.Error()), packet, callID, rankingMode, category, orderParam, offset, length)
+			_, rmcError := protocol.GetScore(fmt.Errorf("Failed to read category from parameters. %s", err.Error()), packet, callID, rankingMode, category, orderParam, offset, length)
 			if rmcError != nil {
 				globals.RespondError(packet, ProtocolID, rmcError)
 			}

--- a/ranking/legacy/get_self_score.go
+++ b/ranking/legacy/get_self_score.go
@@ -1,0 +1,110 @@
+// Package protocol implements the legacy Ranking protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+	ranking_types "github.com/PretendoNetwork/nex-protocols-go/v2/ranking/legacy/types"
+)
+
+func (protocol *Protocol) handleGetSelfScore(packet nex.PacketInterface) {
+	if protocol.GetSelfScore == nil {
+		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::GetSelfScore not implemented")
+
+		globals.Logger.Warning(err.Message)
+		globals.RespondError(packet, ProtocolID, err)
+
+		return
+	}
+
+	endpoint := packet.Sender().Endpoint()
+	rankingVersion := endpoint.LibraryVersions().Ranking
+
+	request := packet.RMCMessage()
+	callID := request.CallID
+	parameters := request.Parameters
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	var uniqueID types.UInt32
+	var category types.UInt32
+	orderParam := ranking_types.NewRankingOrderParam()
+	var length types.UInt8
+
+	var err error
+
+	err = uniqueID.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.GetSelfScore(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, category, orderParam, length)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	if rankingVersion.GreaterOrEqual("2.0.0") {
+		err = category.ExtractFrom(parametersStream)
+		if err != nil {
+			_, rmcError := protocol.GetSelfScore(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, category, orderParam, length)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+	} else {
+		var categories types.List[types.UInt16]
+
+		err = categories.ExtractFrom(parametersStream)
+		if err != nil {
+			_, rmcError := protocol.GetSelfScore(fmt.Errorf("Failed to read categories from parameters. %s", err.Error()), packet, callID, uniqueID, category, orderParam, length)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+
+		if len(categories) != 1 {
+			_, rmcError := protocol.GetSelfScore(fmt.Errorf("Failed to read categories from parameters. Expected length of 1, got %d", len(categories)), packet, callID, uniqueID, category, orderParam, length)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+
+		category = types.UInt32(categories[0])
+	}
+
+	err = orderParam.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.GetSelfScore(fmt.Errorf("Failed to read orderParam from parameters. %s", err.Error()), packet, callID, uniqueID, category, orderParam, length)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = length.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.GetSelfScore(fmt.Errorf("Failed to read length from parameters. %s", err.Error()), packet, callID, uniqueID, category, orderParam, length)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	rmcMessage, rmcError := protocol.GetSelfScore(nil, packet, callID, uniqueID, category, orderParam, length)
+	if rmcError != nil {
+		globals.RespondError(packet, ProtocolID, rmcError)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/get_self_score.go
+++ b/ranking/legacy/get_self_score.go
@@ -30,7 +30,7 @@ func (protocol *Protocol) handleGetSelfScore(packet nex.PacketInterface) {
 
 	var uniqueID types.UInt32
 	var category types.UInt32
-	orderParam := ranking_types.NewRankingOrderParam()
+	var orderParam ranking_types.RankingOrderParam
 	var length types.UInt8
 
 	var err error
@@ -48,7 +48,7 @@ func (protocol *Protocol) handleGetSelfScore(packet nex.PacketInterface) {
 	if rankingVersion.GreaterOrEqual("2.0.0") {
 		err = category.ExtractFrom(parametersStream)
 		if err != nil {
-			_, rmcError := protocol.GetSelfScore(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, category, orderParam, length)
+			_, rmcError := protocol.GetSelfScore(fmt.Errorf("Failed to read category from parameters. %s", err.Error()), packet, callID, uniqueID, category, orderParam, length)
 			if rmcError != nil {
 				globals.RespondError(packet, ProtocolID, rmcError)
 			}

--- a/ranking/legacy/get_top_score.go
+++ b/ranking/legacy/get_top_score.go
@@ -1,0 +1,87 @@
+// Package protocol implements the legacy Ranking protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+)
+
+func (protocol *Protocol) handleGetTopScore(packet nex.PacketInterface) {
+	if protocol.GetTopScore == nil {
+		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::GetTopScore not implemented")
+
+		globals.Logger.Warning(err.Message)
+		globals.RespondError(packet, ProtocolID, err)
+
+		return
+	}
+
+	endpoint := packet.Sender().Endpoint()
+	rankingVersion := endpoint.LibraryVersions().Ranking
+
+	request := packet.RMCMessage()
+	callID := request.CallID
+	parameters := request.Parameters
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	var uniqueID types.UInt32
+	var category types.UInt32
+
+	var err error
+
+	err = uniqueID.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.GetTopScore(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, category)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	if rankingVersion.GreaterOrEqual("2.0.0") {
+		err = category.ExtractFrom(parametersStream)
+		if err != nil {
+			_, rmcError := protocol.GetTopScore(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, category)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+	} else {
+		var categories types.List[types.UInt16]
+
+		err = categories.ExtractFrom(parametersStream)
+		if err != nil {
+			_, rmcError := protocol.GetTopScore(fmt.Errorf("Failed to read categories from parameters. %s", err.Error()), packet, callID, uniqueID, category)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+
+		if len(categories) != 1 {
+			_, rmcError := protocol.GetTopScore(fmt.Errorf("Failed to read categories from parameters. Expected length of 1, got %d", len(categories)), packet, callID, uniqueID, category)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+
+		category = types.UInt32(categories[0])
+	}
+
+	rmcMessage, rmcError := protocol.GetTopScore(nil, packet, callID, uniqueID, category)
+	if rmcError != nil {
+		globals.RespondError(packet, ProtocolID, rmcError)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/get_top_score.go
+++ b/ranking/legacy/get_top_score.go
@@ -45,7 +45,7 @@ func (protocol *Protocol) handleGetTopScore(packet nex.PacketInterface) {
 	if rankingVersion.GreaterOrEqual("2.0.0") {
 		err = category.ExtractFrom(parametersStream)
 		if err != nil {
-			_, rmcError := protocol.GetTopScore(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, category)
+			_, rmcError := protocol.GetTopScore(fmt.Errorf("Failed to read category from parameters. %s", err.Error()), packet, callID, uniqueID, category)
 			if rmcError != nil {
 				globals.RespondError(packet, ProtocolID, rmcError)
 			}

--- a/ranking/legacy/get_total.go
+++ b/ranking/legacy/get_total.go
@@ -1,0 +1,94 @@
+// Package protocol implements the legacy Ranking protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+)
+
+func (protocol *Protocol) handleGetTotal(packet nex.PacketInterface) {
+	if protocol.GetTotal == nil {
+		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::GetTotal not implemented")
+
+		globals.Logger.Warning(err.Message)
+		globals.RespondError(packet, ProtocolID, err)
+
+		return
+	}
+
+	endpoint := packet.Sender().Endpoint()
+
+	request := packet.RMCMessage()
+	callID := request.CallID
+	parameters := request.Parameters
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	var uniqueID types.UInt32
+	var unknown1 types.UInt8
+	var unknown2 types.UInt8
+	var unknown3 types.UInt8
+	var unknown4 types.UInt32
+
+	var err error
+
+	err = uniqueID.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.GetTotal(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, unknown1, unknown2, unknown3, unknown4)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = unknown1.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.GetTotal(fmt.Errorf("Failed to read unknown1 from parameters. %s", err.Error()), packet, callID, uniqueID, unknown1, unknown2, unknown3, unknown4)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = unknown2.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.GetTotal(fmt.Errorf("Failed to read unknown2 from parameters. %s", err.Error()), packet, callID, uniqueID, unknown1, unknown2, unknown3, unknown4)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = unknown3.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.GetTotal(fmt.Errorf("Failed to read unknown3 from parameters. %s", err.Error()), packet, callID, uniqueID, unknown1, unknown2, unknown3, unknown4)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = unknown4.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.GetTotal(fmt.Errorf("Failed to read unknown4 from parameters. %s", err.Error()), packet, callID, uniqueID, unknown1, unknown2, unknown3, unknown4)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	rmcMessage, rmcError := protocol.GetTotal(nil, packet, callID, uniqueID, unknown1, unknown2, unknown3, unknown4)
+	if rmcError != nil {
+		globals.RespondError(packet, ProtocolID, rmcError)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/protocol.go
+++ b/ranking/legacy/protocol.go
@@ -134,19 +134,19 @@ type Protocol struct {
 	DeleteAllScore        func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32) (*nex.RMCMessage, *nex.Error)
 	UploadCommonData      func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, commonData types.Buffer) (*nex.RMCMessage, *nex.Error)
 	DeleteCommonData      func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32) (*nex.RMCMessage, *nex.Error)
-	Unk0x7                func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, unknown types.UInt8) (*nex.RMCMessage, *nex.Error)
-	Unk0x8                func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, unknown types.UInt8) (*nex.RMCMessage, *nex.Error)
-	Unk0x9                func(err error, packet nex.PacketInterface, callID uint32, unknown1 types.UInt32, unknown2 types.UInt32, unknown3 types.List[types.UInt32], unknown4 types.List[types.UInt8]) (*nex.RMCMessage, *nex.Error)
+	Unk0x7                func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, unknown types.UInt8) (*nex.RMCMessage, *nex.Error) // TODO - Find name if possible
+	Unk0x8                func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, unknown types.UInt8) (*nex.RMCMessage, *nex.Error) // TODO - Find name if possible
+	Unk0x9                func(err error, packet nex.PacketInterface, callID uint32, unknown1 types.UInt32, unknown2 types.UInt32, unknown3 types.List[types.UInt32], unknown4 types.List[types.UInt8]) (*nex.RMCMessage, *nex.Error) // TODO - Find name if possible
 	GetTopScore           func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32) (*nex.RMCMessage, *nex.Error)
 	GetCommonData         func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32) (*nex.RMCMessage, *nex.Error)
-	Unk0xC                func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32) (*nex.RMCMessage, *nex.Error)
-	Unk0xD                func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, orderParam ranking_types.RankingOrderParam) (*nex.RMCMessage, *nex.Error)
+	Unk0xC                func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32) (*nex.RMCMessage, *nex.Error) // TODO - Find name if possible
+	Unk0xD                func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, orderParam ranking_types.RankingOrderParam) (*nex.RMCMessage, *nex.Error) // TODO - Find name if possible
 	GetScore              func(err error, packet nex.PacketInterface, callID uint32, rankingMode types.UInt8, category types.UInt32, orderParam ranking_types.RankingOrderParam, offset types.UInt32, length types.UInt8) (*nex.RMCMessage, *nex.Error)
 	GetSelfScore          func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, orderParam ranking_types.RankingOrderParam, length types.UInt8) (*nex.RMCMessage, *nex.Error)
 	GetTotal              func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, unknown1 types.UInt8, unknown2 types.UInt8, unknown3 types.UInt8, unknown4 types.UInt32) (*nex.RMCMessage, *nex.Error)
 	UploadScoreWithLimit  func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, scores types.List[types.UInt32], unknown1 types.UInt8, unknown2 types.UInt32, limit types.UInt16) (*nex.RMCMessage, *nex.Error)
 	UploadScoresWithLimit func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, scores types.List[ranking_types.RankingScoreWithLimit]) (*nex.RMCMessage, *nex.Error)
-	Unk0x13               func(err error, packet nex.PacketInterface, callID uint32, unknown1 types.UInt32, unknown2 types.UInt32, unknown3 types.List[types.UInt32], unknown4 types.List[types.UInt8], unknown5 types.Bool, unknown6 types.UInt16) (*nex.RMCMessage, *nex.Error)
+	Unk0x13               func(err error, packet nex.PacketInterface, callID uint32, unknown1 types.UInt32, unknown2 types.UInt32, unknown3 types.List[types.UInt32], unknown4 types.List[types.UInt8], unknown5 types.Bool, unknown6 types.UInt16) (*nex.RMCMessage, *nex.Error) // TODO - Find name if possible
 	Patches               nex.ServiceProtocol
 	PatchedMethods        []uint32
 }
@@ -161,19 +161,19 @@ type Interface interface {
 	SetHandlerDeleteAllScore(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32) (*nex.RMCMessage, *nex.Error))
 	SetHandlerUploadCommonData(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, commonData types.Buffer) (*nex.RMCMessage, *nex.Error))
 	SetHandlerDeleteCommonData(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32) (*nex.RMCMessage, *nex.Error))
-	SetHandlerUnk0x7(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, unknown types.UInt8) (*nex.RMCMessage, *nex.Error))
-	SetHandlerUnk0x8(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, unknown types.UInt8) (*nex.RMCMessage, *nex.Error))
-	SetHandlerUnk0x9(handler func(err error, packet nex.PacketInterface, callID uint32, unknown1 types.UInt32, unknown2 types.UInt32, unknown3 types.List[types.UInt32], unknown4 types.List[types.UInt8]) (*nex.RMCMessage, *nex.Error))
+	SetHandlerUnk0x7(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, unknown types.UInt8) (*nex.RMCMessage, *nex.Error)) // TODO - Find name if possible
+	SetHandlerUnk0x8(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, unknown types.UInt8) (*nex.RMCMessage, *nex.Error)) // TODO - Find name if possible
+	SetHandlerUnk0x9(handler func(err error, packet nex.PacketInterface, callID uint32, unknown1 types.UInt32, unknown2 types.UInt32, unknown3 types.List[types.UInt32], unknown4 types.List[types.UInt8]) (*nex.RMCMessage, *nex.Error)) // TODO - Find name if possible
 	SetHandlerGetTopScore(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32) (*nex.RMCMessage, *nex.Error))
 	SetHandlerGetCommonData(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32) (*nex.RMCMessage, *nex.Error))
-	SetHandlerUnk0xC(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32) (*nex.RMCMessage, *nex.Error))
-	SetHandlerUnk0xD(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, orderParam ranking_types.RankingOrderParam) (*nex.RMCMessage, *nex.Error))
+	SetHandlerUnk0xC(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32) (*nex.RMCMessage, *nex.Error)) // TODO - Find name if possible
+	SetHandlerUnk0xD(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, orderParam ranking_types.RankingOrderParam) (*nex.RMCMessage, *nex.Error)) // TODO - Find name if possible
 	SetHandlerGetScore(handler func(err error, packet nex.PacketInterface, callID uint32, rankingMode types.UInt8, category types.UInt32, orderParam ranking_types.RankingOrderParam, offset types.UInt32, length types.UInt8) (*nex.RMCMessage, *nex.Error))
 	SetHandlerGetSelfScore(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, orderParam ranking_types.RankingOrderParam, length types.UInt8) (*nex.RMCMessage, *nex.Error))
 	SetHandlerGetTotal(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, unknown1 types.UInt8, unknown2 types.UInt8, unknown3 types.UInt8, unknown4 types.UInt32) (*nex.RMCMessage, *nex.Error))
 	SetHandlerUploadScoreWithLimit(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, scores types.List[types.UInt32], unknown1 types.UInt8, unknown2 types.UInt32, limit types.UInt16) (*nex.RMCMessage, *nex.Error))
 	SetHandlerUploadScoresWithLimit(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, scores types.List[ranking_types.RankingScoreWithLimit]) (*nex.RMCMessage, *nex.Error))
-	SetHandlerUnk0x13(handler func(err error, packet nex.PacketInterface, callID uint32, unknown1 types.UInt32, unknown2 types.UInt32, unknown3 types.List[types.UInt32], unknown4 types.List[types.UInt8], unknown5 types.Bool, unknown6 types.UInt16) (*nex.RMCMessage, *nex.Error))
+	SetHandlerUnk0x13(handler func(err error, packet nex.PacketInterface, callID uint32, unknown1 types.UInt32, unknown2 types.UInt32, unknown3 types.List[types.UInt32], unknown4 types.List[types.UInt8], unknown5 types.Bool, unknown6 types.UInt16) (*nex.RMCMessage, *nex.Error)) // TODO - Find name if possible
 }
 
 // Endpoint returns the endpoint implementing the protocol
@@ -217,16 +217,19 @@ func (protocol *Protocol) SetHandlerDeleteCommonData(handler func(err error, pac
 }
 
 // SetHandlerUnk0x7 sets the handler for the Unk0x7 method
+// TODO - Find name if possible
 func (protocol *Protocol) SetHandlerUnk0x7(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, unknown types.UInt8) (*nex.RMCMessage, *nex.Error)) {
 	protocol.Unk0x7 = handler
 }
 
 // SetHandlerUnk0x8 sets the handler for the Unk0x8 method
+// TODO - Find name if possible
 func (protocol *Protocol) SetHandlerUnk0x8(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, unknown types.UInt8) (*nex.RMCMessage, *nex.Error)) {
 	protocol.Unk0x8 = handler
 }
 
 // SetHandlerUnk0x9 sets the handler for the Unk0x9 method
+// TODO - Find name if possible
 func (protocol *Protocol) SetHandlerUnk0x9(handler func(err error, packet nex.PacketInterface, callID uint32, unknown1 types.UInt32, unknown2 types.UInt32, unknown3 types.List[types.UInt32], unknown4 types.List[types.UInt8]) (*nex.RMCMessage, *nex.Error)) {
 	protocol.Unk0x9 = handler
 }
@@ -242,11 +245,13 @@ func (protocol *Protocol) SetHandlerGetCommonData(handler func(err error, packet
 }
 
 // SetHandlerUnk0xC sets the handler for the Unk0xC method
+// TODO - Find name if possible
 func (protocol *Protocol) SetHandlerUnk0xC(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32) (*nex.RMCMessage, *nex.Error)) {
 	protocol.Unk0xC = handler
 }
 
 // SetHandlerUnk0xD sets the handler for the Unk0xD method
+// TODO - Find name if possible
 func (protocol *Protocol) SetHandlerUnk0xD(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, orderParam ranking_types.RankingOrderParam) (*nex.RMCMessage, *nex.Error)) {
 	protocol.Unk0xD = handler
 }
@@ -277,6 +282,7 @@ func (protocol *Protocol) SetHandlerUploadScoresWithLimit(handler func(err error
 }
 
 // SetHandlerUnk0x13 sets the handler for the Unk0x13 method
+// TODO - Find name if possible
 func (protocol *Protocol) SetHandlerUnk0x13(handler func(err error, packet nex.PacketInterface, callID uint32, unknown1 types.UInt32, unknown2 types.UInt32, unknown3 types.List[types.UInt32], unknown4 types.List[types.UInt8], unknown5 types.Bool, unknown6 types.UInt16) (*nex.RMCMessage, *nex.Error)) {
 	protocol.Unk0x13 = handler
 }
@@ -313,19 +319,19 @@ func (protocol *Protocol) HandlePacket(packet nex.PacketInterface) {
 		case MethodDeleteCommonData:
 			protocol.handleDeleteCommonData(packet)
 		case MethodUnk0x7:
-			protocol.handleUnk0x7(packet)
+			protocol.handleUnk0x7(packet) // TODO - Find name if possible
 		case MethodUnk0x8:
-			protocol.handleUnk0x8(packet)
+			protocol.handleUnk0x8(packet) // TODO - Find name if possible
 		case MethodUnk0x9:
-			protocol.handleUnk0x9(packet)
+			protocol.handleUnk0x9(packet) // TODO - Find name if possible
 		case MethodGetTopScore:
 			protocol.handleGetTopScore(packet)
 		case MethodGetCommonData:
 			protocol.handleGetCommonData(packet)
 		case MethodUnk0xC:
-			protocol.handleUnk0xC(packet)
+			protocol.handleUnk0xC(packet) // TODO - Find name if possible
 		case MethodUnk0xD:
-			protocol.handleUnk0xD(packet)
+			protocol.handleUnk0xD(packet) // TODO - Find name if possible
 		case MethodGetScore:
 			protocol.handleGetScore(packet)
 		case MethodGetSelfScore:
@@ -337,7 +343,7 @@ func (protocol *Protocol) HandlePacket(packet nex.PacketInterface) {
 		case MethodUploadScoresWithLimit:
 			protocol.handleUploadScoresWithLimit(packet)
 		case MethodUnk0x13:
-			protocol.handleUnk0x13(packet)
+			protocol.handleUnk0x13(packet) // TODO - Find name if possible
 		default:
 			errMessage := fmt.Sprintf("Unsupported Ranking method ID: %#v\n", message.MethodID)
 			err := nex.NewError(nex.ResultCodes.Core.NotImplemented, errMessage)
@@ -358,17 +364,17 @@ func (protocol *Protocol) HandlePacket(packet nex.PacketInterface) {
 		case MethodDeleteCommonDataNEX1:
 			protocol.handleDeleteCommonData(packet)
 		case MethodUnk0x7NEX1:
-			protocol.handleUnk0x7(packet)
+			protocol.handleUnk0x7(packet) // TODO - Find name if possible
 		case MethodUnk0x8NEX1:
-			protocol.handleUnk0x8(packet)
+			protocol.handleUnk0x8(packet) // TODO - Find name if possible
 		case MethodGetTopScoreNEX1:
 			protocol.handleGetTopScore(packet)
 		case MethodGetCommonDataNEX1:
 			protocol.handleGetCommonData(packet)
 		case MethodUnk0xCNEX1:
-			protocol.handleUnk0xC(packet)
+			protocol.handleUnk0xC(packet) // TODO - Find name if possible
 		case MethodUnk0xDNEX1:
-			protocol.handleUnk0xD(packet)
+			protocol.handleUnk0xD(packet) // TODO - Find name if possible
 		case MethodGetScoreNEX1:
 			protocol.handleGetScore(packet)
 		case MethodGetSelfScoreNEX1:

--- a/ranking/legacy/protocol.go
+++ b/ranking/legacy/protocol.go
@@ -1,0 +1,391 @@
+// Package protocol implements the legacy Ranking protocol
+package protocol
+
+import (
+	"fmt"
+	"slices"
+
+	nex "github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+
+	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+	ranking_types "github.com/PretendoNetwork/nex-protocols-go/v2/ranking/legacy/types"
+)
+
+const (
+	// ProtocolID is the protocol ID for the legacy Ranking protocol
+	ProtocolID = 0x70
+
+	// MethodUploadScore is the method ID for the method UploadScore
+	MethodUploadScore = 0x1
+
+	// MethodUploadScores is the method ID for the method UploadScores
+	MethodUploadScores = 0x2
+
+	// MethodDeleteScore is the method ID for the method DeleteScore
+	MethodDeleteScore = 0x3
+
+	// MethodDeleteAllScore is the method ID for the method DeleteAllScore
+	MethodDeleteAllScore = 0x4
+
+	// MethodUploadCommonData is the method ID for the method UploadCommonData
+	MethodUploadCommonData = 0x5
+
+	// MethodDeleteCommonData is the method ID for the method DeleteCommonData
+	MethodDeleteCommonData = 0x6
+
+	// MethodUnk0x7 is the method ID for the method Unk0x7
+	// TODO - Find name if possible
+	MethodUnk0x7 = 0x7
+
+	// MethodUnk0x8 is the method ID for the method Unk0x8
+	// TODO - Find name if possible
+	MethodUnk0x8 = 0x8
+
+	// MethodUnk0x9 is the method ID for the method Unk0x9
+	// TODO - Find name if possible
+	MethodUnk0x9 = 0x9
+
+	// MethodGetTopScore is the method ID for the the method GetTopScore
+	MethodGetTopScore = 0xA
+
+	// MethodGetCommonData is the method ID for the method GetCommonData
+	MethodGetCommonData = 0xB
+
+	// MethodUnk0xC is the method ID for the method Unk0xC
+	// TODO - Find name if possible
+	MethodUnk0xC = 0xC
+
+	// MethodUnk0xD is the method ID for the method Unk0xD
+	// TODO - Find name if possible
+	MethodUnk0xD = 0xD
+
+	// MethodGetScore is the method ID for the method GetScore
+	MethodGetScore = 0xE
+
+	// MethodGetSelfScore is the method ID for the method GetSelfScore
+	MethodGetSelfScore = 0xF
+
+	// MethodGetTotal is the method ID for method GetTotal
+	MethodGetTotal = 0x10
+
+	// MethodUploadScoreWithLimit is the method ID for method UploadScoreWithLimit
+	MethodUploadScoreWithLimit = 0x11
+
+	// MethodUploadScoresWithLimit is the method ID for method UploadScoresWithLimit
+	MethodUploadScoresWithLimit = 0x12
+
+	// MethodUnk0x13 is the method ID for the method Unk0x13
+	// TODO - Find name if possible
+	MethodUnk0x13 = 0x13
+
+	// * NEX 1 method IDs
+
+	// MethodDeleteScoreNEX1 is the method ID for the method DeleteScore on NEX 1
+	MethodDeleteScoreNEX1 = 0x2
+
+	// MethodDeleteAllScoreNEX1 is the method ID for the method DeleteAllScore on NEX 1
+	MethodDeleteAllScoreNEX1 = 0x3
+
+	// MethodUploadCommonDataNEX1 is the method ID for the method UploadCommonData on NEX 1
+	MethodUploadCommonDataNEX1 = 0x4
+
+	// MethodDeleteCommonDataNEX1 is the method ID for the method DeleteCommonData on NEX 1
+	MethodDeleteCommonDataNEX1 = 0x5
+
+	// MethodUnk0x7NEX1 is the method ID for the method Unk0x7 on NEX 1
+	// TODO - Find name if possible
+	MethodUnk0x7NEX1 = 0x6
+
+	// MethodUnk0x8NEX1 is the method ID for the method Unk0x8 on NEX 1
+	// TODO - Find name if possible
+	MethodUnk0x8NEX1 = 0x7
+
+	// MethodGetTopScoreNEX1 is the method ID for the the method GetTopScore on NEX 1
+	MethodGetTopScoreNEX1 = 0x8
+
+	// MethodGetCommonDataNEX1 is the method ID for the method GetCommonData on NEX 1
+	MethodGetCommonDataNEX1 = 0x9
+
+	// MethodUnk0xCNEX1 is the method ID for the method Unk0xC on NEX 1
+	// TODO - Find name if possible
+	MethodUnk0xCNEX1 = 0xA
+
+	// MethodUnk0xDNEX1 is the method ID for the method Unk0xD on NEX 1
+	// TODO - Find name if possible
+	MethodUnk0xDNEX1 = 0xB
+
+	// MethodGetScoreNEX1 is the method ID for the method GetScore on NEX 1
+	MethodGetScoreNEX1 = 0xC
+
+	// MethodGetSelfScoreNEX1 is the method ID for the method GetSelfScore on NEX 1
+	MethodGetSelfScoreNEX1 = 0xD
+
+	// MethodGetTotalNEX1 is the method ID for method GetTotal on NEX 1
+	MethodGetTotalNEX1 = 0xE
+)
+
+// Protocol stores all the RMC method handlers for the Ranking protocol and listens for requests
+type Protocol struct {
+	endpoint              nex.EndpointInterface
+	UploadScore           func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, scores types.List[types.UInt32], unknown1 types.UInt8, unknown2 types.UInt32) (*nex.RMCMessage, *nex.Error)
+	UploadScores          func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, scores types.List[ranking_types.RankingScore]) (*nex.RMCMessage, *nex.Error)
+	DeleteScore           func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32) (*nex.RMCMessage, *nex.Error)
+	DeleteAllScore        func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32) (*nex.RMCMessage, *nex.Error)
+	UploadCommonData      func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, commonData types.Buffer) (*nex.RMCMessage, *nex.Error)
+	DeleteCommonData      func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32) (*nex.RMCMessage, *nex.Error)
+	Unk0x7                func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, unknown types.UInt8) (*nex.RMCMessage, *nex.Error)
+	Unk0x8                func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, unknown types.UInt8) (*nex.RMCMessage, *nex.Error)
+	Unk0x9                func(err error, packet nex.PacketInterface, callID uint32, unknown1 types.UInt32, unknown2 types.UInt32, unknown3 types.List[types.UInt32], unknown4 types.List[types.UInt8]) (*nex.RMCMessage, *nex.Error)
+	GetTopScore           func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32) (*nex.RMCMessage, *nex.Error)
+	GetCommonData         func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32) (*nex.RMCMessage, *nex.Error)
+	Unk0xC                func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32) (*nex.RMCMessage, *nex.Error)
+	Unk0xD                func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, orderParam ranking_types.RankingOrderParam) (*nex.RMCMessage, *nex.Error)
+	GetScore              func(err error, packet nex.PacketInterface, callID uint32, rankingMode types.UInt8, category types.UInt32, orderParam ranking_types.RankingOrderParam, offset types.UInt32, length types.UInt8) (*nex.RMCMessage, *nex.Error)
+	GetSelfScore          func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, orderParam ranking_types.RankingOrderParam, length types.UInt8) (*nex.RMCMessage, *nex.Error)
+	GetTotal              func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, unknown1 types.UInt8, unknown2 types.UInt8, unknown3 types.UInt8, unknown4 types.UInt32) (*nex.RMCMessage, *nex.Error)
+	UploadScoreWithLimit  func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, scores types.List[types.UInt32], unknown1 types.UInt8, unknown2 types.UInt32, limit types.UInt16) (*nex.RMCMessage, *nex.Error)
+	UploadScoresWithLimit func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, scores types.List[ranking_types.RankingScoreWithLimit]) (*nex.RMCMessage, *nex.Error)
+	Unk0x13               func(err error, packet nex.PacketInterface, callID uint32, unknown1 types.UInt32, unknown2 types.UInt32, unknown3 types.List[types.UInt32], unknown4 types.List[types.UInt8], unknown5 types.Bool, unknown6 types.UInt16) (*nex.RMCMessage, *nex.Error)
+	Patches               nex.ServiceProtocol
+	PatchedMethods        []uint32
+}
+
+// Interface implements the methods present on the legacy Ranking protocol struct
+type Interface interface {
+	Endpoint() nex.EndpointInterface
+	SetEndpoint(endpoint nex.EndpointInterface)
+	SetHandlerUploadScore(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, scores types.List[types.UInt32], unknown1 types.UInt8, unknown2 types.UInt32) (*nex.RMCMessage, *nex.Error))
+	SetHandlerUploadScores(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, scores types.List[ranking_types.RankingScore]) (*nex.RMCMessage, *nex.Error))
+	SetHandlerDeleteScore(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32) (*nex.RMCMessage, *nex.Error))
+	SetHandlerDeleteAllScore(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32) (*nex.RMCMessage, *nex.Error))
+	SetHandlerUploadCommonData(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, commonData types.Buffer) (*nex.RMCMessage, *nex.Error))
+	SetHandlerDeleteCommonData(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32) (*nex.RMCMessage, *nex.Error))
+	SetHandlerUnk0x7(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, unknown types.UInt8) (*nex.RMCMessage, *nex.Error))
+	SetHandlerUnk0x8(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, unknown types.UInt8) (*nex.RMCMessage, *nex.Error))
+	SetHandlerUnk0x9(handler func(err error, packet nex.PacketInterface, callID uint32, unknown1 types.UInt32, unknown2 types.UInt32, unknown3 types.List[types.UInt32], unknown4 types.List[types.UInt8]) (*nex.RMCMessage, *nex.Error))
+	SetHandlerGetTopScore(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32) (*nex.RMCMessage, *nex.Error))
+	SetHandlerGetCommonData(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32) (*nex.RMCMessage, *nex.Error))
+	SetHandlerUnk0xC(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32) (*nex.RMCMessage, *nex.Error))
+	SetHandlerUnk0xD(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, orderParam ranking_types.RankingOrderParam) (*nex.RMCMessage, *nex.Error))
+	SetHandlerGetScore(handler func(err error, packet nex.PacketInterface, callID uint32, rankingMode types.UInt8, category types.UInt32, orderParam ranking_types.RankingOrderParam, offset types.UInt32, length types.UInt8) (*nex.RMCMessage, *nex.Error))
+	SetHandlerGetSelfScore(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, orderParam ranking_types.RankingOrderParam, length types.UInt8) (*nex.RMCMessage, *nex.Error))
+	SetHandlerGetTotal(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, unknown1 types.UInt8, unknown2 types.UInt8, unknown3 types.UInt8, unknown4 types.UInt32) (*nex.RMCMessage, *nex.Error))
+	SetHandlerUploadScoreWithLimit(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, scores types.List[types.UInt32], unknown1 types.UInt8, unknown2 types.UInt32, limit types.UInt16) (*nex.RMCMessage, *nex.Error))
+	SetHandlerUploadScoresWithLimit(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, scores types.List[ranking_types.RankingScoreWithLimit]) (*nex.RMCMessage, *nex.Error))
+	SetHandlerUnk0x13(handler func(err error, packet nex.PacketInterface, callID uint32, unknown1 types.UInt32, unknown2 types.UInt32, unknown3 types.List[types.UInt32], unknown4 types.List[types.UInt8], unknown5 types.Bool, unknown6 types.UInt16) (*nex.RMCMessage, *nex.Error))
+}
+
+// Endpoint returns the endpoint implementing the protocol
+func (protocol *Protocol) Endpoint() nex.EndpointInterface {
+	return protocol.endpoint
+}
+
+// SetEndpoint sets the endpoint implementing the protocol
+func (protocol *Protocol) SetEndpoint(endpoint nex.EndpointInterface) {
+	protocol.endpoint = endpoint
+}
+
+// SetHandlerUploadScore sets the handler for the UploadScore method
+func (protocol *Protocol) SetHandlerUploadScore(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, scores types.List[types.UInt32], unknown1 types.UInt8, unknown2 types.UInt32) (*nex.RMCMessage, *nex.Error)) {
+	protocol.UploadScore = handler
+}
+
+// SetHandlerUploadScores sets the handler for the UploadScores method
+func (protocol *Protocol) SetHandlerUploadScores(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, scores types.List[ranking_types.RankingScore]) (*nex.RMCMessage, *nex.Error)) {
+	protocol.UploadScores = handler
+}
+
+// SetHandlerDeleteScore sets the handler for the DeleteScore method
+func (protocol *Protocol) SetHandlerDeleteScore(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32) (*nex.RMCMessage, *nex.Error)) {
+	protocol.DeleteScore = handler
+}
+
+// SetHandlerDeleteAllScore sets the handler for the DeleteAllScore method
+func (protocol *Protocol) SetHandlerDeleteAllScore(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32) (*nex.RMCMessage, *nex.Error)) {
+	protocol.DeleteAllScore = handler
+}
+
+// SetHandlerUploadCommonData sets the handler for the UploadCommonData method
+func (protocol *Protocol) SetHandlerUploadCommonData(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, commonData types.Buffer) (*nex.RMCMessage, *nex.Error)) {
+	protocol.UploadCommonData = handler
+}
+
+// SetHandlerDeleteCommonData sets the handler for the DeleteCommonData method
+func (protocol *Protocol) SetHandlerDeleteCommonData(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32) (*nex.RMCMessage, *nex.Error)) {
+	protocol.DeleteCommonData = handler
+}
+
+// SetHandlerUnk0x7 sets the handler for the Unk0x7 method
+func (protocol *Protocol) SetHandlerUnk0x7(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, unknown types.UInt8) (*nex.RMCMessage, *nex.Error)) {
+	protocol.Unk0x7 = handler
+}
+
+// SetHandlerUnk0x8 sets the handler for the Unk0x8 method
+func (protocol *Protocol) SetHandlerUnk0x8(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, unknown types.UInt8) (*nex.RMCMessage, *nex.Error)) {
+	protocol.Unk0x8 = handler
+}
+
+// SetHandlerUnk0x9 sets the handler for the Unk0x9 method
+func (protocol *Protocol) SetHandlerUnk0x9(handler func(err error, packet nex.PacketInterface, callID uint32, unknown1 types.UInt32, unknown2 types.UInt32, unknown3 types.List[types.UInt32], unknown4 types.List[types.UInt8]) (*nex.RMCMessage, *nex.Error)) {
+	protocol.Unk0x9 = handler
+}
+
+// SetHandlerGetTopScore sets the handler for the GetTopScore method
+func (protocol *Protocol) SetHandlerGetTopScore(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32) (*nex.RMCMessage, *nex.Error)) {
+	protocol.GetTopScore = handler
+}
+
+// SetHandlerGetCommonData sets the handler for the GetCommonData method
+func (protocol *Protocol) SetHandlerGetCommonData(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32) (*nex.RMCMessage, *nex.Error)) {
+	protocol.GetCommonData = handler
+}
+
+// SetHandlerUnk0xC sets the handler for the Unk0xC method
+func (protocol *Protocol) SetHandlerUnk0xC(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32) (*nex.RMCMessage, *nex.Error)) {
+	protocol.Unk0xC = handler
+}
+
+// SetHandlerUnk0xD sets the handler for the Unk0xD method
+func (protocol *Protocol) SetHandlerUnk0xD(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, orderParam ranking_types.RankingOrderParam) (*nex.RMCMessage, *nex.Error)) {
+	protocol.Unk0xD = handler
+}
+
+// SetHandlerGetScore sets the handler for the GetScore method
+func (protocol *Protocol) SetHandlerGetScore(handler func(err error, packet nex.PacketInterface, callID uint32, rankingMode types.UInt8, category types.UInt32, orderParam ranking_types.RankingOrderParam, offset types.UInt32, length types.UInt8) (*nex.RMCMessage, *nex.Error)) {
+	protocol.GetScore = handler
+}
+
+// SetHandlerGetSelfScore sets the handler for the GetSelfScore method
+func (protocol *Protocol) SetHandlerGetSelfScore(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, orderParam ranking_types.RankingOrderParam, length types.UInt8) (*nex.RMCMessage, *nex.Error)) {
+	protocol.GetSelfScore = handler
+}
+
+// SetHandlerGetTotal sets the handler for the GetTotal method
+func (protocol *Protocol) SetHandlerGetTotal(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, unknown1 types.UInt8, unknown2 types.UInt8, unknown3 types.UInt8, unknown4 types.UInt32) (*nex.RMCMessage, *nex.Error)) {
+	protocol.GetTotal = handler
+}
+
+// SetHandlerUploadScoreWithLimit sets the handler for the UploadScoreWithLimit method
+func (protocol *Protocol) SetHandlerUploadScoreWithLimit(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, category types.UInt32, scores types.List[types.UInt32], unknown1 types.UInt8, unknown2 types.UInt32, limit types.UInt16) (*nex.RMCMessage, *nex.Error)) {
+	protocol.UploadScoreWithLimit = handler
+}
+
+// SetHandlerUploadScoresWithLimit sets the handler for the UploadScoresWithLimit method
+func (protocol *Protocol) SetHandlerUploadScoresWithLimit(handler func(err error, packet nex.PacketInterface, callID uint32, uniqueID types.UInt32, scores types.List[ranking_types.RankingScoreWithLimit]) (*nex.RMCMessage, *nex.Error)) {
+	protocol.UploadScoresWithLimit = handler
+}
+
+// SetHandlerUnk0x13 sets the handler for the Unk0x13 method
+func (protocol *Protocol) SetHandlerUnk0x13(handler func(err error, packet nex.PacketInterface, callID uint32, unknown1 types.UInt32, unknown2 types.UInt32, unknown3 types.List[types.UInt32], unknown4 types.List[types.UInt8], unknown5 types.Bool, unknown6 types.UInt16) (*nex.RMCMessage, *nex.Error)) {
+	protocol.Unk0x13 = handler
+}
+
+// HandlePacket sends the packet to the correct RMC method handler
+func (protocol *Protocol) HandlePacket(packet nex.PacketInterface) {
+	message := packet.RMCMessage()
+
+	if !message.IsRequest || message.ProtocolID != ProtocolID {
+		return
+	}
+
+	if protocol.Patches != nil && slices.Contains(protocol.PatchedMethods, message.MethodID) {
+		protocol.Patches.HandlePacket(packet)
+		return
+	}
+
+	endpoint := packet.Sender().Endpoint()
+	rankingVersion := endpoint.LibraryVersions().Ranking
+
+	// * NEX 1 doesn't implement UploadScores, Unk0x9 and any method after UploadScoresWithLimit
+	if rankingVersion.GreaterOrEqual("2.0.0") {
+		switch message.MethodID {
+		case MethodUploadScore:
+			protocol.handleUploadScore(packet)
+		case MethodUploadScores:
+			protocol.handleUploadScores(packet)
+		case MethodDeleteScore:
+			protocol.handleDeleteScore(packet)
+		case MethodDeleteAllScore:
+			protocol.handleDeleteAllScore(packet)
+		case MethodUploadCommonData:
+			protocol.handleUploadCommonData(packet)
+		case MethodDeleteCommonData:
+			protocol.handleDeleteCommonData(packet)
+		case MethodUnk0x7:
+			protocol.handleUnk0x7(packet)
+		case MethodUnk0x8:
+			protocol.handleUnk0x8(packet)
+		case MethodUnk0x9:
+			protocol.handleUnk0x9(packet)
+		case MethodGetTopScore:
+			protocol.handleGetTopScore(packet)
+		case MethodGetCommonData:
+			protocol.handleGetCommonData(packet)
+		case MethodUnk0xC:
+			protocol.handleUnk0xC(packet)
+		case MethodUnk0xD:
+			protocol.handleUnk0xD(packet)
+		case MethodGetScore:
+			protocol.handleGetScore(packet)
+		case MethodGetSelfScore:
+			protocol.handleGetSelfScore(packet)
+		case MethodGetTotal:
+			protocol.handleGetTotal(packet)
+		case MethodUploadScoreWithLimit:
+			protocol.handleUploadScoreWithLimit(packet)
+		case MethodUploadScoresWithLimit:
+			protocol.handleUploadScoresWithLimit(packet)
+		case MethodUnk0x13:
+			protocol.handleUnk0x13(packet)
+		default:
+			errMessage := fmt.Sprintf("Unsupported Ranking method ID: %#v\n", message.MethodID)
+			err := nex.NewError(nex.ResultCodes.Core.NotImplemented, errMessage)
+
+			globals.RespondError(packet, ProtocolID, err)
+			globals.Logger.Warning(err.Message)
+		}
+	} else {
+		switch message.MethodID {
+		case MethodUploadScore:
+			protocol.handleUploadScore(packet)
+		case MethodDeleteScoreNEX1:
+			protocol.handleDeleteScore(packet)
+		case MethodDeleteAllScoreNEX1:
+			protocol.handleDeleteAllScore(packet)
+		case MethodUploadCommonDataNEX1:
+			protocol.handleUploadCommonData(packet)
+		case MethodDeleteCommonDataNEX1:
+			protocol.handleDeleteCommonData(packet)
+		case MethodUnk0x7NEX1:
+			protocol.handleUnk0x7(packet)
+		case MethodUnk0x8NEX1:
+			protocol.handleUnk0x8(packet)
+		case MethodGetTopScoreNEX1:
+			protocol.handleGetTopScore(packet)
+		case MethodGetCommonDataNEX1:
+			protocol.handleGetCommonData(packet)
+		case MethodUnk0xCNEX1:
+			protocol.handleUnk0xC(packet)
+		case MethodUnk0xDNEX1:
+			protocol.handleUnk0xD(packet)
+		case MethodGetScoreNEX1:
+			protocol.handleGetScore(packet)
+		case MethodGetSelfScoreNEX1:
+			protocol.handleGetSelfScore(packet)
+		case MethodGetTotalNEX1:
+			protocol.handleGetTotal(packet)
+		default:
+			errMessage := fmt.Sprintf("Unsupported Ranking method ID: %#v\n", message.MethodID)
+			err := nex.NewError(nex.ResultCodes.Core.NotImplemented, errMessage)
+
+			globals.RespondError(packet, ProtocolID, err)
+			globals.Logger.Warning(err.Message)
+		}
+	}
+}
+
+// NewProtocol returns a new Ranking protocol
+func NewProtocol() *Protocol {
+	return &Protocol{}
+}

--- a/ranking/legacy/types/ranking_data.go
+++ b/ranking/legacy/types/ranking_data.go
@@ -1,0 +1,251 @@
+// Package types implements all the types used by the legacy Ranking protocol
+package types
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
+
+// RankingData is a type within the Ranking protocol
+type RankingData struct {
+	types.Structure
+	UniqueID    types.UInt32
+	PrincipalID types.PID
+	Order       types.UInt32
+	Category    types.UInt32
+	Scores      types.List[types.UInt32]
+	Unknown1    types.UInt8
+	Unknown2    types.UInt32
+	CommonData  types.Buffer
+}
+
+// WriteTo writes the RankingData to the given writable
+func (rd RankingData) WriteTo(writable types.Writable) {
+	stream := writable.(*nex.ByteStreamOut)
+	libraryVersion := stream.LibraryVersions.Ranking
+
+	contentWritable := writable.CopyNew()
+
+	rd.PrincipalID.WriteTo(contentWritable)
+	rd.UniqueID.WriteTo(contentWritable)
+	rd.Order.WriteTo(contentWritable)
+
+	if libraryVersion.GreaterOrEqual("2.0.0") {
+		rd.Category.WriteTo(contentWritable)
+	} else {
+		category := types.List[types.UInt16]{types.UInt16(rd.Category)}
+		category.WriteTo(contentWritable)
+	}
+
+	rd.Category.WriteTo(contentWritable)
+	rd.Scores.WriteTo(contentWritable)
+	rd.Unknown1.WriteTo(contentWritable)
+	rd.Unknown2.WriteTo(contentWritable)
+	rd.CommonData.WriteTo(contentWritable)
+
+	content := contentWritable.Bytes()
+
+	rd.WriteHeaderTo(writable, uint32(len(content)))
+
+	writable.Write(content)
+}
+
+// ExtractFrom extracts the RankingData from the given readable
+func (rd *RankingData) ExtractFrom(readable types.Readable) error {
+	stream := readable.(*nex.ByteStreamIn)
+	libraryVersion := stream.LibraryVersions.Ranking
+
+	var err error
+
+	err = rd.ExtractHeaderFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingData header. %s", err.Error())
+	}
+
+	err = rd.PrincipalID.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingData.PrincipalID. %s", err.Error())
+	}
+
+	err = rd.UniqueID.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingData.UniqueID. %s", err.Error())
+	}
+
+	err = rd.Order.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingData.Order. %s", err.Error())
+	}
+
+	if libraryVersion.GreaterOrEqual("2.0.0") {
+		err = rd.Category.ExtractFrom(readable)
+		if err != nil {
+			return fmt.Errorf("Failed to extract RankingData.Category. %s", err.Error())
+		}
+	} else {
+		var category types.List[types.UInt16]
+
+		err = category.ExtractFrom(readable)
+		if err != nil {
+			return fmt.Errorf("Failed to extract RankingData.Category. %s", err.Error())
+		}
+
+		if len(category) != 1 {
+			return fmt.Errorf("Failed to extract RankingData.Category. Expected length of 1, got %d", len(category))
+		}
+
+		rd.Category = types.UInt32(category[0])
+	}
+
+	err = rd.Category.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingData.Category. %s", err.Error())
+	}
+
+	err = rd.Scores.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingData.Scores. %s", err.Error())
+	}
+
+	err = rd.Unknown1.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingData.Unknown1. %s", err.Error())
+	}
+
+	err = rd.Unknown2.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingData.Unknown2. %s", err.Error())
+	}
+
+	err = rd.CommonData.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingData.CommonData. %s", err.Error())
+	}
+
+	return nil
+}
+
+// Copy returns a new copied instance of RankingData
+func (rd RankingData) Copy() types.RVType {
+	copied := NewRankingData()
+
+	copied.StructureVersion = rd.StructureVersion
+	copied.PrincipalID = rd.PrincipalID.Copy().(types.PID)
+	copied.UniqueID = rd.UniqueID.Copy().(types.UInt64)
+	copied.Order = rd.Order.Copy().(types.UInt32)
+	copied.Category = rd.Category.Copy().(types.UInt32)
+	copied.Scores = rd.Scores.Copy().(types.UInt32)
+	copied.Unknown1 = rd.Unknown1.Copy().(types.Buffer)
+	copied.Unknown2 = rd.Unknown2.Copy().(types.UInt64)
+	copied.CommonData = rd.CommonData.Copy().(types.Buffer)
+	copied.UpdateTime = rd.UpdateTime.Copy().(types.DateTime)
+
+	return copied
+}
+
+// Equals checks if the given RankingData contains the same data as the current RankingData
+func (rd RankingData) Equals(o types.RVType) bool {
+	if _, ok := o.(RankingData); !ok {
+		return false
+	}
+
+	other := o.(RankingData)
+
+	if rd.StructureVersion != other.StructureVersion {
+		return false
+	}
+
+	if !rd.PrincipalID.Equals(other.PrincipalID) {
+		return false
+	}
+
+	if !rd.UniqueID.Equals(other.UniqueID) {
+		return false
+	}
+
+	if !rd.Order.Equals(other.Order) {
+		return false
+	}
+
+	if !rd.Category.Equals(other.Category) {
+		return false
+	}
+
+	if !rd.Scores.Equals(other.Scores) {
+		return false
+	}
+
+	if !rd.Unknown1.Equals(other.Unknown1) {
+		return false
+	}
+
+	if !rd.Unknown2.Equals(other.Unknown2) {
+		return false
+	}
+
+	if !rd.CommonData.Equals(other.CommonData) {
+		return false
+	}
+
+	return rd.UpdateTime.Equals(other.UpdateTime)
+}
+
+// CopyRef copies the current value of the RankingData
+// and returns a pointer to the new copy
+func (rd RankingData) CopyRef() types.RVTypePtr {
+	copied := rd.Copy().(RankingData)
+	return &copied
+}
+
+// Deref takes a pointer to the RankingData
+// and dereferences it to the raw value.
+// Only useful when working with an instance of RVTypePtr
+func (rd *RankingData) Deref() types.RVType {
+	return *rd
+}
+
+// String returns the string representation of the RankingData
+func (rd RankingData) String() string {
+	return rd.FormatToString(0)
+}
+
+// FormatToString pretty-prints the RankingData using the provided indentation level
+func (rd RankingData) FormatToString(indentationLevel int) string {
+	indentationValues := strings.Repeat("\t", indentationLevel+1)
+	indentationEnd := strings.Repeat("\t", indentationLevel)
+
+	var b strings.Builder
+
+	b.WriteString("RankingData{\n")
+	b.WriteString(fmt.Sprintf("%sPrincipalID: %s,\n", indentationValues, rd.PrincipalID.FormatToString(indentationLevel+1)))
+	b.WriteString(fmt.Sprintf("%sUniqueID: %s,\n", indentationValues, rd.UniqueID))
+	b.WriteString(fmt.Sprintf("%sOrder: %s,\n", indentationValues, rd.Order))
+	b.WriteString(fmt.Sprintf("%sCategory: %s,\n", indentationValues, rd.Category))
+	b.WriteString(fmt.Sprintf("%sScores: %s,\n", indentationValues, rd.Scores))
+	b.WriteString(fmt.Sprintf("%sUnknown1: %s,\n", indentationValues, rd.Unknown1))
+	b.WriteString(fmt.Sprintf("%sUnknown2: %s,\n", indentationValues, rd.Unknown2))
+	b.WriteString(fmt.Sprintf("%sCommonData: %s,\n", indentationValues, rd.CommonData))
+	b.WriteString(fmt.Sprintf("%sUpdateTime: %s,\n", indentationValues, rd.UpdateTime.FormatToString(indentationLevel+1)))
+	b.WriteString(fmt.Sprintf("%s}", indentationEnd))
+
+	return b.String()
+}
+
+// NewRankingData returns a new RankingData
+func NewRankingData() RankingData {
+	return RankingData{
+		PrincipalID: types.NewPID(0),
+		UniqueID:    types.NewUInt64(0),
+		Order:       types.NewUInt32(0),
+		Category:    types.NewUInt32(0),
+		Scores:       types.NewUInt32(0),
+		Unknown1:      types.NewBuffer(nil),
+		Unknown2:       types.NewUInt64(0),
+		CommonData:  types.NewBuffer(nil),
+		UpdateTime:  types.NewDateTime(0),
+	}
+
+}

--- a/ranking/legacy/types/ranking_data.go
+++ b/ranking/legacy/types/ranking_data.go
@@ -99,11 +99,6 @@ func (rd *RankingData) ExtractFrom(readable types.Readable) error {
 		rd.Category = types.UInt32(category[0])
 	}
 
-	err = rd.Category.ExtractFrom(readable)
-	if err != nil {
-		return fmt.Errorf("Failed to extract RankingData.Category. %s", err.Error())
-	}
-
 	err = rd.Scores.ExtractFrom(readable)
 	if err != nil {
 		return fmt.Errorf("Failed to extract RankingData.Scores. %s", err.Error())

--- a/ranking/legacy/types/ranking_data.go
+++ b/ranking/legacy/types/ranking_data.go
@@ -40,7 +40,6 @@ func (rd RankingData) WriteTo(writable types.Writable) {
 		category.WriteTo(contentWritable)
 	}
 
-	rd.Category.WriteTo(contentWritable)
 	rd.Scores.WriteTo(contentWritable)
 	rd.Unknown1.WriteTo(contentWritable)
 	rd.Unknown2.WriteTo(contentWritable)

--- a/ranking/legacy/types/ranking_data.go
+++ b/ranking/legacy/types/ranking_data.go
@@ -134,14 +134,13 @@ func (rd RankingData) Copy() types.RVType {
 
 	copied.StructureVersion = rd.StructureVersion
 	copied.PrincipalID = rd.PrincipalID.Copy().(types.PID)
-	copied.UniqueID = rd.UniqueID.Copy().(types.UInt64)
+	copied.UniqueID = rd.UniqueID.Copy().(types.UInt32)
 	copied.Order = rd.Order.Copy().(types.UInt32)
 	copied.Category = rd.Category.Copy().(types.UInt32)
-	copied.Scores = rd.Scores.Copy().(types.UInt32)
-	copied.Unknown1 = rd.Unknown1.Copy().(types.Buffer)
-	copied.Unknown2 = rd.Unknown2.Copy().(types.UInt64)
+	copied.Scores = rd.Scores.Copy().(types.List[types.UInt32])
+	copied.Unknown1 = rd.Unknown1.Copy().(types.UInt8)
+	copied.Unknown2 = rd.Unknown2.Copy().(types.UInt32)
 	copied.CommonData = rd.CommonData.Copy().(types.Buffer)
-	copied.UpdateTime = rd.UpdateTime.Copy().(types.DateTime)
 
 	return copied
 }
@@ -186,11 +185,7 @@ func (rd RankingData) Equals(o types.RVType) bool {
 		return false
 	}
 
-	if !rd.CommonData.Equals(other.CommonData) {
-		return false
-	}
-
-	return rd.UpdateTime.Equals(other.UpdateTime)
+	return rd.CommonData.Equals(other.CommonData)
 }
 
 // CopyRef copies the current value of the RankingData
@@ -228,7 +223,6 @@ func (rd RankingData) FormatToString(indentationLevel int) string {
 	b.WriteString(fmt.Sprintf("%sUnknown1: %s,\n", indentationValues, rd.Unknown1))
 	b.WriteString(fmt.Sprintf("%sUnknown2: %s,\n", indentationValues, rd.Unknown2))
 	b.WriteString(fmt.Sprintf("%sCommonData: %s,\n", indentationValues, rd.CommonData))
-	b.WriteString(fmt.Sprintf("%sUpdateTime: %s,\n", indentationValues, rd.UpdateTime.FormatToString(indentationLevel+1)))
 	b.WriteString(fmt.Sprintf("%s}", indentationEnd))
 
 	return b.String()
@@ -238,14 +232,13 @@ func (rd RankingData) FormatToString(indentationLevel int) string {
 func NewRankingData() RankingData {
 	return RankingData{
 		PrincipalID: types.NewPID(0),
-		UniqueID:    types.NewUInt64(0),
+		UniqueID:    types.NewUInt32(0),
 		Order:       types.NewUInt32(0),
 		Category:    types.NewUInt32(0),
-		Scores:       types.NewUInt32(0),
-		Unknown1:      types.NewBuffer(nil),
-		Unknown2:       types.NewUInt64(0),
+		Scores:      types.NewList[types.UInt32](),
+		Unknown1:    types.NewUInt8(0),
+		Unknown2:    types.NewUInt32(0),
 		CommonData:  types.NewBuffer(nil),
-		UpdateTime:  types.NewDateTime(0),
 	}
 
 }

--- a/ranking/legacy/types/ranking_order_param.go
+++ b/ranking/legacy/types/ranking_order_param.go
@@ -1,0 +1,195 @@
+// Package types implements all the types used by the legacy Ranking protocol
+package types
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
+
+// RankingOrderParam is a type within the Ranking protocol
+type RankingOrderParam struct {
+	types.Structure
+	ScoreIndex      types.UInt8
+	ScoreOrder      types.UInt8
+	RankCalculation types.UInt8
+	Unknown1        types.UInt8
+	Unknown2        types.UInt8
+	Unknown3        types.UInt8
+	Unknown4        types.UInt32
+}
+
+// WriteTo writes the RankingOrderParam to the given writable
+func (rop RankingOrderParam) WriteTo(writable types.Writable) {
+	contentWritable := writable.CopyNew()
+
+	rop.ScoreIndex.WriteTo(contentWritable)
+	rop.ScoreOrder.WriteTo(contentWritable)
+	rop.RankCalculation.WriteTo(contentWritable)
+	rop.Unknown1.WriteTo(contentWritable)
+	rop.Unknown2.WriteTo(contentWritable)
+	rop.Unknown3.WriteTo(contentWritable)
+	rop.Unknown4.WriteTo(contentWritable)
+
+	content := contentWritable.Bytes()
+
+	rop.WriteHeaderTo(writable, uint32(len(content)))
+
+	writable.Write(content)
+}
+
+// ExtractFrom extracts the RankingOrderParam from the given readable
+func (rop *RankingOrderParam) ExtractFrom(readable types.Readable) error {
+	var err error
+
+	err = rop.ExtractHeaderFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingOrderParam header. %s", err.Error())
+	}
+
+	err = rop.ScoreIndex.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingOrderParam.ScoreIndex. %s", err.Error())
+	}
+
+	err = rop.ScoreOrder.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingOrderParam.ScoreOrder. %s", err.Error())
+	}
+
+	err = rop.RankCalculation.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingOrderParam.RankCalculation. %s", err.Error())
+	}
+
+	err = rop.Unknown1.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingOrderParam.Unknown1. %s", err.Error())
+	}
+
+	err = rop.Unknown2.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingOrderParam.Unknown2. %s", err.Error())
+	}
+
+	err = rop.Unknown3.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingOrderParam.Unknown3. %s", err.Error())
+	}
+
+	err = rop.Unknown4.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingOrderParam.Unknown4. %s", err.Error())
+	}
+
+	return nil
+}
+
+// Copy returns a new copied instance of RankingOrderParam
+func (rop RankingOrderParam) Copy() types.RVType {
+	copied := NewRankingOrderParam()
+
+	copied.StructureVersion = rop.StructureVersion
+	copied.ScoreIndex = rop.ScoreIndex.Copy().(types.UInt8)
+	copied.ScoreOrder = rop.ScoreOrder.Copy().(types.UInt8)
+	copied.RankCalculation = rop.RankCalculation.Copy().(types.UInt8)
+	copied.Unknown1 = rop.Unknown1.Copy().(types.UInt8)
+	copied.Unknown2 = rop.Unknown2.Copy().(types.UInt8)
+	copied.Unknown3 = rop.Unknown3.Copy().(types.UInt8)
+	copied.Unknown4 = rop.Unknown4.Copy().(types.UInt32)
+
+	return copied
+}
+
+// Equals checks if the given RankingOrderParam contains the same data as the current RankingOrderParam
+func (rop RankingOrderParam) Equals(o types.RVType) bool {
+	if _, ok := o.(RankingOrderParam); !ok {
+		return false
+	}
+
+	other := o.(RankingOrderParam)
+
+	if rop.StructureVersion != other.StructureVersion {
+		return false
+	}
+
+	if !rop.ScoreIndex.Equals(other.ScoreIndex) {
+		return false
+	}
+
+	if !rop.ScoreOrder.Equals(other.ScoreOrder) {
+		return false
+	}
+
+	if !rop.RankCalculation.Equals(other.RankCalculation) {
+		return false
+	}
+
+	if !rop.Unknown1.Equals(other.Unknown1) {
+		return false
+	}
+
+	if !rop.Unknown2.Equals(other.Unknown2) {
+		return false
+	}
+
+	if !rop.Unknown3.Equals(other.Unknown3) {
+		return false
+	}
+
+	return rop.Unknown4.Equals(other.Unknown4)
+}
+
+// CopyRef copies the current value of the RankingOrderParam
+// and returns a pointer to the new copy
+func (rop RankingOrderParam) CopyRef() types.RVTypePtr {
+	copied := rop.Copy().(RankingOrderParam)
+	return &copied
+}
+
+// Deref takes a pointer to the RankingOrderParam
+// and dereferences it to the raw value.
+// Only useful when working with an instance of RVTypePtr
+func (rop *RankingOrderParam) Deref() types.RVType {
+	return *rop
+}
+
+// String returns the string representation of the RankingOrderParam
+func (rop RankingOrderParam) String() string {
+	return rop.FormatToString(0)
+}
+
+// FormatToString pretty-prints the RankingOrderParam using the provided indentation level
+func (rop RankingOrderParam) FormatToString(indentationLevel int) string {
+	indentationValues := strings.Repeat("\t", indentationLevel+1)
+	indentationEnd := strings.Repeat("\t", indentationLevel)
+
+	var b strings.Builder
+
+	b.WriteString("RankingOrderParam{\n")
+	b.WriteString(fmt.Sprintf("%sScoreIndex: %s,\n", indentationValues, rop.ScoreIndex))
+	b.WriteString(fmt.Sprintf("%sScoreOrder: %s,\n", indentationValues, rop.ScoreOrder))
+	b.WriteString(fmt.Sprintf("%sRankCalculation: %s,\n", indentationValues, rop.RankCalculation))
+	b.WriteString(fmt.Sprintf("%sUnknown1: %s,\n", indentationValues, rop.Unknown1))
+	b.WriteString(fmt.Sprintf("%sUnknown2: %s,\n", indentationValues, rop.Unknown2))
+	b.WriteString(fmt.Sprintf("%sUnknown3: %s,\n", indentationValues, rop.Unknown3))
+	b.WriteString(fmt.Sprintf("%sUnknown4: %s,\n", indentationValues, rop.Unknown4))
+	b.WriteString(fmt.Sprintf("%s}", indentationEnd))
+
+	return b.String()
+}
+
+// NewRankingOrderParam returns a new RankingOrderParam
+func NewRankingOrderParam() RankingOrderParam {
+	return RankingOrderParam{
+		ScoreIndex:      types.NewUInt8(0),
+		ScoreOrder:      types.NewUInt8(0),
+		RankCalculation: types.NewUInt8(0),
+		Unknown1:        types.NewUInt8(0),
+		Unknown2:        types.NewUInt8(0),
+		Unknown3:        types.NewUInt8(0),
+		Unknown4:        types.NewUInt32(0),
+	}
+
+}

--- a/ranking/legacy/types/ranking_score.go
+++ b/ranking/legacy/types/ranking_score.go
@@ -1,0 +1,153 @@
+// Package types implements all the types used by the legacy Ranking protocol
+package types
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
+
+// RankingScore is a type within the Ranking protocol
+type RankingScore struct {
+	types.Structure
+	Category types.UInt32
+	Score    types.List[types.UInt32]
+	Unknown1 types.UInt8
+	Unknown2 types.UInt32
+}
+
+// WriteTo writes the RankingScore to the given writable
+func (rs RankingScore) WriteTo(writable types.Writable) {
+	contentWritable := writable.CopyNew()
+
+	rs.Category.WriteTo(contentWritable)
+	rs.Score.WriteTo(contentWritable)
+	rs.Unknown1.WriteTo(contentWritable)
+	rs.Unknown2.WriteTo(contentWritable)
+
+	content := contentWritable.Bytes()
+
+	rs.WriteHeaderTo(writable, uint32(len(content)))
+
+	writable.Write(content)
+}
+
+// ExtractFrom extracts the RankingScore from the given readable
+func (rs *RankingScore) ExtractFrom(readable types.Readable) error {
+	var err error
+
+	err = rs.ExtractHeaderFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingScore header. %s", err.Error())
+	}
+
+	err = rs.Category.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingScore.Category. %s", err.Error())
+	}
+
+	err = rs.Score.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingScore.Score. %s", err.Error())
+	}
+
+	err = rs.Unknown1.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingScore.Unknown1. %s", err.Error())
+	}
+
+	err = rs.Unknown2.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingScore.Unknown2. %s", err.Error())
+	}
+
+	return nil
+}
+
+// Copy returns a new copied instance of RankingScore
+func (rs RankingScore) Copy() types.RVType {
+	copied := NewRankingScore()
+
+	copied.StructureVersion = rs.StructureVersion
+	copied.Category = rs.Category.Copy().(types.UInt32)
+	copied.Score = rs.Score.Copy().(types.List[types.UInt32])
+	copied.Unknown1 = rs.Unknown1.Copy().(types.UInt8)
+	copied.Unknown2 = rs.Unknown2.Copy().(types.UInt32)
+
+	return copied
+}
+
+// Equals checks if the given RankingScore contains the same data as the current RankingScore
+func (rs RankingScore) Equals(o types.RVType) bool {
+	if _, ok := o.(RankingScore); !ok {
+		return false
+	}
+
+	other := o.(RankingScore)
+
+	if rs.StructureVersion != other.StructureVersion {
+		return false
+	}
+
+	if !rs.Category.Equals(other.Category) {
+		return false
+	}
+
+	if !rs.Score.Equals(other.Score) {
+		return false
+	}
+
+	if !rs.Unknown1.Equals(other.Unknown1) {
+		return false
+	}
+
+	return rs.Unknown2.Equals(other.Unknown2)
+}
+
+// CopyRef copies the current value of the RankingScore
+// and returns a pointer to the new copy
+func (rs RankingScore) CopyRef() types.RVTypePtr {
+	copied := rs.Copy().(RankingScore)
+	return &copied
+}
+
+// Deref takes a pointer to the RankingScore
+// and dereferences it to the raw value.
+// Only useful when working with an instance of RVTypePtr
+func (rs *RankingScore) Deref() types.RVType {
+	return *rs
+}
+
+// String returns the string representation of the RankingScore
+func (rs RankingScore) String() string {
+	return rs.FormatToString(0)
+}
+
+// FormatToString pretty-prints the RankingScore using the provided indentation level
+func (rs RankingScore) FormatToString(indentationLevel int) string {
+	indentationValues := strings.Repeat("\t", indentationLevel+1)
+	indentationEnd := strings.Repeat("\t", indentationLevel)
+
+	var b strings.Builder
+
+	b.WriteString("RankingScore{\n")
+	b.WriteString(fmt.Sprintf("%sCategory: %s,\n", indentationValues, rs.Category))
+	b.WriteString(fmt.Sprintf("%sScore: %s,\n", indentationValues, rs.Score))
+	b.WriteString(fmt.Sprintf("%sUnknown1: %s,\n", indentationValues, rs.Unknown1))
+	b.WriteString(fmt.Sprintf("%sUnknown2: %s,\n", indentationValues, rs.Unknown2))
+	b.WriteString(fmt.Sprintf("%s}", indentationEnd))
+
+	return b.String()
+}
+
+// NewRankingScore returns a new RankingScore
+func NewRankingScore() RankingScore {
+	return RankingScore{
+		Category: types.NewUInt32(0),
+		Score:    types.NewList[types.UInt32](),
+		Unknown1: types.NewUInt8(0),
+		Unknown2: types.NewUInt32(0),
+	}
+
+}

--- a/ranking/legacy/types/ranking_score_with_limit.go
+++ b/ranking/legacy/types/ranking_score_with_limit.go
@@ -1,0 +1,167 @@
+// Package types implements all the types used by the legacy Ranking protocol
+package types
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
+
+// RankingScoreWithLimit is a type within the Ranking protocol
+type RankingScoreWithLimit struct {
+	types.Structure
+	Category types.UInt32
+	Score    types.List[types.UInt32]
+	Unknown1 types.UInt8
+	Unknown2 types.UInt32
+	Limit    types.UInt16
+}
+
+// WriteTo writes the RankingScoreWithLimit to the given writable
+func (rswl RankingScoreWithLimit) WriteTo(writable types.Writable) {
+	contentWritable := writable.CopyNew()
+
+	rswl.Category.WriteTo(contentWritable)
+	rswl.Score.WriteTo(contentWritable)
+	rswl.Unknown1.WriteTo(contentWritable)
+	rswl.Unknown2.WriteTo(contentWritable)
+	rswl.Limit.WriteTo(contentWritable)
+
+	content := contentWritable.Bytes()
+
+	rswl.WriteHeaderTo(writable, uint32(len(content)))
+
+	writable.Write(content)
+}
+
+// ExtractFrom extracts the RankingScoreWithLimit from the given readable
+func (rswl *RankingScoreWithLimit) ExtractFrom(readable types.Readable) error {
+	var err error
+
+	err = rswl.ExtractHeaderFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingScoreWithLimit header. %s", err.Error())
+	}
+
+	err = rswl.Category.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingScoreWithLimit.Category. %s", err.Error())
+	}
+
+	err = rswl.Score.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingScoreWithLimit.Score. %s", err.Error())
+	}
+
+	err = rswl.Unknown1.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingScoreWithLimit.Unknown1. %s", err.Error())
+	}
+
+	err = rswl.Unknown2.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingScoreWithLimit.Unknown2. %s", err.Error())
+	}
+
+	err = rswl.Limit.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("Failed to extract RankingScoreWithLimit.Limit. %s", err.Error())
+	}
+
+	return nil
+}
+
+// Copy returns a new copied instance of RankingScoreWithLimit
+func (rswl RankingScoreWithLimit) Copy() types.RVType {
+	copied := NewRankingScoreWithLimit()
+
+	copied.StructureVersion = rswl.StructureVersion
+	copied.Category = rswl.Category.Copy().(types.UInt32)
+	copied.Score = rswl.Score.Copy().(types.List[types.UInt32])
+	copied.Unknown1 = rswl.Unknown1.Copy().(types.UInt8)
+	copied.Unknown2 = rswl.Unknown2.Copy().(types.UInt32)
+	copied.Limit = rswl.Limit.Copy().(types.UInt16)
+
+	return copied
+}
+
+// Equals checks if the given RankingScoreWithLimit contains the same data as the current RankingScoreWithLimit
+func (rswl RankingScoreWithLimit) Equals(o types.RVType) bool {
+	if _, ok := o.(RankingScoreWithLimit); !ok {
+		return false
+	}
+
+	other := o.(RankingScoreWithLimit)
+
+	if rswl.StructureVersion != other.StructureVersion {
+		return false
+	}
+
+	if !rswl.Category.Equals(other.Category) {
+		return false
+	}
+
+	if !rswl.Score.Equals(other.Score) {
+		return false
+	}
+
+	if !rswl.Unknown1.Equals(other.Unknown1) {
+		return false
+	}
+
+	if !rswl.Unknown2.Equals(other.Unknown2) {
+		return false
+	}
+
+	return rswl.Limit.Equals(other.Limit)
+}
+
+// CopyRef copies the current value of the RankingScoreWithLimit
+// and returns a pointer to the new copy
+func (rswl RankingScoreWithLimit) CopyRef() types.RVTypePtr {
+	copied := rswl.Copy().(RankingScoreWithLimit)
+	return &copied
+}
+
+// Deref takes a pointer to the RankingScoreWithLimit
+// and dereferences it to the raw value.
+// Only useful when working with an instance of RVTypePtr
+func (rswl *RankingScoreWithLimit) Deref() types.RVType {
+	return *rswl
+}
+
+// String returns the string representation of the RankingScoreWithLimit
+func (rswl RankingScoreWithLimit) String() string {
+	return rswl.FormatToString(0)
+}
+
+// FormatToString pretty-prints the RankingScoreWithLimit using the provided indentation level
+func (rswl RankingScoreWithLimit) FormatToString(indentationLevel int) string {
+	indentationValues := strings.Repeat("\t", indentationLevel+1)
+	indentationEnd := strings.Repeat("\t", indentationLevel)
+
+	var b strings.Builder
+
+	b.WriteString("RankingScoreWithLimit{\n")
+	b.WriteString(fmt.Sprintf("%sCategory: %s,\n", indentationValues, rswl.Category))
+	b.WriteString(fmt.Sprintf("%sScore: %s,\n", indentationValues, rswl.Score))
+	b.WriteString(fmt.Sprintf("%sUnknown1: %s,\n", indentationValues, rswl.Unknown1))
+	b.WriteString(fmt.Sprintf("%sUnknown2: %s,\n", indentationValues, rswl.Unknown2))
+	b.WriteString(fmt.Sprintf("%sLimit: %s,\n", indentationValues, rswl.Limit))
+	b.WriteString(fmt.Sprintf("%s}", indentationEnd))
+
+	return b.String()
+}
+
+// NewRankingScoreWithLimit returns a new RankingScoreWithLimit
+func NewRankingScoreWithLimit() RankingScoreWithLimit {
+	return RankingScoreWithLimit{
+		Category: types.NewUInt32(0),
+		Score:    types.NewList[types.UInt32](),
+		Unknown1: types.NewUInt8(0),
+		Unknown2: types.NewUInt32(0),
+		Limit:    types.NewUInt16(0),
+	}
+
+}

--- a/ranking/legacy/unk_0x13.go
+++ b/ranking/legacy/unk_0x13.go
@@ -9,6 +9,7 @@ import (
 	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
 )
 
+// TODO - Find name if possible
 func (protocol *Protocol) handleUnk0x13(packet nex.PacketInterface) {
 	if protocol.Unk0x13 == nil {
 		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::Unk0x13 not implemented")

--- a/ranking/legacy/unk_0x13.go
+++ b/ranking/legacy/unk_0x13.go
@@ -1,0 +1,105 @@
+// Package protocol implements the legacy Ranking protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+)
+
+func (protocol *Protocol) handleUnk0x13(packet nex.PacketInterface) {
+	if protocol.Unk0x13 == nil {
+		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::Unk0x13 not implemented")
+
+		globals.Logger.Warning(err.Message)
+		globals.RespondError(packet, ProtocolID, err)
+
+		return
+	}
+
+	endpoint := packet.Sender().Endpoint()
+
+	request := packet.RMCMessage()
+	callID := request.CallID
+	parameters := request.Parameters
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	var unknown1 types.UInt32
+	var unknown2 types.UInt32
+	var unknown3 types.List[types.UInt32]
+	var unknown4 types.List[types.UInt8]
+	var unknown5 types.Bool
+	var unknown6 types.UInt16
+
+	var err error
+
+	err = unknown1.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.Unk0x13(fmt.Errorf("Failed to read unknown1 from parameters. %s", err.Error()), packet, callID, unknown1, unknown2, unknown3, unknown4, unknown5, unknown6)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = unknown2.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.Unk0x13(fmt.Errorf("Failed to read unknown2 from parameters. %s", err.Error()), packet, callID, unknown1, unknown2, unknown3, unknown4, unknown5, unknown6)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = unknown3.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.Unk0x13(fmt.Errorf("Failed to read unknown3 from parameters. %s", err.Error()), packet, callID, unknown1, unknown2, unknown3, unknown4, unknown5, unknown6)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = unknown4.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.Unk0x13(fmt.Errorf("Failed to read unknown4 from parameters. %s", err.Error()), packet, callID, unknown1, unknown2, unknown3, unknown4, unknown5, unknown6)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = unknown5.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.Unk0x13(fmt.Errorf("Failed to read unknown5 from parameters. %s", err.Error()), packet, callID, unknown1, unknown2, unknown3, unknown4, unknown5, unknown6)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = unknown6.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.Unk0x13(fmt.Errorf("Failed to read unknown6 from parameters. %s", err.Error()), packet, callID, unknown1, unknown2, unknown3, unknown4, unknown5, unknown6)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	rmcMessage, rmcError := protocol.Unk0x13(nil, packet, callID, unknown1, unknown2, unknown3, unknown4, unknown5, unknown6)
+	if rmcError != nil {
+		globals.RespondError(packet, ProtocolID, rmcError)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/unk_0x7.go
+++ b/ranking/legacy/unk_0x7.go
@@ -9,6 +9,7 @@ import (
 	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
 )
 
+// TODO - Find name if possible
 func (protocol *Protocol) handleUnk0x7(packet nex.PacketInterface) {
 	if protocol.Unk0x7 == nil {
 		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::Unk0x7 not implemented")

--- a/ranking/legacy/unk_0x7.go
+++ b/ranking/legacy/unk_0x7.go
@@ -1,0 +1,98 @@
+// Package protocol implements the legacy Ranking protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+)
+
+func (protocol *Protocol) handleUnk0x7(packet nex.PacketInterface) {
+	if protocol.Unk0x7 == nil {
+		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::Unk0x7 not implemented")
+
+		globals.Logger.Warning(err.Message)
+		globals.RespondError(packet, ProtocolID, err)
+
+		return
+	}
+
+	endpoint := packet.Sender().Endpoint()
+	rankingVersion := endpoint.LibraryVersions().Ranking
+
+	request := packet.RMCMessage()
+	callID := request.CallID
+	parameters := request.Parameters
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	var uniqueID types.UInt32
+	var category types.UInt32
+	var unknown types.UInt8
+
+	var err error
+
+	err = uniqueID.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.Unk0x7(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, category, unknown)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	if rankingVersion.GreaterOrEqual("2.0.0") {
+		err = category.ExtractFrom(parametersStream)
+		if err != nil {
+			_, rmcError := protocol.Unk0x7(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, category, unknown)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+	} else {
+		var categories types.List[types.UInt16]
+
+		err = categories.ExtractFrom(parametersStream)
+		if err != nil {
+			_, rmcError := protocol.Unk0x7(fmt.Errorf("Failed to read categories from parameters. %s", err.Error()), packet, callID, uniqueID, category, unknown)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+
+		if len(categories) != 1 {
+			_, rmcError := protocol.Unk0x7(fmt.Errorf("Failed to read categories from parameters. Expected length of 1, got %d", len(categories)), packet, callID, uniqueID, category, unknown)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+
+		category = types.UInt32(categories[0])
+	}
+
+	err = unknown.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.Unk0x7(fmt.Errorf("Failed to read unknown from parameters. %s", err.Error()), packet, callID, uniqueID, category, unknown)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	rmcMessage, rmcError := protocol.Unk0x7(nil, packet, callID, uniqueID, category, unknown)
+	if rmcError != nil {
+		globals.RespondError(packet, ProtocolID, rmcError)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/unk_0x7.go
+++ b/ranking/legacy/unk_0x7.go
@@ -47,7 +47,7 @@ func (protocol *Protocol) handleUnk0x7(packet nex.PacketInterface) {
 	if rankingVersion.GreaterOrEqual("2.0.0") {
 		err = category.ExtractFrom(parametersStream)
 		if err != nil {
-			_, rmcError := protocol.Unk0x7(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, category, unknown)
+			_, rmcError := protocol.Unk0x7(fmt.Errorf("Failed to read category from parameters. %s", err.Error()), packet, callID, uniqueID, category, unknown)
 			if rmcError != nil {
 				globals.RespondError(packet, ProtocolID, rmcError)
 			}

--- a/ranking/legacy/unk_0x8.go
+++ b/ranking/legacy/unk_0x8.go
@@ -9,6 +9,7 @@ import (
 	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
 )
 
+// TODO - Find name if possible
 func (protocol *Protocol) handleUnk0x8(packet nex.PacketInterface) {
 	if protocol.Unk0x8 == nil {
 		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::Unk0x8 not implemented")

--- a/ranking/legacy/unk_0x8.go
+++ b/ranking/legacy/unk_0x8.go
@@ -1,0 +1,61 @@
+// Package protocol implements the legacy Ranking protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+)
+
+func (protocol *Protocol) handleUnk0x8(packet nex.PacketInterface) {
+	if protocol.Unk0x8 == nil {
+		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::Unk0x8 not implemented")
+
+		globals.Logger.Warning(err.Message)
+		globals.RespondError(packet, ProtocolID, err)
+
+		return
+	}
+
+	endpoint := packet.Sender().Endpoint()
+
+	request := packet.RMCMessage()
+	callID := request.CallID
+	parameters := request.Parameters
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	var uniqueID types.UInt32
+	var unknown types.UInt8
+
+	var err error
+
+	err = uniqueID.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.Unk0x8(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, unknown)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = unknown.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.Unk0x8(fmt.Errorf("Failed to read unknown from parameters. %s", err.Error()), packet, callID, uniqueID, unknown)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	rmcMessage, rmcError := protocol.Unk0x8(nil, packet, callID, uniqueID, unknown)
+	if rmcError != nil {
+		globals.RespondError(packet, ProtocolID, rmcError)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/unk_0x8.go
+++ b/ranking/legacy/unk_0x8.go
@@ -44,7 +44,7 @@ func (protocol *Protocol) handleUnk0x8(packet nex.PacketInterface) {
 
 	err = unknown.ExtractFrom(parametersStream)
 	if err != nil {
-		_, rmcError := protocol.Unk0x8(fmt.Errorf("Failed to read unknown from parameters. %s", err.Error()), packet, callID, uniqueID, unknown)
+		_, rmcError := protocol.Unk0x8(fmt.Errorf("Failed to read category from parameters. %s", err.Error()), packet, callID, uniqueID, unknown)
 		if rmcError != nil {
 			globals.RespondError(packet, ProtocolID, rmcError)
 		}

--- a/ranking/legacy/unk_0x9.go
+++ b/ranking/legacy/unk_0x9.go
@@ -1,0 +1,83 @@
+// Package protocol implements the legacy Ranking protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+)
+
+func (protocol *Protocol) handleUnk0x9(packet nex.PacketInterface) {
+	if protocol.Unk0x9 == nil {
+		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::Unk0x9 not implemented")
+
+		globals.Logger.Warning(err.Message)
+		globals.RespondError(packet, ProtocolID, err)
+
+		return
+	}
+
+	endpoint := packet.Sender().Endpoint()
+
+	request := packet.RMCMessage()
+	callID := request.CallID
+	parameters := request.Parameters
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	var unknown1 types.UInt32
+	var unknown2 types.UInt32
+	var unknown3 types.List[types.UInt32]
+	var unknown4 types.List[types.UInt8]
+
+	var err error
+
+	err = unknown1.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.Unk0x9(fmt.Errorf("Failed to read unknown1 from parameters. %s", err.Error()), packet, callID, unknown1, unknown2, unknown3, unknown4)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = unknown2.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.Unk0x9(fmt.Errorf("Failed to read unknown2 from parameters. %s", err.Error()), packet, callID, unknown1, unknown2, unknown3, unknown4)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = unknown3.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.Unk0x9(fmt.Errorf("Failed to read unknown3 from parameters. %s", err.Error()), packet, callID, unknown1, unknown2, unknown3, unknown4)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = unknown4.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.Unk0x9(fmt.Errorf("Failed to read unknown4 from parameters. %s", err.Error()), packet, callID, unknown1, unknown2, unknown3, unknown4)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	rmcMessage, rmcError := protocol.Unk0x9(nil, packet, callID, unknown1, unknown2, unknown3, unknown4)
+	if rmcError != nil {
+		globals.RespondError(packet, ProtocolID, rmcError)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/unk_0x9.go
+++ b/ranking/legacy/unk_0x9.go
@@ -9,6 +9,7 @@ import (
 	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
 )
 
+// TODO - Find name if possible
 func (protocol *Protocol) handleUnk0x9(packet nex.PacketInterface) {
 	if protocol.Unk0x9 == nil {
 		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::Unk0x9 not implemented")

--- a/ranking/legacy/unk_0xc.go
+++ b/ranking/legacy/unk_0xc.go
@@ -1,0 +1,87 @@
+// Package protocol implements the legacy Ranking protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+)
+
+func (protocol *Protocol) handleUnk0xC(packet nex.PacketInterface) {
+	if protocol.Unk0xC == nil {
+		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::Unk0xC not implemented")
+
+		globals.Logger.Warning(err.Message)
+		globals.RespondError(packet, ProtocolID, err)
+
+		return
+	}
+
+	endpoint := packet.Sender().Endpoint()
+	rankingVersion := endpoint.LibraryVersions().Ranking
+
+	request := packet.RMCMessage()
+	callID := request.CallID
+	parameters := request.Parameters
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	var uniqueID types.UInt32
+	var category types.UInt32
+
+	var err error
+
+	err = uniqueID.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.Unk0xC(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, category)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	if rankingVersion.GreaterOrEqual("2.0.0") {
+		err = category.ExtractFrom(parametersStream)
+		if err != nil {
+			_, rmcError := protocol.Unk0xC(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, category)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+	} else {
+		var categories types.List[types.UInt16]
+
+		err = categories.ExtractFrom(parametersStream)
+		if err != nil {
+			_, rmcError := protocol.Unk0xC(fmt.Errorf("Failed to read categories from parameters. %s", err.Error()), packet, callID, uniqueID, category)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+
+		if len(categories) != 1 {
+			_, rmcError := protocol.Unk0xC(fmt.Errorf("Failed to read categories from parameters. Expected length of 1, got %d", len(categories)), packet, callID, uniqueID, category)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+
+		category = types.UInt32(categories[0])
+	}
+
+	rmcMessage, rmcError := protocol.Unk0xC(nil, packet, callID, uniqueID, category)
+	if rmcError != nil {
+		globals.RespondError(packet, ProtocolID, rmcError)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/unk_0xc.go
+++ b/ranking/legacy/unk_0xc.go
@@ -46,7 +46,7 @@ func (protocol *Protocol) handleUnk0xC(packet nex.PacketInterface) {
 	if rankingVersion.GreaterOrEqual("2.0.0") {
 		err = category.ExtractFrom(parametersStream)
 		if err != nil {
-			_, rmcError := protocol.Unk0xC(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, category)
+			_, rmcError := protocol.Unk0xC(fmt.Errorf("Failed to read category from parameters. %s", err.Error()), packet, callID, uniqueID, category)
 			if rmcError != nil {
 				globals.RespondError(packet, ProtocolID, rmcError)
 			}

--- a/ranking/legacy/unk_0xc.go
+++ b/ranking/legacy/unk_0xc.go
@@ -9,6 +9,7 @@ import (
 	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
 )
 
+// TODO - Find name if possible
 func (protocol *Protocol) handleUnk0xC(packet nex.PacketInterface) {
 	if protocol.Unk0xC == nil {
 		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::Unk0xC not implemented")

--- a/ranking/legacy/unk_0xd.go
+++ b/ranking/legacy/unk_0xd.go
@@ -10,6 +10,7 @@ import (
 	ranking_types "github.com/PretendoNetwork/nex-protocols-go/v2/ranking/legacy/types"
 )
 
+// TODO - Find name if possible
 func (protocol *Protocol) handleUnk0xD(packet nex.PacketInterface) {
 	if protocol.Unk0xD == nil {
 		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::Unk0xD not implemented")

--- a/ranking/legacy/unk_0xd.go
+++ b/ranking/legacy/unk_0xd.go
@@ -1,0 +1,99 @@
+// Package protocol implements the legacy Ranking protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+	ranking_types "github.com/PretendoNetwork/nex-protocols-go/v2/ranking/legacy/types"
+)
+
+func (protocol *Protocol) handleUnk0xD(packet nex.PacketInterface) {
+	if protocol.Unk0xD == nil {
+		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::Unk0xD not implemented")
+
+		globals.Logger.Warning(err.Message)
+		globals.RespondError(packet, ProtocolID, err)
+
+		return
+	}
+
+	endpoint := packet.Sender().Endpoint()
+	rankingVersion := endpoint.LibraryVersions().Ranking
+
+	request := packet.RMCMessage()
+	callID := request.CallID
+	parameters := request.Parameters
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	var uniqueID types.UInt32
+	var category types.UInt32
+	orderParam := ranking_types.NewRankingOrderParam()
+
+	var err error
+
+	err = uniqueID.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.Unk0xD(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, category, orderParam)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	if rankingVersion.GreaterOrEqual("2.0.0") {
+		err = category.ExtractFrom(parametersStream)
+		if err != nil {
+			_, rmcError := protocol.Unk0xD(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, category, orderParam)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+	} else {
+		var categories types.List[types.UInt16]
+
+		err = categories.ExtractFrom(parametersStream)
+		if err != nil {
+			_, rmcError := protocol.Unk0xD(fmt.Errorf("Failed to read categories from parameters. %s", err.Error()), packet, callID, uniqueID, category, orderParam)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+
+		if len(categories) != 1 {
+			_, rmcError := protocol.Unk0xD(fmt.Errorf("Failed to read categories from parameters. Expected length of 1, got %d", len(categories)), packet, callID, uniqueID, category, orderParam)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+
+		category = types.UInt32(categories[0])
+	}
+
+	err = orderParam.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.Unk0xD(fmt.Errorf("Failed to read orderParam from parameters. %s", err.Error()), packet, callID, uniqueID, category, orderParam)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	rmcMessage, rmcError := protocol.Unk0xD(nil, packet, callID, uniqueID, category, orderParam)
+	if rmcError != nil {
+		globals.RespondError(packet, ProtocolID, rmcError)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/unk_0xd.go
+++ b/ranking/legacy/unk_0xd.go
@@ -31,7 +31,7 @@ func (protocol *Protocol) handleUnk0xD(packet nex.PacketInterface) {
 
 	var uniqueID types.UInt32
 	var category types.UInt32
-	orderParam := ranking_types.NewRankingOrderParam()
+	var orderParam ranking_types.RankingOrderParam
 
 	var err error
 
@@ -48,7 +48,7 @@ func (protocol *Protocol) handleUnk0xD(packet nex.PacketInterface) {
 	if rankingVersion.GreaterOrEqual("2.0.0") {
 		err = category.ExtractFrom(parametersStream)
 		if err != nil {
-			_, rmcError := protocol.Unk0xD(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, category, orderParam)
+			_, rmcError := protocol.Unk0xD(fmt.Errorf("Failed to read category from parameters. %s", err.Error()), packet, callID, uniqueID, category, orderParam)
 			if rmcError != nil {
 				globals.RespondError(packet, ProtocolID, rmcError)
 			}

--- a/ranking/legacy/upload_common_data.go
+++ b/ranking/legacy/upload_common_data.go
@@ -1,0 +1,61 @@
+// Package protocol implements the legacy Ranking protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+)
+
+func (protocol *Protocol) handleUploadCommonData(packet nex.PacketInterface) {
+	if protocol.UploadCommonData == nil {
+		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::UploadCommonData not implemented")
+
+		globals.Logger.Warning(err.Message)
+		globals.RespondError(packet, ProtocolID, err)
+
+		return
+	}
+
+	endpoint := packet.Sender().Endpoint()
+
+	request := packet.RMCMessage()
+	callID := request.CallID
+	parameters := request.Parameters
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	var uniqueID types.UInt32
+	var commonData types.Buffer
+
+	var err error
+
+	err = uniqueID.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.UploadCommonData(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, commonData)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = commonData.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.UploadCommonData(fmt.Errorf("Failed to read commonData from parameters. %s", err.Error()), packet, callID, uniqueID, commonData)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	rmcMessage, rmcError := protocol.UploadCommonData(nil, packet, callID, uniqueID, commonData)
+	if rmcError != nil {
+		globals.RespondError(packet, ProtocolID, rmcError)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/upload_score.go
+++ b/ranking/legacy/upload_score.go
@@ -1,0 +1,120 @@
+// Package protocol implements the legacy Ranking protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+)
+
+func (protocol *Protocol) handleUploadScore(packet nex.PacketInterface) {
+	if protocol.UploadScore == nil {
+		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::UploadScore not implemented")
+
+		globals.Logger.Warning(err.Message)
+		globals.RespondError(packet, ProtocolID, err)
+
+		return
+	}
+
+	endpoint := packet.Sender().Endpoint()
+	rankingVersion := endpoint.LibraryVersions().Ranking
+
+	request := packet.RMCMessage()
+	callID := request.CallID
+	parameters := request.Parameters
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	var uniqueID types.UInt32
+	var category types.UInt32
+	var scores types.List[types.UInt32]
+	var unknown1 types.UInt8
+	var unknown2 types.UInt32
+
+	var err error
+
+	err = uniqueID.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.UploadScore(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, category, scores, unknown1, unknown2)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	if rankingVersion.GreaterOrEqual("2.0.0") {
+		err = category.ExtractFrom(parametersStream)
+		if err != nil {
+			_, rmcError := protocol.UploadScore(fmt.Errorf("Failed to read category from parameters. %s", err.Error()), packet, callID, uniqueID, category, scores, unknown1, unknown2)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+	} else {
+		var categories types.List[types.UInt16]
+
+		err = categories.ExtractFrom(parametersStream)
+		if err != nil {
+			_, rmcError := protocol.UploadScore(fmt.Errorf("Failed to read categories from parameters. %s", err.Error()), packet, callID, uniqueID, category, scores, unknown1, unknown2)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+
+		if len(categories) != 1 {
+			_, rmcError := protocol.UploadScore(fmt.Errorf("Failed to read categories from parameters. Expected length of 1, got %d", len(categories)), packet, callID, uniqueID, category, scores, unknown1, unknown2)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
+		}
+
+		category = types.UInt32(categories[0])
+	}
+
+	err = scores.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.UploadScore(fmt.Errorf("Failed to read scores from parameters. %s", err.Error()), packet, callID, uniqueID, category, scores, unknown1, unknown2)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = unknown1.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.UploadScore(fmt.Errorf("Failed to read unknown1 from parameters. %s", err.Error()), packet, callID, uniqueID, category, scores, unknown1, unknown2)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = unknown2.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.UploadScore(fmt.Errorf("Failed to read unknown2 from parameters. %s", err.Error()), packet, callID, uniqueID, category, scores, unknown1, unknown2)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	rmcMessage, rmcError := protocol.UploadScore(nil, packet, callID, uniqueID, category, scores, unknown1, unknown2)
+	if rmcError != nil {
+		globals.RespondError(packet, ProtocolID, rmcError)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/upload_score_with_limit.go
+++ b/ranking/legacy/upload_score_with_limit.go
@@ -85,6 +85,16 @@ func (protocol *Protocol) handleUploadScoreWithLimit(packet nex.PacketInterface)
 		return
 	}
 
+	err = limit.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.UploadScoreWithLimit(fmt.Errorf("Failed to read limit from parameters. %s", err.Error()), packet, callID, uniqueID, category, scores, unknown1, unknown2, limit)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
 	rmcMessage, rmcError := protocol.UploadScoreWithLimit(nil, packet, callID, uniqueID, category, scores, unknown1, unknown2, limit)
 	if rmcError != nil {
 		globals.RespondError(packet, ProtocolID, rmcError)

--- a/ranking/legacy/upload_score_with_limit.go
+++ b/ranking/legacy/upload_score_with_limit.go
@@ -1,0 +1,95 @@
+// Package protocol implements the legacy Ranking protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+)
+
+func (protocol *Protocol) handleUploadScoreWithLimit(packet nex.PacketInterface) {
+	if protocol.UploadScoreWithLimit == nil {
+		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::UploadScoreWithLimit not implemented")
+
+		globals.Logger.Warning(err.Message)
+		globals.RespondError(packet, ProtocolID, err)
+
+		return
+	}
+
+	endpoint := packet.Sender().Endpoint()
+
+	request := packet.RMCMessage()
+	callID := request.CallID
+	parameters := request.Parameters
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	var uniqueID types.UInt32
+	var category types.UInt32
+	var scores types.List[types.UInt32]
+	var unknown1 types.UInt8
+	var unknown2 types.UInt32
+	var limit types.UInt16
+
+	var err error
+
+	err = uniqueID.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.UploadScoreWithLimit(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, category, scores, unknown1, unknown2, limit)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = category.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.UploadScoreWithLimit(fmt.Errorf("Failed to read category from parameters. %s", err.Error()), packet, callID, uniqueID, category, scores, unknown1, unknown2, limit)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = scores.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.UploadScoreWithLimit(fmt.Errorf("Failed to read scores from parameters. %s", err.Error()), packet, callID, uniqueID, category, scores, unknown1, unknown2, limit)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = unknown1.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.UploadScoreWithLimit(fmt.Errorf("Failed to read unknown1 from parameters. %s", err.Error()), packet, callID, uniqueID, category, scores, unknown1, unknown2, limit)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = unknown2.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.UploadScoreWithLimit(fmt.Errorf("Failed to read unknown2 from parameters. %s", err.Error()), packet, callID, uniqueID, category, scores, unknown1, unknown2, limit)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	rmcMessage, rmcError := protocol.UploadScoreWithLimit(nil, packet, callID, uniqueID, category, scores, unknown1, unknown2, limit)
+	if rmcError != nil {
+		globals.RespondError(packet, ProtocolID, rmcError)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/upload_scores.go
+++ b/ranking/legacy/upload_scores.go
@@ -1,0 +1,62 @@
+// Package protocol implements the legacy Ranking protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+	ranking_types "github.com/PretendoNetwork/nex-protocols-go/v2/ranking/legacy/types"
+)
+
+func (protocol *Protocol) handleUploadScores(packet nex.PacketInterface) {
+	if protocol.UploadScores == nil {
+		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::UploadScores not implemented")
+
+		globals.Logger.Warning(err.Message)
+		globals.RespondError(packet, ProtocolID, err)
+
+		return
+	}
+
+	endpoint := packet.Sender().Endpoint()
+
+	request := packet.RMCMessage()
+	callID := request.CallID
+	parameters := request.Parameters
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	var uniqueID types.UInt32
+	var scores types.List[ranking_types.RankingScore]
+
+	var err error
+
+	err = uniqueID.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.UploadScores(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, scores)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = scores.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.UploadScores(fmt.Errorf("Failed to read scores from parameters. %s", err.Error()), packet, callID, uniqueID, scores)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	rmcMessage, rmcError := protocol.UploadScores(nil, packet, callID, uniqueID, scores)
+	if rmcError != nil {
+		globals.RespondError(packet, ProtocolID, rmcError)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}

--- a/ranking/legacy/upload_scores_with_limit.go
+++ b/ranking/legacy/upload_scores_with_limit.go
@@ -1,0 +1,62 @@
+// Package protocol implements the legacy Ranking protocol
+package protocol
+
+import (
+	"fmt"
+
+	nex "github.com/PretendoNetwork/nex-go/v2"
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+	ranking_types "github.com/PretendoNetwork/nex-protocols-go/v2/ranking/legacy/types"
+)
+
+func (protocol *Protocol) handleUploadScoresWithLimit(packet nex.PacketInterface) {
+	if protocol.UploadScoresWithLimit == nil {
+		err := nex.NewError(nex.ResultCodes.Core.NotImplemented, "Ranking::UploadScoresWithLimit not implemented")
+
+		globals.Logger.Warning(err.Message)
+		globals.RespondError(packet, ProtocolID, err)
+
+		return
+	}
+
+	endpoint := packet.Sender().Endpoint()
+
+	request := packet.RMCMessage()
+	callID := request.CallID
+	parameters := request.Parameters
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	var uniqueID types.UInt32
+	var scores types.List[ranking_types.RankingScoreWithLimit]
+
+	var err error
+
+	err = uniqueID.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.UploadScoresWithLimit(fmt.Errorf("Failed to read uniqueID from parameters. %s", err.Error()), packet, callID, uniqueID, scores)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = scores.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.UploadScoresWithLimit(fmt.Errorf("Failed to read scores from parameters. %s", err.Error()), packet, callID, uniqueID, scores)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	rmcMessage, rmcError := protocol.UploadScoresWithLimit(nil, packet, callID, uniqueID, scores)
+	if rmcError != nil {
+		globals.RespondError(packet, ProtocolID, rmcError)
+		return
+	}
+
+	globals.Respond(packet, rmcMessage)
+}


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

Implement Ranking protocol used on NEX versions 1 and 2. Since the official name of this protocol is still `Ranking`, place it inside the folder of the NEX 3 Ranking protocol under the `legacy` name.

NEX 2 implements the category parameters as a UInt32, but NEX 1 does it as a list of UInt16s. However, NEX 1 onlt accepts a single value inside the list, so implement it in the API as a UInt32 and wrap around the NEX 1 cases to extract the first value from the list.

The method IDs on NEX 1 and NEX 2 don't exactly match. To account for this difference, check for the NEX version and use different switch cases of method IDs depending on it. The methods that have a different ID on NEX 1 also have a constant with this ID with the suffix `NEX1`.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.