### PR TITLE
Make NotificationEvent and UpdateNotificationData support NEX 4+

### DIFF
--- a/matchmake-extension/protocol.go
+++ b/matchmake-extension/protocol.go
@@ -189,7 +189,7 @@ type Protocol struct {
 	CreateMatchmakeSession                                  func(err error, packet nex.PacketInterface, callID uint32, anyGathering match_making_types.GatheringHolder, message types.String, participationCount types.UInt16) (*nex.RMCMessage, *nex.Error)
 	JoinMatchmakeSession                                    func(err error, packet nex.PacketInterface, callID uint32, gid types.UInt32, strMessage types.String) (*nex.RMCMessage, *nex.Error)
 	ModifyCurrentGameAttribute                              func(err error, packet nex.PacketInterface, callID uint32, gid types.UInt32, attribIndex types.UInt32, newValue types.UInt32) (*nex.RMCMessage, *nex.Error)
-	UpdateNotificationData                                  func(err error, packet nex.PacketInterface, callID uint32, uiType types.UInt32, uiParam1 types.UInt32, uiParam2 types.UInt32, strParam types.String) (*nex.RMCMessage, *nex.Error)
+	UpdateNotificationData                                  func(err error, packet nex.PacketInterface, callID uint32, uiType types.UInt32, uiParam1 types.UInt64, uiParam2 types.UInt64, strParam types.String) (*nex.RMCMessage, *nex.Error)
 	GetFriendNotificationData                               func(err error, packet nex.PacketInterface, callID uint32, uiType types.Int32) (*nex.RMCMessage, *nex.Error)
 	UpdateApplicationBuffer                                 func(err error, packet nex.PacketInterface, callID uint32, gid types.UInt32, applicationBuffer types.Buffer) (*nex.RMCMessage, *nex.Error)
 	UpdateMatchmakeSessionAttribute                         func(err error, packet nex.PacketInterface, callID uint32, gid types.UInt32, attribs types.List[types.UInt32]) (*nex.RMCMessage, *nex.Error)
@@ -251,7 +251,7 @@ type Interface interface {
 	SetHandlerCreateMatchmakeSession(handler func(err error, packet nex.PacketInterface, callID uint32, anyGathering match_making_types.GatheringHolder, message types.String, participationCount types.UInt16) (*nex.RMCMessage, *nex.Error))
 	SetHandlerJoinMatchmakeSession(handler func(err error, packet nex.PacketInterface, callID uint32, gid types.UInt32, strMessage types.String) (*nex.RMCMessage, *nex.Error))
 	SetHandlerModifyCurrentGameAttribute(handler func(err error, packet nex.PacketInterface, callID uint32, gid types.UInt32, attribIndex types.UInt32, newValue types.UInt32) (*nex.RMCMessage, *nex.Error))
-	SetHandlerUpdateNotificationData(handler func(err error, packet nex.PacketInterface, callID uint32, uiType types.UInt32, uiParam1 types.UInt32, uiParam2 types.UInt32, strParam types.String) (*nex.RMCMessage, *nex.Error))
+	SetHandlerUpdateNotificationData(handler func(err error, packet nex.PacketInterface, callID uint32, uiType types.UInt32, uiParam1 types.UInt64, uiParam2 types.UInt64, strParam types.String) (*nex.RMCMessage, *nex.Error))
 	SetHandlerGetFriendNotificationData(handler func(err error, packet nex.PacketInterface, callID uint32, uiType types.Int32) (*nex.RMCMessage, *nex.Error))
 	SetHandlerUpdateApplicationBuffer(handler func(err error, packet nex.PacketInterface, callID uint32, gid types.UInt32, applicationBuffer types.Buffer) (*nex.RMCMessage, *nex.Error))
 	SetHandlerUpdateMatchmakeSessionAttribute(handler func(err error, packet nex.PacketInterface, callID uint32, gid types.UInt32, attribs types.List[types.UInt32]) (*nex.RMCMessage, *nex.Error))
@@ -350,7 +350,7 @@ func (protocol *Protocol) SetHandlerModifyCurrentGameAttribute(handler func(err 
 }
 
 // SetHandlerUpdateNotificationData sets the handler for the UpdateNotificationData method
-func (protocol *Protocol) SetHandlerUpdateNotificationData(handler func(err error, packet nex.PacketInterface, callID uint32, uiType types.UInt32, uiParam1 types.UInt32, uiParam2 types.UInt32, strParam types.String) (*nex.RMCMessage, *nex.Error)) {
+func (protocol *Protocol) SetHandlerUpdateNotificationData(handler func(err error, packet nex.PacketInterface, callID uint32, uiType types.UInt32, uiParam1 types.UInt64, uiParam2 types.UInt64, strParam types.String) (*nex.RMCMessage, *nex.Error)) {
 	protocol.UpdateNotificationData = handler
 }
 

--- a/matchmake-extension/update_notification_data.go
+++ b/matchmake-extension/update_notification_data.go
@@ -46,36 +46,50 @@ func (protocol *Protocol) handleUpdateNotificationData(packet nex.PacketInterfac
 
 	if libraryVersion.GreaterOrEqual("4.0.0") {
 		err = uiParam1.ExtractFrom(parametersStream)
-	} else {
-		var Param1 types.UInt32
-		err = Param1.ExtractFrom(parametersStream)
-		uiParam1 = types.NewUInt64(uint64(Param1))
-	}
+		if err != nil {
+			_, rmcError := protocol.UpdateNotificationData(fmt.Errorf("Failed to read uiParam1 from parameters. %s", err.Error()), packet, callID, uiType, uiParam1, uiParam2, strParam)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
 
-	if err != nil {
-		_, rmcError := protocol.UpdateNotificationData(fmt.Errorf("Failed to read uiParam1 from parameters. %s", err.Error()), packet, callID, uiType, uiParam1, uiParam2, strParam)
-		if rmcError != nil {
-			globals.RespondError(packet, ProtocolID, rmcError)
+			return
+		}
+	} else {
+		param1, err := parametersStream.ReadUInt32LE()
+		if err != nil {
+			_, rmcError := protocol.UpdateNotificationData(fmt.Errorf("Failed to read uiParam1 from parameters. %s", err.Error()), packet, callID, uiType, uiParam1, uiParam2, strParam)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
 		}
 
-		return
+		uiParam1 = types.UInt64(param1)
 	}
 
 	if libraryVersion.GreaterOrEqual("4.0.0") {
 		err = uiParam2.ExtractFrom(parametersStream)
-	} else {
-		var Param2 types.UInt32
-		err = Param2.ExtractFrom(parametersStream)
-		uiParam2 = types.NewUInt64(uint64(Param2))
-	}
+		if err != nil {
+			_, rmcError := protocol.UpdateNotificationData(fmt.Errorf("Failed to read uiParam2 from parameters. %s", err.Error()), packet, callID, uiType, uiParam1, uiParam2, strParam)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
 
-	if err != nil {
-		_, rmcError := protocol.UpdateNotificationData(fmt.Errorf("Failed to read uiParam2 from parameters. %s", err.Error()), packet, callID, uiType, uiParam1, uiParam2, strParam)
-		if rmcError != nil {
-			globals.RespondError(packet, ProtocolID, rmcError)
+			return
+		}
+	} else {
+		param2, err := parametersStream.ReadUInt32LE()
+		if err != nil {
+			_, rmcError := protocol.UpdateNotificationData(fmt.Errorf("Failed to read uiParam2 from parameters. %s", err.Error()), packet, callID, uiType, uiParam1, uiParam2, strParam)
+			if rmcError != nil {
+				globals.RespondError(packet, ProtocolID, rmcError)
+			}
+
+			return
 		}
 
-		return
+		uiParam2 = types.UInt64(param2)
 	}
 
 	err = strParam.ExtractFrom(parametersStream)

--- a/matchmake-extension/update_notification_data.go
+++ b/matchmake-extension/update_notification_data.go
@@ -25,9 +25,11 @@ func (protocol *Protocol) handleUpdateNotificationData(packet nex.PacketInterfac
 	endpoint := packet.Sender().Endpoint()
 	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
 
+	libraryVersion := endpoint.LibraryVersions().Main
+
 	var uiType types.UInt32
-	var uiParam1 types.UInt32
-	var uiParam2 types.UInt32
+	var uiParam1 types.UInt64
+	var uiParam2 types.UInt64
 	var strParam types.String
 
 	var err error
@@ -42,7 +44,14 @@ func (protocol *Protocol) handleUpdateNotificationData(packet nex.PacketInterfac
 		return
 	}
 
-	err = uiParam1.ExtractFrom(parametersStream)
+	if libraryVersion.GreaterOrEqual("4.0.0") {
+		err = uiParam1.ExtractFrom(parametersStream)
+	} else {
+		var Param1 types.UInt32
+		err = Param1.ExtractFrom(parametersStream)
+		uiParam1 = types.NewUInt64(uint64(Param1))
+	}
+
 	if err != nil {
 		_, rmcError := protocol.UpdateNotificationData(fmt.Errorf("Failed to read uiParam1 from parameters. %s", err.Error()), packet, callID, uiType, uiParam1, uiParam2, strParam)
 		if rmcError != nil {
@@ -52,7 +61,14 @@ func (protocol *Protocol) handleUpdateNotificationData(packet nex.PacketInterfac
 		return
 	}
 
-	err = uiParam2.ExtractFrom(parametersStream)
+	if libraryVersion.GreaterOrEqual("4.0.0") {
+		err = uiParam2.ExtractFrom(parametersStream)
+	} else {
+		var Param2 types.UInt32
+		err = Param2.ExtractFrom(parametersStream)
+		uiParam2 = types.NewUInt64(uint64(Param2))
+	}
+
 	if err != nil {
 		_, rmcError := protocol.UpdateNotificationData(fmt.Errorf("Failed to read uiParam2 from parameters. %s", err.Error()), packet, callID, uiType, uiParam1, uiParam2, strParam)
 		if rmcError != nil {

--- a/notifications/types/notification_event.go
+++ b/notifications/types/notification_event.go
@@ -85,7 +85,7 @@ func (ne *NotificationEvent) ExtractFrom(readable types.Readable) error {
 			return fmt.Errorf("Failed to extract NotificationEvent.Param1. %s", err.Error())
 		}
 	} else {
-		param1, err := readable.ReadUInt64LE()
+		param1, err := readable.ReadUInt32LE()
 		if err != nil {
 			return fmt.Errorf("Failed to extract NotificationEvent.Param1. %s", err.Error())
 		}
@@ -99,7 +99,7 @@ func (ne *NotificationEvent) ExtractFrom(readable types.Readable) error {
 			return fmt.Errorf("Failed to extract NotificationEvent.Param2. %s", err.Error())
 		}
 	} else {
-		param2, err := readable.ReadUInt64LE()
+		param2, err := readable.ReadUInt32LE()
 		if err != nil {
 			return fmt.Errorf("Failed to extract NotificationEvent.Param2. %s", err.Error())
 		}
@@ -118,7 +118,7 @@ func (ne *NotificationEvent) ExtractFrom(readable types.Readable) error {
 			return fmt.Errorf("Failed to extract NotificationEvent.Param3. %s", err.Error())
 		}
 	} else if libraryVersion.GreaterOrEqual("3.4.0") {
-		param3, err := readable.ReadUInt64LE()
+		param3, err := readable.ReadUInt32LE()
 		if err != nil {
 			return fmt.Errorf("Failed to extract NotificationEvent.Param3. %s", err.Error())
 		}

--- a/notifications/types/notification_event.go
+++ b/notifications/types/notification_event.go
@@ -33,23 +33,21 @@ func (ne NotificationEvent) WriteTo(writable types.Writable) {
 	if libraryVersion.GreaterOrEqual("4.0.0") {
 		ne.Param1.WriteTo(contentWritable)
 	} else {
-		types.NewUInt32(uint32(ne.Param1)).WriteTo(contentWritable)
+		contentWritable.WriteUInt32LE(uint32(ne.Param1))
 	}
 
 	if libraryVersion.GreaterOrEqual("4.0.0") {
 		ne.Param2.WriteTo(contentWritable)
 	} else {
-		types.NewUInt32(uint32(ne.Param2)).WriteTo(contentWritable)
+		contentWritable.WriteUInt32LE(uint32(ne.Param2))
 	}
 
 	ne.StrParam.WriteTo(contentWritable)
 
-	if libraryVersion.GreaterOrEqual("3.4.0") {
-		if libraryVersion.GreaterOrEqual("4.0.0") {
-			ne.Param3.WriteTo(contentWritable)
-		} else {
-			types.NewUInt32(uint32(ne.Param3)).WriteTo(contentWritable)
-		}
+	if libraryVersion.GreaterOrEqual("4.0.0") {
+		ne.Param3.WriteTo(contentWritable)
+	} else if libraryVersion.GreaterOrEqual("3.4.0") {
+		contentWritable.WriteUInt32LE(uint32(ne.Param3))
 	}
 
 	content := contentWritable.Bytes()
@@ -87,13 +85,12 @@ func (ne *NotificationEvent) ExtractFrom(readable types.Readable) error {
 			return fmt.Errorf("Failed to extract NotificationEvent.Param1. %s", err.Error())
 		}
 	} else {
-		var Param1 types.UInt32
-		err = Param1.ExtractFrom(readable)
+		param1, err := readable.ReadUInt64LE()
 		if err != nil {
 			return fmt.Errorf("Failed to extract NotificationEvent.Param1. %s", err.Error())
 		}
 
-		ne.Param1 = types.NewUInt64(uint64(Param1))
+		ne.Param1 = types.UInt64(param1)
 	}
 
 	if libraryVersion.GreaterOrEqual("4.0.0") {
@@ -102,13 +99,12 @@ func (ne *NotificationEvent) ExtractFrom(readable types.Readable) error {
 			return fmt.Errorf("Failed to extract NotificationEvent.Param2. %s", err.Error())
 		}
 	} else {
-		var Param2 types.UInt32
-		err = Param2.ExtractFrom(readable)
+		param2, err := readable.ReadUInt64LE()
 		if err != nil {
 			return fmt.Errorf("Failed to extract NotificationEvent.Param2. %s", err.Error())
 		}
 
-		ne.Param2 = types.NewUInt64(uint64(Param2))
+		ne.Param2 = types.UInt64(param2)
 	}
 
 	err = ne.StrParam.ExtractFrom(readable)
@@ -116,21 +112,18 @@ func (ne *NotificationEvent) ExtractFrom(readable types.Readable) error {
 		return fmt.Errorf("Failed to extract NotificationEvent.StrParam. %s", err.Error())
 	}
 
-	if libraryVersion.GreaterOrEqual("3.4.0") {
-		if libraryVersion.GreaterOrEqual("4.0.0") {
-			err = ne.Param3.ExtractFrom(readable)
-			if err != nil {
-				return fmt.Errorf("Failed to extract NotificationEvent.Param3. %s", err.Error())
-			}
-		} else {
-			var Param3 types.UInt32
-			err = Param3.ExtractFrom(readable)
-			if err != nil {
-				return fmt.Errorf("Failed to extract NotificationEvent.Param3. %s", err.Error())
-			}
-
-			ne.Param3 = types.NewUInt64(uint64(Param3))
+	if libraryVersion.GreaterOrEqual("4.0.0") {
+		err = ne.Param3.ExtractFrom(readable)
+		if err != nil {
+			return fmt.Errorf("Failed to extract NotificationEvent.Param3. %s", err.Error())
 		}
+	} else if libraryVersion.GreaterOrEqual("3.4.0") {
+		param3, err := readable.ReadUInt64LE()
+		if err != nil {
+			return fmt.Errorf("Failed to extract NotificationEvent.Param3. %s", err.Error())
+		}
+
+		ne.Param3 = types.UInt64(param3)
 	}
 
 	return nil


### PR DESCRIPTION
Resolves #XXX

### Changes:

Adds pSourceKey to relevant methods in TicketGranting (empty seems to work fine).
Makes NotificationEvent use UInt64s internally and cast to UInt32 based on the version during writing/extraction.
Makes UpdateNotificationData use UInt64s internally (again, casting when appropriate). The way GetFriendNotificationData on nex-protocols-common-go is structured means that only changes to UpdateNotificationData are required.

This has been tested on Yo-kai Watch 3 (NEX 3.10.0) and Yo-kai Watch Busters 2 (NEX 4.2.0) and everything seems to be functional.

- [X] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [X] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [X] I have tested all of my changes.