### PR TITLE
Implement `Screening::ReportDataStoreContent`

### DIFF
--- a/screening/constants/report_category.go
+++ b/screening/constants/report_category.go
@@ -41,4 +41,7 @@ const (
 
 	// ReportCategorySexuallyExplicit means the reported content contained sexually explicit material
 	ReportCategorySexuallyExplicit
+
+	// ReportCategoryOther means the reported content didn't fit into the categories
+	ReportCategoryOther
 )

--- a/screening/constants/report_category.go
+++ b/screening/constants/report_category.go
@@ -1,0 +1,44 @@
+package constants
+
+import "github.com/PretendoNetwork/nex-go/v2/types"
+
+type ReportCategory uint32
+
+// WriteTo writes the ReportCategory to the given writable
+func (rc ReportCategory) WriteTo(writable types.Writable) {
+	writable.WriteUInt32LE(uint32(rc))
+}
+
+// ExtractFrom extracts the ReportCategory value from the given readable
+func (rc *ReportCategory) ExtractFrom(readable types.Readable) error {
+	value, err := readable.ReadUInt32LE()
+	if err != nil {
+		return err
+	}
+
+	*rc = ReportCategory(value)
+	return nil
+}
+
+const (
+	// ReportCategoryInvalid represents an invalid category
+	ReportCategoryInvalid ReportCategory = iota
+
+	// ReportCategoryPersonal means the reported content contained personal information
+	ReportCategoryPersonal
+
+	// ReportCategoryCriminal means the reported content contained criminal material
+	ReportCategoryCriminal
+
+	// ReportCategoryImmoral means the reported content contained immoral material
+	ReportCategoryImmoral
+
+	// ReportCategoryHarassment means the reported content contained harassment material
+	ReportCategoryHarassment
+
+	// ReportCategoryCommercial means the reported content contained commercial material
+	ReportCategoryCommercial
+
+	// ReportCategorySexuallyExplicit means the reported content contained sexually explicit material
+	ReportCategorySexuallyExplicit
+)

--- a/screening/protocol.go
+++ b/screening/protocol.go
@@ -24,8 +24,8 @@ const (
 // Protocol handles the Screening protocol
 type Protocol struct {
 	endpoint               nex.EndpointInterface
-	ReportDataStoreContent func(err error, packet nex.PacketInterface, callID uint32, pContentParam screening_types.ScreeningDataStoreContentParam, pViolationParam screening_types.ScreeningUGCViolationParam) (*nex.RMCMessage, *nex.Error) // TODO - Unknown request/response format
-	ReportUser             func(err error, packet nex.PacketInterface, callID uint32, packetPayload []byte) (*nex.RMCMessage, *nex.Error)                                                                                                     // TODO - Unknown request/response format
+	ReportDataStoreContent func(err error, packet nex.PacketInterface, callID uint32, pContentParam screening_types.ScreeningDataStoreContentParam, pViolationParam screening_types.ScreeningUGCViolationParam) (*nex.RMCMessage, *nex.Error)
+	ReportUser             func(err error, packet nex.PacketInterface, callID uint32, packetPayload []byte) (*nex.RMCMessage, *nex.Error) // TODO - Unknown request/response format
 	Patches                nex.ServiceProtocol
 	PatchedMethods         []uint32
 }

--- a/screening/protocol.go
+++ b/screening/protocol.go
@@ -7,6 +7,7 @@ import (
 
 	nex "github.com/PretendoNetwork/nex-go/v2"
 	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+	screening_types "github.com/PretendoNetwork/nex-protocols-go/v2/screening/types"
 )
 
 const (
@@ -23,8 +24,8 @@ const (
 // Protocol handles the Screening protocol
 type Protocol struct {
 	endpoint               nex.EndpointInterface
-	ReportDataStoreContent func(err error, packet nex.PacketInterface, callID uint32, packetPayload []byte) (*nex.RMCMessage, *nex.Error) // TODO - Unknown request/response format
-	ReportUser             func(err error, packet nex.PacketInterface, callID uint32, packetPayload []byte) (*nex.RMCMessage, *nex.Error) // TODO - Unknown request/response format
+	ReportDataStoreContent func(err error, packet nex.PacketInterface, callID uint32, pContentParam screening_types.ScreeningDataStoreContentParam, pViolationParam screening_types.ScreeningUGCViolationParam) (*nex.RMCMessage, *nex.Error) // TODO - Unknown request/response format
+	ReportUser             func(err error, packet nex.PacketInterface, callID uint32, packetPayload []byte) (*nex.RMCMessage, *nex.Error)                                                                                                     // TODO - Unknown request/response format
 	Patches                nex.ServiceProtocol
 	PatchedMethods         []uint32
 }
@@ -48,7 +49,7 @@ func (protocol *Protocol) SetEndpoint(endpoint nex.EndpointInterface) {
 }
 
 // SetHandlerReportDataStoreContent sets the handler for the ReportDataStoreContent method
-func (protocol *Protocol) SetHandlerReportDataStoreContent(handler func(err error, packet nex.PacketInterface, callID uint32, packetPayload []byte) (*nex.RMCMessage, *nex.Error)) {
+func (protocol *Protocol) SetHandlerReportDataStoreContent(handler func(err error, packet nex.PacketInterface, callID uint32, pContentParam screening_types.ScreeningDataStoreContentParam, pViolationParam screening_types.ScreeningUGCViolationParam) (*nex.RMCMessage, *nex.Error)) {
 	protocol.ReportDataStoreContent = handler
 }
 

--- a/screening/report_datastore_content.go
+++ b/screening/report_datastore_content.go
@@ -30,7 +30,7 @@ func (protocol *Protocol) handleReportDataStoreContent(packet nex.PacketInterfac
 
 	err := pContentParam.ExtractFrom(parametersStream)
 	if err != nil {
-		_, rmcError := protocol.ReportDataStoreContent(fmt.Errorf("failed to read pContentParam from parameters. %s", err.Error()), packet, callID, pContentParam, pViolationParam)
+		_, rmcError := protocol.ReportDataStoreContent(fmt.Errorf("Failed to read pContentParam from parameters. %s", err.Error()), packet, callID, pContentParam, pViolationParam)
 		if rmcError != nil {
 			globals.RespondError(packet, ProtocolID, rmcError)
 		}
@@ -40,7 +40,7 @@ func (protocol *Protocol) handleReportDataStoreContent(packet nex.PacketInterfac
 
 	err = pViolationParam.ExtractFrom(parametersStream)
 	if err != nil {
-		_, rmcError := protocol.ReportDataStoreContent(fmt.Errorf("failed to read pViolationParam from parameters. %s", err.Error()), packet, callID, pContentParam, pViolationParam)
+		_, rmcError := protocol.ReportDataStoreContent(fmt.Errorf("Failed to read pViolationParam from parameters. %s", err.Error()), packet, callID, pContentParam, pViolationParam)
 		if rmcError != nil {
 			globals.RespondError(packet, ProtocolID, rmcError)
 		}

--- a/screening/report_datastore_content.go
+++ b/screening/report_datastore_content.go
@@ -2,8 +2,11 @@
 package protocol
 
 import (
+	"fmt"
+
 	nex "github.com/PretendoNetwork/nex-go/v2"
 	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+	screening_types "github.com/PretendoNetwork/nex-protocols-go/v2/screening/types"
 )
 
 func (protocol *Protocol) handleReportDataStoreContent(packet nex.PacketInterface) {
@@ -16,12 +19,36 @@ func (protocol *Protocol) handleReportDataStoreContent(packet nex.PacketInterfac
 		return
 	}
 
-	globals.Logger.Warning("Screening::ReportDataStoreContent STUBBED")
-
 	request := packet.RMCMessage()
 	callID := request.CallID
+	parameters := request.Parameters
+	endpoint := packet.Sender().Endpoint()
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
 
-	rmcMessage, rmcError := protocol.ReportDataStoreContent(nil, packet, callID, packet.Payload())
+	var pContentParam screening_types.ScreeningDataStoreContentParam
+	var pViolationParam screening_types.ScreeningUGCViolationParam
+
+	err := pContentParam.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.ReportDataStoreContent(fmt.Errorf("failed to read pContentParam from parameters. %s", err.Error()), packet, callID, pContentParam, pViolationParam)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	err = pViolationParam.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.ReportDataStoreContent(fmt.Errorf("failed to read pViolationParam from parameters. %s", err.Error()), packet, callID, pContentParam, pViolationParam)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	rmcMessage, rmcError := protocol.ReportDataStoreContent(nil, packet, callID, pContentParam, pViolationParam)
 	if rmcError != nil {
 		globals.RespondError(packet, ProtocolID, rmcError)
 		return

--- a/screening/types/screening_context_info.go
+++ b/screening/types/screening_context_info.go
@@ -35,17 +35,17 @@ func (sci *ScreeningContextInfo) ExtractFrom(readable types.Readable) error {
 
 	err = sci.ExtractHeaderFrom(readable)
 	if err != nil {
-		return fmt.Errorf("failed to extract ScreeningContextInfo header. %s", err.Error())
+		return fmt.Errorf("Failed to extract ScreeningContextInfo header. %s", err.Error())
 	}
 
 	err = sci.Key.ExtractFrom(readable)
 	if err != nil {
-		return fmt.Errorf("failed to extract ScreeningContextInfo.Key. %s", err.Error())
+		return fmt.Errorf("Failed to extract ScreeningContextInfo.Key. %s", err.Error())
 	}
 
 	err = sci.Value.ExtractFrom(readable)
 	if err != nil {
-		return fmt.Errorf("failed to extract ScreeningContextInfo.Value. %s", err.Error())
+		return fmt.Errorf("Failed to extract ScreeningContextInfo.Value. %s", err.Error())
 	}
 
 	return nil

--- a/screening/types/screening_context_info.go
+++ b/screening/types/screening_context_info.go
@@ -1,0 +1,124 @@
+// Package types implements all the types used by the Screening protocol
+package types
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
+
+// ScreeningContextInfo is a type within the Screening protocol
+type ScreeningContextInfo struct {
+	types.Structure
+	Key   types.String
+	Value types.String
+}
+
+// WriteTo writes the ScreeningContextInfo to the given writable
+func (sci ScreeningContextInfo) WriteTo(writable types.Writable) {
+	contentWritable := writable.CopyNew()
+
+	sci.Key.WriteTo(contentWritable)
+	sci.Value.WriteTo(contentWritable)
+
+	content := contentWritable.Bytes()
+
+	sci.WriteHeaderTo(writable, uint32(len(content)))
+
+	writable.Write(content)
+}
+
+// ExtractFrom extracts the ScreeningContextInfo from the given readable
+func (sci *ScreeningContextInfo) ExtractFrom(readable types.Readable) error {
+	var err error
+
+	err = sci.ExtractHeaderFrom(readable)
+	if err != nil {
+		return fmt.Errorf("failed to extract ScreeningContextInfo header. %s", err.Error())
+	}
+
+	err = sci.Key.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("failed to extract ScreeningContextInfo.Key. %s", err.Error())
+	}
+
+	err = sci.Value.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("failed to extract ScreeningContextInfo.Value. %s", err.Error())
+	}
+
+	return nil
+}
+
+// Copy returns a new copied instance of ScreeningContextInfo
+func (sci ScreeningContextInfo) Copy() types.RVType {
+	copied := NewScreeningContextInfo()
+
+	copied.StructureVersion = sci.StructureVersion
+	copied.Key = sci.Key
+	copied.Value = sci.Value
+
+	return copied
+}
+
+// Equals checks if the given ScreeningContextInfo contains the same data as the current ScreeningContextInfo
+func (sci ScreeningContextInfo) Equals(o types.RVType) bool {
+	if _, ok := o.(ScreeningContextInfo); !ok {
+		return false
+	}
+
+	other := o.(ScreeningContextInfo)
+
+	if sci.StructureVersion != other.StructureVersion {
+		return false
+	}
+
+	if sci.Key != other.Key {
+		return false
+	}
+
+	return sci.Value == other.Value
+}
+
+// CopyRef copies the current value of the ScreeningContextInfo
+// and returns a pointer to the new copy
+func (sci ScreeningContextInfo) CopyRef() types.RVTypePtr {
+	copied := sci
+	return &copied
+}
+
+// Deref takes a pointer to the ScreeningContextInfo
+// and dereferences it to the raw value.
+// Only useful when working with an instance of RVTypePtr
+func (sci *ScreeningContextInfo) Deref() types.RVType {
+	return *sci
+}
+
+// String returns the string representation of the ScreeningContextInfo
+func (sci ScreeningContextInfo) String() string {
+	return sci.FormatToString(0)
+}
+
+// FormatToString pretty-prints the ScreeningContextInfo using the provided indentation level
+func (sci ScreeningContextInfo) FormatToString(indentationLevel int) string {
+	indentationValues := strings.Repeat("\t", indentationLevel+1)
+	indentationEnd := strings.Repeat("\t", indentationLevel)
+
+	var b strings.Builder
+
+	b.WriteString("ScreeningContextInfo{\n")
+	b.WriteString(fmt.Sprintf("%sKey: %s,\n", indentationValues, sci.Key))
+	b.WriteString(fmt.Sprintf("%sValue: %s\n", indentationValues, sci.Value))
+	b.WriteString(fmt.Sprintf("%s}", indentationEnd))
+
+	return b.String()
+}
+
+// NewScreeningContextInfo returns a new ScreeningContextInfo
+func NewScreeningContextInfo() ScreeningContextInfo {
+	return ScreeningContextInfo{
+		Key:   types.NewString(""),
+		Value: types.NewString(""),
+	}
+}

--- a/screening/types/screening_datastore_content_param.go
+++ b/screening/types/screening_datastore_content_param.go
@@ -1,0 +1,166 @@
+// Package types implements all the types used by the Screening protocol
+package types
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
+
+// ScreeningDataStoreContentParam is a type within the Screening protocol
+type ScreeningDataStoreContentParam struct {
+	types.Structure
+	DataID        types.UInt64
+	ContentDataID types.UInt64
+	UGCType       types.String
+	Language      types.String
+	SearchKey     types.String
+}
+
+// WriteTo writes the ScreeningDataStoreContentParam to the given writable
+func (sdscp ScreeningDataStoreContentParam) WriteTo(writable types.Writable) {
+	contentWritable := writable.CopyNew()
+
+	sdscp.DataID.WriteTo(contentWritable)
+	sdscp.ContentDataID.WriteTo(contentWritable)
+	sdscp.UGCType.WriteTo(contentWritable)
+	sdscp.Language.WriteTo(contentWritable)
+	sdscp.SearchKey.WriteTo(contentWritable)
+
+	content := contentWritable.Bytes()
+
+	sdscp.WriteHeaderTo(writable, uint32(len(content)))
+
+	writable.Write(content)
+}
+
+// ExtractFrom extracts the ScreeningDataStoreContentParam from the given readable
+func (sdscp *ScreeningDataStoreContentParam) ExtractFrom(readable types.Readable) error {
+	var err error
+
+	err = sdscp.ExtractHeaderFrom(readable)
+	if err != nil {
+		return fmt.Errorf("failed to extract ScreeningDataStoreContentParam header. %s", err.Error())
+	}
+
+	err = sdscp.DataID.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("failed to extract ScreeningDataStoreContentParam.DataID. %s", err.Error())
+	}
+
+	err = sdscp.ContentDataID.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("failed to extract ScreeningDataStoreContentParam.ContentDataID. %s", err.Error())
+	}
+
+	err = sdscp.UGCType.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("failed to extract ScreeningDataStoreContentParam.UGCType. %s", err.Error())
+	}
+
+	err = sdscp.Language.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("failed to extract ScreeningDataStoreContentParam.Language. %s", err.Error())
+	}
+
+	err = sdscp.SearchKey.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("failed to extract ScreeningDataStoreContentParam.SearchKey. %s", err.Error())
+	}
+
+	return nil
+}
+
+// Copy returns a new copied instance of ScreeningDataStoreContentParam
+func (sdscp ScreeningDataStoreContentParam) Copy() types.RVType {
+	copied := NewScreeningDataStoreContentParam()
+
+	copied.StructureVersion = sdscp.StructureVersion
+	copied.DataID = sdscp.DataID
+	copied.ContentDataID = sdscp.ContentDataID
+	copied.UGCType = sdscp.UGCType
+	copied.Language = sdscp.Language
+	copied.SearchKey = sdscp.SearchKey
+
+	return copied
+}
+
+// Equals checks if the given ScreeningDataStoreContentParam contains the same data as the current ScreeningDataStoreContentParam
+func (sdscp ScreeningDataStoreContentParam) Equals(o types.RVType) bool {
+	if _, ok := o.(ScreeningDataStoreContentParam); !ok {
+		return false
+	}
+
+	other := o.(ScreeningDataStoreContentParam)
+
+	if sdscp.StructureVersion != other.StructureVersion {
+		return false
+	}
+
+	if sdscp.DataID != other.DataID {
+		return false
+	}
+
+	if sdscp.ContentDataID != other.ContentDataID {
+		return false
+	}
+
+	if sdscp.UGCType != other.UGCType {
+		return false
+	}
+
+	if sdscp.Language != other.Language {
+		return false
+	}
+
+	return sdscp.SearchKey == other.SearchKey
+}
+
+// CopyRef copies the current value of the ScreeningDataStoreContentParam
+// and returns a pointer to the new copy
+func (sdscp ScreeningDataStoreContentParam) CopyRef() types.RVTypePtr {
+	copied := sdscp
+	return &copied
+}
+
+// Deref takes a pointer to the ScreeningDataStoreContentParam
+// and dereferences it to the raw value.
+// Only useful when working with an instance of RVTypePtr
+func (sdscp *ScreeningDataStoreContentParam) Deref() types.RVType {
+	return *sdscp
+}
+
+// String returns the string representation of the ScreeningDataStoreContentParam
+func (sdscp ScreeningDataStoreContentParam) String() string {
+	return sdscp.FormatToString(0)
+}
+
+// FormatToString pretty-prints the ScreeningDataStoreContentParam using the provided indentation level
+func (sdscp ScreeningDataStoreContentParam) FormatToString(indentationLevel int) string {
+	indentationValues := strings.Repeat("\t", indentationLevel+1)
+	indentationEnd := strings.Repeat("\t", indentationLevel)
+
+	var b strings.Builder
+
+	b.WriteString("ScreeningDataStoreContentParam{\n")
+	b.WriteString(fmt.Sprintf("%sDataID: %s,\n", indentationValues, sdscp.DataID))
+	b.WriteString(fmt.Sprintf("%sContentDataID: %s,\n", indentationValues, sdscp.ContentDataID))
+	b.WriteString(fmt.Sprintf("%sUGCType: %s,\n", indentationValues, sdscp.UGCType))
+	b.WriteString(fmt.Sprintf("%sLanguage: %s,\n", indentationValues, sdscp.Language))
+	b.WriteString(fmt.Sprintf("%sSearchKey: %s\n", indentationValues, sdscp.SearchKey))
+	b.WriteString(fmt.Sprintf("%s}", indentationEnd))
+
+	return b.String()
+}
+
+// NewScreeningDataStoreContentParam returns a new ScreeningDataStoreContentParam
+func NewScreeningDataStoreContentParam() ScreeningDataStoreContentParam {
+	return ScreeningDataStoreContentParam{
+		DataID:        types.NewUInt64(0),
+		ContentDataID: types.NewUInt64(0),
+		UGCType:       types.NewString(""),
+		Language:      types.NewString(""),
+		SearchKey:     types.NewString(""),
+	}
+}

--- a/screening/types/screening_datastore_content_param.go
+++ b/screening/types/screening_datastore_content_param.go
@@ -41,32 +41,32 @@ func (sdscp *ScreeningDataStoreContentParam) ExtractFrom(readable types.Readable
 
 	err = sdscp.ExtractHeaderFrom(readable)
 	if err != nil {
-		return fmt.Errorf("failed to extract ScreeningDataStoreContentParam header. %s", err.Error())
+		return fmt.Errorf("Failed to extract ScreeningDataStoreContentParam header. %s", err.Error())
 	}
 
 	err = sdscp.DataID.ExtractFrom(readable)
 	if err != nil {
-		return fmt.Errorf("failed to extract ScreeningDataStoreContentParam.DataID. %s", err.Error())
+		return fmt.Errorf("Failed to extract ScreeningDataStoreContentParam.DataID. %s", err.Error())
 	}
 
 	err = sdscp.ContentDataID.ExtractFrom(readable)
 	if err != nil {
-		return fmt.Errorf("failed to extract ScreeningDataStoreContentParam.ContentDataID. %s", err.Error())
+		return fmt.Errorf("Failed to extract ScreeningDataStoreContentParam.ContentDataID. %s", err.Error())
 	}
 
 	err = sdscp.UGCType.ExtractFrom(readable)
 	if err != nil {
-		return fmt.Errorf("failed to extract ScreeningDataStoreContentParam.UGCType. %s", err.Error())
+		return fmt.Errorf("Failed to extract ScreeningDataStoreContentParam.UGCType. %s", err.Error())
 	}
 
 	err = sdscp.Language.ExtractFrom(readable)
 	if err != nil {
-		return fmt.Errorf("failed to extract ScreeningDataStoreContentParam.Language. %s", err.Error())
+		return fmt.Errorf("Failed to extract ScreeningDataStoreContentParam.Language. %s", err.Error())
 	}
 
 	err = sdscp.SearchKey.ExtractFrom(readable)
 	if err != nil {
-		return fmt.Errorf("failed to extract ScreeningDataStoreContentParam.SearchKey. %s", err.Error())
+		return fmt.Errorf("Failed to extract ScreeningDataStoreContentParam.SearchKey. %s", err.Error())
 	}
 
 	return nil

--- a/screening/types/screening_ugc_violation_param.go
+++ b/screening/types/screening_ugc_violation_param.go
@@ -146,7 +146,7 @@ func (suvp ScreeningUGCViolationParam) FormatToString(indentationLevel int) stri
 func NewScreeningUGCViolationParam() ScreeningUGCViolationParam {
 	return ScreeningUGCViolationParam{
 		Category:         constants.ReportCategoryInvalid, // TODO - Find the real default
-		Reason:           types.NewString("0"),
+		Reason:           types.NewString(""),
 		Context:          types.NewList[ScreeningContextInfo](),
 		ScreenshotDataID: types.NewUInt64(0),
 	}

--- a/screening/types/screening_ugc_violation_param.go
+++ b/screening/types/screening_ugc_violation_param.go
@@ -1,0 +1,153 @@
+// Package types implements all the types used by the Screening protocol
+package types
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+	"github.com/PretendoNetwork/nex-protocols-go/v2/screening/constants"
+)
+
+// ScreeningUGCViolationParam is a type within the Screening protocol
+type ScreeningUGCViolationParam struct {
+	types.Structure
+	Category         constants.ReportCategory
+	Reason           types.String
+	Context          types.List[ScreeningContextInfo]
+	ScreenshotDataID types.UInt64
+}
+
+// WriteTo writes the ScreeningUGCViolationParam to the given writable
+func (suvp ScreeningUGCViolationParam) WriteTo(writable types.Writable) {
+	contentWritable := writable.CopyNew()
+
+	suvp.Category.WriteTo(contentWritable)
+	suvp.Reason.WriteTo(contentWritable)
+	suvp.Context.WriteTo(contentWritable)
+	suvp.ScreenshotDataID.WriteTo(contentWritable)
+
+	content := contentWritable.Bytes()
+
+	suvp.WriteHeaderTo(writable, uint32(len(content)))
+
+	writable.Write(content)
+}
+
+// ExtractFrom extracts the ScreeningUGCViolationParam from the given readable
+func (suvp *ScreeningUGCViolationParam) ExtractFrom(readable types.Readable) error {
+	var err error
+
+	err = suvp.ExtractHeaderFrom(readable)
+	if err != nil {
+		return fmt.Errorf("failed to extract ScreeningUGCViolationParam header. %s", err.Error())
+	}
+
+	err = suvp.Category.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("failed to extract ScreeningUGCViolationParam.Category. %s", err.Error())
+	}
+
+	err = suvp.Reason.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("failed to extract ScreeningUGCViolationParam.Reason. %s", err.Error())
+	}
+
+	err = suvp.Context.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("failed to extract ScreeningUGCViolationParam.Context. %s", err.Error())
+	}
+
+	err = suvp.ScreenshotDataID.ExtractFrom(readable)
+	if err != nil {
+		return fmt.Errorf("failed to extract ScreeningUGCViolationParam.ScreenshotDataID. %s", err.Error())
+	}
+
+	return nil
+}
+
+// Copy returns a new copied instance of ScreeningUGCViolationParam
+func (suvp ScreeningUGCViolationParam) Copy() types.RVType {
+	copied := NewScreeniGCUgcViolationParam()
+
+	copied.StructureVersion = suvp.StructureVersion
+	copied.Category = suvp.Category
+	copied.Reason = suvp.Reason
+	copied.Context = suvp.Context
+	copied.ScreenshotDataID = suvp.ScreenshotDataID
+
+	return copied
+}
+
+// Equals checks if the given ScreeningUGCViolationParam contains the same data as the current ScreeningUGCViolationParam
+func (suvp ScreeningUGCViolationParam) Equals(o types.RVType) bool {
+	if _, ok := o.(ScreeningUGCViolationParam); !ok {
+		return false
+	}
+
+	other := o.(ScreeningUGCViolationParam)
+
+	if suvp.StructureVersion != other.StructureVersion {
+		return false
+	}
+
+	if suvp.Category != other.Category {
+		return false
+	}
+
+	if suvp.Reason != other.Reason {
+		return false
+	}
+
+	if !suvp.Context.Equals(other.Context) {
+		return false
+	}
+
+	return suvp.ScreenshotDataID == other.ScreenshotDataID
+}
+
+// CopyRef copies the current value of the ScreeningUGCViolationParam
+// and returns a pointer to the new copy
+func (suvp ScreeningUGCViolationParam) CopyRef() types.RVTypePtr {
+	copied := suvp
+	return &copied
+}
+
+// Deref takes a pointer to the ScreeningUGCViolationParam
+// and dereferences it to the raw value.
+// Only useful when working with an instance of RVTypePtr
+func (suvp *ScreeningUGCViolationParam) Deref() types.RVType {
+	return *suvp
+}
+
+// String returns the string representation of the ScreeningUGCViolationParam
+func (suvp ScreeningUGCViolationParam) String() string {
+	return suvp.FormatToString(0)
+}
+
+// FormatToString pretty-prints the ScreeningUGCViolationParam using the provided indentation level
+func (suvp ScreeningUGCViolationParam) FormatToString(indentationLevel int) string {
+	indentationValues := strings.Repeat("\t", indentationLevel+1)
+	indentationEnd := strings.Repeat("\t", indentationLevel)
+
+	var b strings.Builder
+
+	b.WriteString("ScreeningUGCViolationParam{\n")
+	b.WriteString(fmt.Sprintf("%sCategory: %d,\n", indentationValues, suvp.Category))
+	b.WriteString(fmt.Sprintf("%sReason: %s,\n", indentationValues, suvp.Reason))
+	b.WriteString(fmt.Sprintf("%sContext: %s,\n", indentationValues, suvp.Context))
+	b.WriteString(fmt.Sprintf("%sScreenshotDataID: %s\n", indentationValues, suvp.ScreenshotDataID))
+	b.WriteString(fmt.Sprintf("%s}", indentationEnd))
+
+	return b.String()
+}
+
+// NewScreeniGCUgcViolationParam returns a new ScreeningUGCViolationParam
+func NewScreeniGCUgcViolationParam() ScreeningUGCViolationParam {
+	return ScreeningUGCViolationParam{
+		Category:         constants.ReportCategoryInvalid, // TODO - Find the real default
+		Reason:           types.NewString("0"),
+		Context:          types.NewList[ScreeningContextInfo](),
+		ScreenshotDataID: types.NewUInt64(0),
+	}
+}

--- a/screening/types/screening_ugc_violation_param.go
+++ b/screening/types/screening_ugc_violation_param.go
@@ -68,7 +68,7 @@ func (suvp *ScreeningUGCViolationParam) ExtractFrom(readable types.Readable) err
 
 // Copy returns a new copied instance of ScreeningUGCViolationParam
 func (suvp ScreeningUGCViolationParam) Copy() types.RVType {
-	copied := NewScreeniGCUgcViolationParam()
+	copied := NewScreeningUGCViolationParam()
 
 	copied.StructureVersion = suvp.StructureVersion
 	copied.Category = suvp.Category
@@ -142,8 +142,8 @@ func (suvp ScreeningUGCViolationParam) FormatToString(indentationLevel int) stri
 	return b.String()
 }
 
-// NewScreeniGCUgcViolationParam returns a new ScreeningUGCViolationParam
-func NewScreeniGCUgcViolationParam() ScreeningUGCViolationParam {
+// NewScreeningUGCViolationParam returns a new ScreeningUGCViolationParam
+func NewScreeningUGCViolationParam() ScreeningUGCViolationParam {
 	return ScreeningUGCViolationParam{
 		Category:         constants.ReportCategoryInvalid, // TODO - Find the real default
 		Reason:           types.NewString("0"),

--- a/screening/types/screening_ugc_violation_param.go
+++ b/screening/types/screening_ugc_violation_param.go
@@ -40,27 +40,27 @@ func (suvp *ScreeningUGCViolationParam) ExtractFrom(readable types.Readable) err
 
 	err = suvp.ExtractHeaderFrom(readable)
 	if err != nil {
-		return fmt.Errorf("failed to extract ScreeningUGCViolationParam header. %s", err.Error())
+		return fmt.Errorf("Failed to extract ScreeningUGCViolationParam header. %s", err.Error())
 	}
 
 	err = suvp.Category.ExtractFrom(readable)
 	if err != nil {
-		return fmt.Errorf("failed to extract ScreeningUGCViolationParam.Category. %s", err.Error())
+		return fmt.Errorf("Failed to extract ScreeningUGCViolationParam.Category. %s", err.Error())
 	}
 
 	err = suvp.Reason.ExtractFrom(readable)
 	if err != nil {
-		return fmt.Errorf("failed to extract ScreeningUGCViolationParam.Reason. %s", err.Error())
+		return fmt.Errorf("Failed to extract ScreeningUGCViolationParam.Reason. %s", err.Error())
 	}
 
 	err = suvp.Context.ExtractFrom(readable)
 	if err != nil {
-		return fmt.Errorf("failed to extract ScreeningUGCViolationParam.Context. %s", err.Error())
+		return fmt.Errorf("Failed to extract ScreeningUGCViolationParam.Context. %s", err.Error())
 	}
 
 	err = suvp.ScreenshotDataID.ExtractFrom(readable)
 	if err != nil {
-		return fmt.Errorf("failed to extract ScreeningUGCViolationParam.ScreenshotDataID. %s", err.Error())
+		return fmt.Errorf("Failed to extract ScreeningUGCViolationParam.ScreenshotDataID. %s", err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
Resolves #XXX

### Changes:

Adds a proper handler for `Screening::ReportDataStoreContent`

Data comes from:

- https://github.com/Hengle/FE_Engage-Global_Metadata/blob/77e1b20a35bb17bfd3054e5651faf6072ed724d0/no_namespace/Detail.cs#L1627
- https://github.com/Hengle/FE_Engage-Global_Metadata/blob/77e1b20a35bb17bfd3054e5651faf6072ed724d0/NexPlugin/ScreeningDataStoreContentParam.cs
- https://github.com/Hengle/FE_Engage-Global_Metadata/blob/77e1b20a35bb17bfd3054e5651faf6072ed724d0/NexPlugin/ScreeningUgcViolationParam.cs
- https://github.com/Hengle/FE_Engage-Global_Metadata/blob/77e1b20a35bb17bfd3054e5651faf6072ed724d0/NexPlugin/ScreeningContextInfo.cs
- https://github.com/Hengle/FE_Engage-Global_Metadata/blob/77e1b20a35bb17bfd3054e5651faf6072ed724d0/no_namespace/Screening.cs#L13

Sadly there's no details for `Screening:: ReportUser`. The struct field order is assumed to be correct. I'll add this to the wiki in the morning

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.