### PR TITLE
Moves to `if-ok` style syntax when decoding protocol class types

### DIFF
--- a/aa-user/types/application_info.go
+++ b/aa-user/types/application_info.go
@@ -34,25 +34,19 @@ func (ai ApplicationInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ApplicationInfo from the given readable
 func (ai *ApplicationInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = ai.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := ai.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ApplicationInfo.Data. %s", err.Error())
 	}
 
-	err = ai.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := ai.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ApplicationInfo header. %s", err.Error())
 	}
 
-	err = ai.TitleID.ExtractFrom(readable)
-	if err != nil {
+	if err := ai.TitleID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ApplicationInfo.TitleID. %s", err.Error())
 	}
 
-	err = ai.TitleVersion.ExtractFrom(readable)
-	if err != nil {
+	if err := ai.TitleVersion.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ApplicationInfo.TitleVersion. %s", err.Error())
 	}
 

--- a/account-management/types/account_data.go
+++ b/account-management/types/account_data.go
@@ -45,55 +45,43 @@ func (ad AccountData) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the AccountData from the given readable
 func (ad *AccountData) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = ad.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := ad.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AccountData header. %s", err.Error())
 	}
 
-	err = ad.PID.ExtractFrom(readable)
-	if err != nil {
+	if err := ad.PID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AccountData.PID. %s", err.Error())
 	}
 
-	err = ad.StrName.ExtractFrom(readable)
-	if err != nil {
+	if err := ad.StrName.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AccountData.StrName. %s", err.Error())
 	}
 
-	err = ad.UIGroups.ExtractFrom(readable)
-	if err != nil {
+	if err := ad.UIGroups.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AccountData.UIGroups. %s", err.Error())
 	}
 
-	err = ad.StrEmail.ExtractFrom(readable)
-	if err != nil {
+	if err := ad.StrEmail.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AccountData.StrEmail. %s", err.Error())
 	}
 
-	err = ad.DTCreationDate.ExtractFrom(readable)
-	if err != nil {
+	if err := ad.DTCreationDate.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AccountData.DTCreationDate. %s", err.Error())
 	}
 
-	err = ad.DTEffectiveDate.ExtractFrom(readable)
-	if err != nil {
+	if err := ad.DTEffectiveDate.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AccountData.DTEffectiveDate. %s", err.Error())
 	}
 
-	err = ad.StrNotEffectiveMsg.ExtractFrom(readable)
-	if err != nil {
+	if err := ad.StrNotEffectiveMsg.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AccountData.StrNotEffectiveMsg. %s", err.Error())
 	}
 
-	err = ad.DTExpiryDate.ExtractFrom(readable)
-	if err != nil {
+	if err := ad.DTExpiryDate.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AccountData.DTExpiryDate. %s", err.Error())
 	}
 
-	err = ad.StrExpiredMsg.ExtractFrom(readable)
-	if err != nil {
+	if err := ad.StrExpiredMsg.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AccountData.StrExpiredMsg. %s", err.Error())
 	}
 

--- a/account-management/types/account_extra_info.go
+++ b/account-management/types/account_extra_info.go
@@ -43,25 +43,19 @@ func (aei AccountExtraInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the AccountExtraInfo from the given readable
 func (aei *AccountExtraInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = aei.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := aei.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AccountExtraInfo header. %s", err.Error())
 	}
 
-	err = aei.LocalFriendCode.ExtractFrom(readable)
-	if err != nil {
+	if err := aei.LocalFriendCode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AccountExtraInfo.LocalFriendCode. %s", err.Error())
 	}
 
-	err = aei.MoveCount.ExtractFrom(readable)
-	if err != nil {
+	if err := aei.MoveCount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AccountExtraInfo.MoveCount. %s", err.Error())
 	}
 
-	err = aei.NEXToken.ExtractFrom(readable)
-	if err != nil {
+	if err := aei.NEXToken.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AccountExtraInfo.NEXToken. %s", err.Error())
 	}
 

--- a/account-management/types/basic_account_info.go
+++ b/account-management/types/basic_account_info.go
@@ -31,20 +31,15 @@ func (bai BasicAccountInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the BasicAccountInfo from the given readable
 func (bai *BasicAccountInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = bai.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := bai.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract BasicAccountInfo header. %s", err.Error())
 	}
 
-	err = bai.PIDOwner.ExtractFrom(readable)
-	if err != nil {
+	if err := bai.PIDOwner.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract BasicAccountInfo.PIDOwner. %s", err.Error())
 	}
 
-	err = bai.StrName.ExtractFrom(readable)
-	if err != nil {
+	if err := bai.StrName.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract BasicAccountInfo.StrName. %s", err.Error())
 	}
 

--- a/account-management/types/nintendo_create_account_data.go
+++ b/account-management/types/nintendo_create_account_data.go
@@ -46,30 +46,23 @@ func (ncad NintendoCreateAccountData) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the NintendoCreateAccountData from the given readable
 func (ncad *NintendoCreateAccountData) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = ncad.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := ncad.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoCreateAccountData header. %s", err.Error())
 	}
 
-	err = ncad.NNAInfo.ExtractFrom(readable)
-	if err != nil {
+	if err := ncad.NNAInfo.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoCreateAccountData.NNAInfo. %s", err.Error())
 	}
 
-	err = ncad.Token.ExtractFrom(readable)
-	if err != nil {
+	if err := ncad.Token.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoCreateAccountData.Token. %s", err.Error())
 	}
 
-	err = ncad.Birthday.ExtractFrom(readable)
-	if err != nil {
+	if err := ncad.Birthday.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoCreateAccountData.Birthday. %s", err.Error())
 	}
 
-	err = ncad.Unknown.ExtractFrom(readable)
-	if err != nil {
+	if err := ncad.Unknown.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoCreateAccountData.Unknown. %s", err.Error())
 	}
 

--- a/datastore/miitopia/types/mii_tube_mii_info.go
+++ b/datastore/miitopia/types/mii_tube_mii_info.go
@@ -34,25 +34,19 @@ func (mtmi MiiTubeMiiInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the MiiTubeMiiInfo from the given readable
 func (mtmi *MiiTubeMiiInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = mtmi.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := mtmi.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiTubeMiiInfo header. %s", err.Error())
 	}
 
-	err = mtmi.MetaInfo.ExtractFrom(readable)
-	if err != nil {
+	if err := mtmi.MetaInfo.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiTubeMiiInfo.MetaInfo. %s", err.Error())
 	}
 
-	err = mtmi.Category.ExtractFrom(readable)
-	if err != nil {
+	if err := mtmi.Category.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiTubeMiiInfo.Category. %s", err.Error())
 	}
 
-	err = mtmi.RankingType.ExtractFrom(readable)
-	if err != nil {
+	if err := mtmi.RankingType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiTubeMiiInfo.RankingType. %s", err.Error())
 	}
 

--- a/datastore/miitopia/types/mii_tube_search_param.go
+++ b/datastore/miitopia/types/mii_tube_search_param.go
@@ -41,45 +41,35 @@ func (mtsp MiiTubeSearchParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the MiiTubeSearchParam from the given readable
 func (mtsp *MiiTubeSearchParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = mtsp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := mtsp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiTubeSearchParam header. %s", err.Error())
 	}
 
-	err = mtsp.Name.ExtractFrom(readable)
-	if err != nil {
+	if err := mtsp.Name.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiTubeSearchParam.Name. %s", err.Error())
 	}
 
-	err = mtsp.Page.ExtractFrom(readable)
-	if err != nil {
+	if err := mtsp.Page.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiTubeSearchParam.Page. %s", err.Error())
 	}
 
-	err = mtsp.Category.ExtractFrom(readable)
-	if err != nil {
+	if err := mtsp.Category.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiTubeSearchParam.Category. %s", err.Error())
 	}
 
-	err = mtsp.Gender.ExtractFrom(readable)
-	if err != nil {
+	if err := mtsp.Gender.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiTubeSearchParam.Gender. %s", err.Error())
 	}
 
-	err = mtsp.Country.ExtractFrom(readable)
-	if err != nil {
+	if err := mtsp.Country.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiTubeSearchParam.Country. %s", err.Error())
 	}
 
-	err = mtsp.SearchType.ExtractFrom(readable)
-	if err != nil {
+	if err := mtsp.SearchType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiTubeSearchParam.SearchType. %s", err.Error())
 	}
 
-	err = mtsp.ResultOption.ExtractFrom(readable)
-	if err != nil {
+	if err := mtsp.ResultOption.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiTubeSearchParam.ResultOption. %s", err.Error())
 	}
 

--- a/datastore/miitopia/types/mii_tube_search_result.go
+++ b/datastore/miitopia/types/mii_tube_search_result.go
@@ -36,30 +36,23 @@ func (mtsr MiiTubeSearchResult) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the MiiTubeSearchResult from the given readable
 func (mtsr *MiiTubeSearchResult) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = mtsr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := mtsr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiTubeSearchResult header. %s", err.Error())
 	}
 
-	err = mtsr.Result.ExtractFrom(readable)
-	if err != nil {
+	if err := mtsr.Result.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiTubeSearchResult.Result. %s", err.Error())
 	}
 
-	err = mtsr.Count.ExtractFrom(readable)
-	if err != nil {
+	if err := mtsr.Count.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiTubeSearchResult.Count. %s", err.Error())
 	}
 
-	err = mtsr.Page.ExtractFrom(readable)
-	if err != nil {
+	if err := mtsr.Page.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiTubeSearchResult.Page. %s", err.Error())
 	}
 
-	err = mtsr.HasNext.ExtractFrom(readable)
-	if err != nil {
+	if err := mtsr.HasNext.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiTubeSearchResult.ExtractNext. %s", err.Error())
 	}
 

--- a/datastore/nintendo-badge-arcade/types/datastore_get_meta_by_owner_id_param.go
+++ b/datastore/nintendo-badge-arcade/types/datastore_get_meta_by_owner_id_param.go
@@ -35,30 +35,23 @@ func (dsgmboidp DataStoreGetMetaByOwnerIDParam) WriteTo(writable types.Writable)
 
 // ExtractFrom extracts the DataStoreGetMetaByOwnerIDParam from the given readable
 func (dsgmboidp *DataStoreGetMetaByOwnerIDParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsgmboidp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsgmboidp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetMetaByOwnerIDParam header. %s", err.Error())
 	}
 
-	err = dsgmboidp.OwnerIDs.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgmboidp.OwnerIDs.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetMetaByOwnerIDParam.OwnerIDs. %s", err.Error())
 	}
 
-	err = dsgmboidp.DataTypes.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgmboidp.DataTypes.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetMetaByOwnerIDParam.DataTypes. %s", err.Error())
 	}
 
-	err = dsgmboidp.ResultOption.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgmboidp.ResultOption.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetMetaByOwnerIDParam.ResultOption. %s", err.Error())
 	}
 
-	err = dsgmboidp.ResultRange.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgmboidp.ResultRange.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetMetaByOwnerIDParam.ResultRange. %s", err.Error())
 	}
 

--- a/datastore/pokemon-bank/types/bank_migration_info.go
+++ b/datastore/pokemon-bank/types/bank_migration_info.go
@@ -31,20 +31,15 @@ func (bmi BankMigrationInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the BankMigrationInfo from the given readable
 func (bmi *BankMigrationInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = bmi.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := bmi.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract BankMigrationInfo header. %s", err.Error())
 	}
 
-	err = bmi.MigrationStatus.ExtractFrom(readable)
-	if err != nil {
+	if err := bmi.MigrationStatus.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract BankMigrationInfo.MigrationStatus. %s", err.Error())
 	}
 
-	err = bmi.UpdatedTime.ExtractFrom(readable)
-	if err != nil {
+	if err := bmi.UpdatedTime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract BankMigrationInfo.UpdatedTime. %s", err.Error())
 	}
 

--- a/datastore/pokemon-bank/types/bank_transaction_param.go
+++ b/datastore/pokemon-bank/types/bank_transaction_param.go
@@ -37,35 +37,27 @@ func (btp BankTransactionParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the BankTransactionParam from the given readable
 func (btp *BankTransactionParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = btp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := btp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract BankTransactionParam header. %s", err.Error())
 	}
 
-	err = btp.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := btp.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract BankTransactionParam.DataID. %s", err.Error())
 	}
 
-	err = btp.CurVersion.ExtractFrom(readable)
-	if err != nil {
+	if err := btp.CurVersion.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract BankTransactionParam.CurVersion. %s", err.Error())
 	}
 
-	err = btp.UpdateVersion.ExtractFrom(readable)
-	if err != nil {
+	if err := btp.UpdateVersion.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract BankTransactionParam.UpdateVersion. %s", err.Error())
 	}
 
-	err = btp.Size.ExtractFrom(readable)
-	if err != nil {
+	if err := btp.Size.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract BankTransactionParam.Size. %s", err.Error())
 	}
 
-	err = btp.TransactionPassword.ExtractFrom(readable)
-	if err != nil {
+	if err := btp.TransactionPassword.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract BankTransactionParam.TransactionPassword. %s", err.Error())
 	}
 

--- a/datastore/pokemon-bank/types/global_trade_station_data.go
+++ b/datastore/pokemon-bank/types/global_trade_station_data.go
@@ -37,35 +37,27 @@ func (gtsd GlobalTradeStationData) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the GlobalTradeStationData from the given readable
 func (gtsd *GlobalTradeStationData) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsd.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsd.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationData header. %s", err.Error())
 	}
 
-	err = gtsd.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsd.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationData.DataID. %s", err.Error())
 	}
 
-	err = gtsd.OwnerID.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsd.OwnerID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationData.OwnerID. %s", err.Error())
 	}
 
-	err = gtsd.UpdatedTime.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsd.UpdatedTime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationData.UpdatedTime. %s", err.Error())
 	}
 
-	err = gtsd.IndexData.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsd.IndexData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationData.IndexData. %s", err.Error())
 	}
 
-	err = gtsd.Version.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsd.Version.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationData.Version. %s", err.Error())
 	}
 

--- a/datastore/pokemon-bank/types/global_trade_station_delete_pokemon_param.go
+++ b/datastore/pokemon-bank/types/global_trade_station_delete_pokemon_param.go
@@ -31,20 +31,15 @@ func (gtsdpp GlobalTradeStationDeletePokemonParam) WriteTo(writable types.Writab
 
 // ExtractFrom extracts the GlobalTradeStationDeletePokemonParam from the given readable
 func (gtsdpp *GlobalTradeStationDeletePokemonParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsdpp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsdpp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDeletePokemonParam header. %s", err.Error())
 	}
 
-	err = gtsdpp.PrepareUploadKey.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsdpp.PrepareUploadKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDeletePokemonParam.PrepareUploadKey. %s", err.Error())
 	}
 
-	err = gtsdpp.DeleteFlag.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsdpp.DeleteFlag.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDeletePokemonParam.DeleteFlag. %s", err.Error())
 	}
 

--- a/datastore/pokemon-bank/types/global_trade_station_download_my_pokemon_param.go
+++ b/datastore/pokemon-bank/types/global_trade_station_download_my_pokemon_param.go
@@ -29,15 +29,11 @@ func (gtsdmpp GlobalTradeStationDownloadMyPokemonParam) WriteTo(writable types.W
 
 // ExtractFrom extracts the GlobalTradeStationDownloadMyPokemonParam from the given readable
 func (gtsdmpp *GlobalTradeStationDownloadMyPokemonParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsdmpp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsdmpp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDownloadMyPokemonParam header. %s", err.Error())
 	}
 
-	err = gtsdmpp.PrepareUploadKey.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsdmpp.PrepareUploadKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDownloadMyPokemonParam.PrepareUploadKey. %s", err.Error())
 	}
 

--- a/datastore/pokemon-bank/types/global_trade_station_download_my_pokemon_result.go
+++ b/datastore/pokemon-bank/types/global_trade_station_download_my_pokemon_result.go
@@ -31,20 +31,15 @@ func (gtsdmpr GlobalTradeStationDownloadMyPokemonResult) WriteTo(writable types.
 
 // ExtractFrom extracts the GlobalTradeStationDownloadMyPokemonResult from the given readable
 func (gtsdmpr *GlobalTradeStationDownloadMyPokemonResult) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsdmpr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsdmpr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDownloadMyPokemonResult header. %s", err.Error())
 	}
 
-	err = gtsdmpr.Result.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsdmpr.Result.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDownloadMyPokemonResult.Result. %s", err.Error())
 	}
 
-	err = gtsdmpr.IsTraded.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsdmpr.IsTraded.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDownloadMyPokemonResult.IsTraded. %s", err.Error())
 	}
 

--- a/datastore/pokemon-bank/types/global_trade_station_download_other_pokemon_param.go
+++ b/datastore/pokemon-bank/types/global_trade_station_download_other_pokemon_param.go
@@ -29,15 +29,11 @@ func (gtsdopp GlobalTradeStationDownloadOtherPokemonParam) WriteTo(writable type
 
 // ExtractFrom extracts the GlobalTradeStationDownloadOtherPokemonParam from the given readable
 func (gtsdopp *GlobalTradeStationDownloadOtherPokemonParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsdopp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsdopp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDownloadOtherPokemonParam header. %s", err.Error())
 	}
 
-	err = gtsdopp.PrepareUploadKey.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsdopp.PrepareUploadKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDownloadOtherPokemonParam.PrepareUploadKey. %s", err.Error())
 	}
 

--- a/datastore/pokemon-bank/types/global_trade_station_download_pokemon_result.go
+++ b/datastore/pokemon-bank/types/global_trade_station_download_pokemon_result.go
@@ -33,25 +33,19 @@ func (gtsdpr GlobalTradeStationDownloadPokemonResult) WriteTo(writable types.Wri
 
 // ExtractFrom extracts the GlobalTradeStationDownloadPokemonResult from the given readable
 func (gtsdpr *GlobalTradeStationDownloadPokemonResult) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsdpr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsdpr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDownloadPokemonResult header. %s", err.Error())
 	}
 
-	err = gtsdpr.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsdpr.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDownloadPokemonResult.DataID. %s", err.Error())
 	}
 
-	err = gtsdpr.IndexData.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsdpr.IndexData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDownloadPokemonResult.IndexData. %s", err.Error())
 	}
 
-	err = gtsdpr.PokemonData.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsdpr.PokemonData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDownloadPokemonResult.PokemonData. %s", err.Error())
 	}
 

--- a/datastore/pokemon-bank/types/global_trade_station_prepare_trade_pokemon_param.go
+++ b/datastore/pokemon-bank/types/global_trade_station_prepare_trade_pokemon_param.go
@@ -31,20 +31,15 @@ func (gtsptpp GlobalTradeStationPrepareTradePokemonParam) WriteTo(writable types
 
 // ExtractFrom extracts the GlobalTradeStationPrepareTradePokemonParam from the given readable
 func (gtsptpp *GlobalTradeStationPrepareTradePokemonParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsptpp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsptpp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationPrepareTradePokemonParam header. %s", err.Error())
 	}
 
-	err = gtsptpp.TradeKey.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsptpp.TradeKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationPrepareTradePokemonParam.TradeKey. %s", err.Error())
 	}
 
-	err = gtsptpp.PrepareUploadKey.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsptpp.PrepareUploadKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationPrepareTradePokemonParam.PrepareUploadKey. %s", err.Error())
 	}
 

--- a/datastore/pokemon-bank/types/global_trade_station_prepare_trade_pokemon_result.go
+++ b/datastore/pokemon-bank/types/global_trade_station_prepare_trade_pokemon_result.go
@@ -31,20 +31,15 @@ func (gtsptpr GlobalTradeStationPrepareTradePokemonResult) WriteTo(writable type
 
 // ExtractFrom extracts the GlobalTradeStationPrepareTradePokemonResult from the given readable
 func (gtsptpr *GlobalTradeStationPrepareTradePokemonResult) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsptpr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsptpr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationPrepareTradePokemonResult header. %s", err.Error())
 	}
 
-	err = gtsptpr.Result.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsptpr.Result.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationPrepareTradePokemonResult.Result. %s", err.Error())
 	}
 
-	err = gtsptpr.PrepareTradeKey.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsptpr.PrepareTradeKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationPrepareTradePokemonResult.PrepareTradeKey. %s", err.Error())
 	}
 

--- a/datastore/pokemon-bank/types/global_trade_station_record_key.go
+++ b/datastore/pokemon-bank/types/global_trade_station_record_key.go
@@ -31,20 +31,15 @@ func (gtsrk GlobalTradeStationRecordKey) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the GlobalTradeStationRecordKey from the given readable
 func (gtsrk *GlobalTradeStationRecordKey) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsrk.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsrk.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationRecordKey header. %s", err.Error())
 	}
 
-	err = gtsrk.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsrk.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationRecordKey.DataID. %s", err.Error())
 	}
 
-	err = gtsrk.Password.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsrk.Password.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationRecordKey.Password. %s", err.Error())
 	}
 

--- a/datastore/pokemon-bank/types/global_trade_station_search_pokemon_param.go
+++ b/datastore/pokemon-bank/types/global_trade_station_search_pokemon_param.go
@@ -41,45 +41,35 @@ func (gtsspp GlobalTradeStationSearchPokemonParam) WriteTo(writable types.Writab
 
 // ExtractFrom extracts the GlobalTradeStationSearchPokemonParam from the given readable
 func (gtsspp *GlobalTradeStationSearchPokemonParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsspp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsspp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonParam header. %s", err.Error())
 	}
 
-	err = gtsspp.PrepareUploadKey.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsspp.PrepareUploadKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonParam.PrepareUploadKey. %s", err.Error())
 	}
 
-	err = gtsspp.Conditions.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsspp.Conditions.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonParam.Conditions. %s", err.Error())
 	}
 
-	err = gtsspp.ResultOrderColumn.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsspp.ResultOrderColumn.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonParam.ResultOrderColumn. %s", err.Error())
 	}
 
-	err = gtsspp.ResultOrder.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsspp.ResultOrder.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonParam.ResultOrder. %s", err.Error())
 	}
 
-	err = gtsspp.UploadedAfter.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsspp.UploadedAfter.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonParam.UploadedAfter. %s", err.Error())
 	}
 
-	err = gtsspp.UploadedBefore.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsspp.UploadedBefore.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonParam.UploadedBefore. %s", err.Error())
 	}
 
-	err = gtsspp.ResultRange.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsspp.ResultRange.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonParam.ResultRange. %s", err.Error())
 	}
 

--- a/datastore/pokemon-bank/types/global_trade_station_search_pokemon_result.go
+++ b/datastore/pokemon-bank/types/global_trade_station_search_pokemon_result.go
@@ -33,25 +33,19 @@ func (gtsspr GlobalTradeStationSearchPokemonResult) WriteTo(writable types.Writa
 
 // ExtractFrom extracts the GlobalTradeStationSearchPokemonResult from the given readable
 func (gtsspr *GlobalTradeStationSearchPokemonResult) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsspr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsspr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonResult header. %s", err.Error())
 	}
 
-	err = gtsspr.TotalCount.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsspr.TotalCount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonResult.TotalCount. %s", err.Error())
 	}
 
-	err = gtsspr.Result.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsspr.Result.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonResult.Result. %s", err.Error())
 	}
 
-	err = gtsspr.TotalCountType.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsspr.TotalCountType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonResult.TotalCountType. %s", err.Error())
 	}
 

--- a/datastore/pokemon-bank/types/global_trade_station_trade_key.go
+++ b/datastore/pokemon-bank/types/global_trade_station_trade_key.go
@@ -31,20 +31,15 @@ func (gtstk GlobalTradeStationTradeKey) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the GlobalTradeStationTradeKey from the given readable
 func (gtstk *GlobalTradeStationTradeKey) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtstk.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtstk.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradeKey header. %s", err.Error())
 	}
 
-	err = gtstk.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstk.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradeKey.DataID. %s", err.Error())
 	}
 
-	err = gtstk.Version.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstk.Version.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradeKey.Version. %s", err.Error())
 	}
 

--- a/datastore/pokemon-bank/types/global_trade_station_trade_pokemon_param.go
+++ b/datastore/pokemon-bank/types/global_trade_station_trade_pokemon_param.go
@@ -43,50 +43,39 @@ func (gtstpp GlobalTradeStationTradePokemonParam) WriteTo(writable types.Writabl
 
 // ExtractFrom extracts the GlobalTradeStationTradePokemonParam from the given readable
 func (gtstpp *GlobalTradeStationTradePokemonParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtstpp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtstpp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonParam header. %s", err.Error())
 	}
 
-	err = gtstpp.TradeKey.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstpp.TradeKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonParam.TradeKey. %s", err.Error())
 	}
 
-	err = gtstpp.PrepareTradeKey.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstpp.PrepareTradeKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonParam.PrepareTradeKey. %s", err.Error())
 	}
 
-	err = gtstpp.PrepareUploadKey.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstpp.PrepareUploadKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonParam.PrepareUploadKey. %s", err.Error())
 	}
 
-	err = gtstpp.Period.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstpp.Period.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonParam.Period. %s", err.Error())
 	}
 
-	err = gtstpp.IndexData.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstpp.IndexData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonParam.IndexData. %s", err.Error())
 	}
 
-	err = gtstpp.PokemonData.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstpp.PokemonData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonParam.PokemonData. %s", err.Error())
 	}
 
-	err = gtstpp.Signature.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstpp.Signature.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonParam.Signature. %s", err.Error())
 	}
 
-	err = gtstpp.NeedData.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstpp.NeedData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonParam.NeedData. %s", err.Error())
 	}
 

--- a/datastore/pokemon-bank/types/global_trade_station_trade_pokemon_result.go
+++ b/datastore/pokemon-bank/types/global_trade_station_trade_pokemon_result.go
@@ -31,20 +31,15 @@ func (gtstpr GlobalTradeStationTradePokemonResult) WriteTo(writable types.Writab
 
 // ExtractFrom extracts the GlobalTradeStationTradePokemonResult from the given readable
 func (gtstpr *GlobalTradeStationTradePokemonResult) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtstpr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtstpr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonResult header. %s", err.Error())
 	}
 
-	err = gtstpr.Result.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstpr.Result.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonResult.Result. %s", err.Error())
 	}
 
-	err = gtstpr.MyDataID.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstpr.MyDataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonResult.MyDataID. %s", err.Error())
 	}
 

--- a/datastore/pokemon-bank/types/global_trade_station_upload_pokemon_param.go
+++ b/datastore/pokemon-bank/types/global_trade_station_upload_pokemon_param.go
@@ -37,35 +37,27 @@ func (gtsupp GlobalTradeStationUploadPokemonParam) WriteTo(writable types.Writab
 
 // ExtractFrom extracts the GlobalTradeStationUploadPokemonParam from the given readable
 func (gtsupp *GlobalTradeStationUploadPokemonParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsupp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsupp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationUploadPokemonParam header. %s", err.Error())
 	}
 
-	err = gtsupp.PrepareUploadKey.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsupp.PrepareUploadKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationUploadPokemonParam.PrepareUploadKey. %s", err.Error())
 	}
 
-	err = gtsupp.Period.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsupp.Period.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationUploadPokemonParam.Period. %s", err.Error())
 	}
 
-	err = gtsupp.IndexData.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsupp.IndexData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationUploadPokemonParam.IndexData. %s", err.Error())
 	}
 
-	err = gtsupp.PokemonData.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsupp.PokemonData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationUploadPokemonParam.PokemonData. %s", err.Error())
 	}
 
-	err = gtsupp.Signature.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsupp.Signature.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationUploadPokemonParam.Signature. %s", err.Error())
 	}
 

--- a/datastore/pokemon-gen6/types/global_trade_station_data.go
+++ b/datastore/pokemon-gen6/types/global_trade_station_data.go
@@ -37,35 +37,27 @@ func (gtsd GlobalTradeStationData) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the GlobalTradeStationData from the given readable
 func (gtsd *GlobalTradeStationData) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsd.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsd.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationData header. %s", err.Error())
 	}
 
-	err = gtsd.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsd.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationData.DataID. %s", err.Error())
 	}
 
-	err = gtsd.OwnerID.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsd.OwnerID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationData.OwnerID. %s", err.Error())
 	}
 
-	err = gtsd.UpdatedTime.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsd.UpdatedTime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationData.UpdatedTime. %s", err.Error())
 	}
 
-	err = gtsd.IndexData.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsd.IndexData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationData.IndexData. %s", err.Error())
 	}
 
-	err = gtsd.Version.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsd.Version.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationData.Version. %s", err.Error())
 	}
 

--- a/datastore/pokemon-gen6/types/global_trade_station_delete_pokemon_param.go
+++ b/datastore/pokemon-gen6/types/global_trade_station_delete_pokemon_param.go
@@ -31,20 +31,15 @@ func (gtsdpp GlobalTradeStationDeletePokemonParam) WriteTo(writable types.Writab
 
 // ExtractFrom extracts the GlobalTradeStationDeletePokemonParam from the given readable
 func (gtsdpp *GlobalTradeStationDeletePokemonParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsdpp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsdpp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDeletePokemonParam header. %s", err.Error())
 	}
 
-	err = gtsdpp.PrepareUploadKey.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsdpp.PrepareUploadKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDeletePokemonParam.PrepareUploadKey. %s", err.Error())
 	}
 
-	err = gtsdpp.DeleteFlag.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsdpp.DeleteFlag.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDeletePokemonParam.DeleteFlag. %s", err.Error())
 	}
 

--- a/datastore/pokemon-gen6/types/global_trade_station_download_my_pokemon_param.go
+++ b/datastore/pokemon-gen6/types/global_trade_station_download_my_pokemon_param.go
@@ -29,15 +29,11 @@ func (gtsdmpp GlobalTradeStationDownloadMyPokemonParam) WriteTo(writable types.W
 
 // ExtractFrom extracts the GlobalTradeStationDownloadMyPokemonParam from the given readable
 func (gtsdmpp *GlobalTradeStationDownloadMyPokemonParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsdmpp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsdmpp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDownloadMyPokemonParam header. %s", err.Error())
 	}
 
-	err = gtsdmpp.PrepareUploadKey.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsdmpp.PrepareUploadKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDownloadMyPokemonParam.PrepareUploadKey. %s", err.Error())
 	}
 

--- a/datastore/pokemon-gen6/types/global_trade_station_download_my_pokemon_result.go
+++ b/datastore/pokemon-gen6/types/global_trade_station_download_my_pokemon_result.go
@@ -31,20 +31,15 @@ func (gtsdmpr GlobalTradeStationDownloadMyPokemonResult) WriteTo(writable types.
 
 // ExtractFrom extracts the GlobalTradeStationDownloadMyPokemonResult from the given readable
 func (gtsdmpr *GlobalTradeStationDownloadMyPokemonResult) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsdmpr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsdmpr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDownloadMyPokemonResult header. %s", err.Error())
 	}
 
-	err = gtsdmpr.Result.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsdmpr.Result.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDownloadMyPokemonResult.Result. %s", err.Error())
 	}
 
-	err = gtsdmpr.IsTraded.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsdmpr.IsTraded.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDownloadMyPokemonResult.IsTraded. %s", err.Error())
 	}
 

--- a/datastore/pokemon-gen6/types/global_trade_station_download_other_pokemon_param.go
+++ b/datastore/pokemon-gen6/types/global_trade_station_download_other_pokemon_param.go
@@ -29,15 +29,11 @@ func (gtsdopp GlobalTradeStationDownloadOtherPokemonParam) WriteTo(writable type
 
 // ExtractFrom extracts the GlobalTradeStationDownloadOtherPokemonParam from the given readable
 func (gtsdopp *GlobalTradeStationDownloadOtherPokemonParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsdopp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsdopp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDownloadOtherPokemonParam header. %s", err.Error())
 	}
 
-	err = gtsdopp.PrepareUploadKey.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsdopp.PrepareUploadKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDownloadOtherPokemonParam.PrepareUploadKey. %s", err.Error())
 	}
 

--- a/datastore/pokemon-gen6/types/global_trade_station_download_pokemon_result.go
+++ b/datastore/pokemon-gen6/types/global_trade_station_download_pokemon_result.go
@@ -33,25 +33,19 @@ func (gtsdpr GlobalTradeStationDownloadPokemonResult) WriteTo(writable types.Wri
 
 // ExtractFrom extracts the GlobalTradeStationDownloadPokemonResult from the given readable
 func (gtsdpr *GlobalTradeStationDownloadPokemonResult) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsdpr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsdpr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDownloadPokemonResult header. %s", err.Error())
 	}
 
-	err = gtsdpr.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsdpr.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDownloadPokemonResult.DataID. %s", err.Error())
 	}
 
-	err = gtsdpr.IndexData.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsdpr.IndexData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDownloadPokemonResult.IndexData. %s", err.Error())
 	}
 
-	err = gtsdpr.PokemonData.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsdpr.PokemonData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationDownloadPokemonResult.PokemonData. %s", err.Error())
 	}
 

--- a/datastore/pokemon-gen6/types/global_trade_station_prepare_trade_pokemon_param.go
+++ b/datastore/pokemon-gen6/types/global_trade_station_prepare_trade_pokemon_param.go
@@ -31,20 +31,15 @@ func (gtsptpp GlobalTradeStationPrepareTradePokemonParam) WriteTo(writable types
 
 // ExtractFrom extracts the GlobalTradeStationPrepareTradePokemonParam from the given readable
 func (gtsptpp *GlobalTradeStationPrepareTradePokemonParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsptpp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsptpp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationPrepareTradePokemonParam header. %s", err.Error())
 	}
 
-	err = gtsptpp.TradeKey.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsptpp.TradeKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationPrepareTradePokemonParam.TradeKey. %s", err.Error())
 	}
 
-	err = gtsptpp.PrepareUploadKey.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsptpp.PrepareUploadKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationPrepareTradePokemonParam.PrepareUploadKey. %s", err.Error())
 	}
 

--- a/datastore/pokemon-gen6/types/global_trade_station_prepare_trade_pokemon_result.go
+++ b/datastore/pokemon-gen6/types/global_trade_station_prepare_trade_pokemon_result.go
@@ -31,20 +31,15 @@ func (gtsptpr GlobalTradeStationPrepareTradePokemonResult) WriteTo(writable type
 
 // ExtractFrom extracts the GlobalTradeStationPrepareTradePokemonResult from the given readable
 func (gtsptpr *GlobalTradeStationPrepareTradePokemonResult) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsptpr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsptpr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationPrepareTradePokemonResult header. %s", err.Error())
 	}
 
-	err = gtsptpr.Result.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsptpr.Result.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationPrepareTradePokemonResult.Result. %s", err.Error())
 	}
 
-	err = gtsptpr.PrepareTradeKey.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsptpr.PrepareTradeKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationPrepareTradePokemonResult.PrepareTradeKey. %s", err.Error())
 	}
 

--- a/datastore/pokemon-gen6/types/global_trade_station_record_key.go
+++ b/datastore/pokemon-gen6/types/global_trade_station_record_key.go
@@ -31,20 +31,15 @@ func (gtsrk GlobalTradeStationRecordKey) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the GlobalTradeStationRecordKey from the given readable
 func (gtsrk *GlobalTradeStationRecordKey) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsrk.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsrk.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationRecordKey header. %s", err.Error())
 	}
 
-	err = gtsrk.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsrk.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationRecordKey.DataID. %s", err.Error())
 	}
 
-	err = gtsrk.Password.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsrk.Password.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationRecordKey.Password. %s", err.Error())
 	}
 

--- a/datastore/pokemon-gen6/types/global_trade_station_search_pokemon_param.go
+++ b/datastore/pokemon-gen6/types/global_trade_station_search_pokemon_param.go
@@ -41,45 +41,35 @@ func (gtsspp GlobalTradeStationSearchPokemonParam) WriteTo(writable types.Writab
 
 // ExtractFrom extracts the GlobalTradeStationSearchPokemonParam from the given readable
 func (gtsspp *GlobalTradeStationSearchPokemonParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsspp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsspp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonParam header. %s", err.Error())
 	}
 
-	err = gtsspp.PrepareUploadKey.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsspp.PrepareUploadKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonParam.PrepareUploadKey. %s", err.Error())
 	}
 
-	err = gtsspp.Conditions.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsspp.Conditions.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonParam.Conditions. %s", err.Error())
 	}
 
-	err = gtsspp.ResultOrderColumn.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsspp.ResultOrderColumn.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonParam.ResultOrderColumn. %s", err.Error())
 	}
 
-	err = gtsspp.ResultOrder.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsspp.ResultOrder.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonParam.ResultOrder. %s", err.Error())
 	}
 
-	err = gtsspp.UploadedAfter.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsspp.UploadedAfter.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonParam.UploadedAfter. %s", err.Error())
 	}
 
-	err = gtsspp.UploadedBefore.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsspp.UploadedBefore.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonParam.UploadedBefore. %s", err.Error())
 	}
 
-	err = gtsspp.ResultRange.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsspp.ResultRange.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonParam.ResultRange. %s", err.Error())
 	}
 

--- a/datastore/pokemon-gen6/types/global_trade_station_search_pokemon_result.go
+++ b/datastore/pokemon-gen6/types/global_trade_station_search_pokemon_result.go
@@ -33,25 +33,19 @@ func (gtsspr GlobalTradeStationSearchPokemonResult) WriteTo(writable types.Writa
 
 // ExtractFrom extracts the GlobalTradeStationSearchPokemonResult from the given readable
 func (gtsspr *GlobalTradeStationSearchPokemonResult) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsspr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsspr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonResult header. %s", err.Error())
 	}
 
-	err = gtsspr.TotalCount.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsspr.TotalCount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonResult.TotalCount. %s", err.Error())
 	}
 
-	err = gtsspr.Result.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsspr.Result.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonResult.Result. %s", err.Error())
 	}
 
-	err = gtsspr.TotalCountType.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsspr.TotalCountType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationSearchPokemonResult.TotalCountType. %s", err.Error())
 	}
 

--- a/datastore/pokemon-gen6/types/global_trade_station_trade_key.go
+++ b/datastore/pokemon-gen6/types/global_trade_station_trade_key.go
@@ -31,20 +31,15 @@ func (gtstk GlobalTradeStationTradeKey) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the GlobalTradeStationTradeKey from the given readable
 func (gtstk *GlobalTradeStationTradeKey) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtstk.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtstk.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradeKey header. %s", err.Error())
 	}
 
-	err = gtstk.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstk.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradeKey.DataID. %s", err.Error())
 	}
 
-	err = gtstk.Version.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstk.Version.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradeKey.Version. %s", err.Error())
 	}
 

--- a/datastore/pokemon-gen6/types/global_trade_station_trade_pokemon_param.go
+++ b/datastore/pokemon-gen6/types/global_trade_station_trade_pokemon_param.go
@@ -43,50 +43,39 @@ func (gtstpp GlobalTradeStationTradePokemonParam) WriteTo(writable types.Writabl
 
 // ExtractFrom extracts the GlobalTradeStationTradePokemonParam from the given readable
 func (gtstpp *GlobalTradeStationTradePokemonParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtstpp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtstpp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonParam header. %s", err.Error())
 	}
 
-	err = gtstpp.TradeKey.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstpp.TradeKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonParam.TradeKey. %s", err.Error())
 	}
 
-	err = gtstpp.PrepareTradeKey.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstpp.PrepareTradeKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonParam.PrepareTradeKey. %s", err.Error())
 	}
 
-	err = gtstpp.PrepareUploadKey.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstpp.PrepareUploadKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonParam.PrepareUploadKey. %s", err.Error())
 	}
 
-	err = gtstpp.Period.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstpp.Period.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonParam.Period. %s", err.Error())
 	}
 
-	err = gtstpp.IndexData.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstpp.IndexData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonParam.IndexData. %s", err.Error())
 	}
 
-	err = gtstpp.PokemonData.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstpp.PokemonData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonParam.PokemonData. %s", err.Error())
 	}
 
-	err = gtstpp.Signature.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstpp.Signature.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonParam.Signature. %s", err.Error())
 	}
 
-	err = gtstpp.NeedData.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstpp.NeedData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonParam.NeedData. %s", err.Error())
 	}
 

--- a/datastore/pokemon-gen6/types/global_trade_station_trade_pokemon_result.go
+++ b/datastore/pokemon-gen6/types/global_trade_station_trade_pokemon_result.go
@@ -31,20 +31,15 @@ func (gtstpr GlobalTradeStationTradePokemonResult) WriteTo(writable types.Writab
 
 // ExtractFrom extracts the GlobalTradeStationTradePokemonResult from the given readable
 func (gtstpr *GlobalTradeStationTradePokemonResult) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtstpr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtstpr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonResult header. %s", err.Error())
 	}
 
-	err = gtstpr.Result.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstpr.Result.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonResult.Result. %s", err.Error())
 	}
 
-	err = gtstpr.MyDataID.ExtractFrom(readable)
-	if err != nil {
+	if err := gtstpr.MyDataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationTradePokemonResult.MyDataID. %s", err.Error())
 	}
 

--- a/datastore/pokemon-gen6/types/global_trade_station_upload_pokemon_param.go
+++ b/datastore/pokemon-gen6/types/global_trade_station_upload_pokemon_param.go
@@ -37,35 +37,27 @@ func (gtsupp GlobalTradeStationUploadPokemonParam) WriteTo(writable types.Writab
 
 // ExtractFrom extracts the GlobalTradeStationUploadPokemonParam from the given readable
 func (gtsupp *GlobalTradeStationUploadPokemonParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gtsupp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gtsupp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationUploadPokemonParam header. %s", err.Error())
 	}
 
-	err = gtsupp.PrepareUploadKey.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsupp.PrepareUploadKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationUploadPokemonParam.PrepareUploadKey. %s", err.Error())
 	}
 
-	err = gtsupp.Period.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsupp.Period.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationUploadPokemonParam.Period. %s", err.Error())
 	}
 
-	err = gtsupp.IndexData.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsupp.IndexData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationUploadPokemonParam.IndexData. %s", err.Error())
 	}
 
-	err = gtsupp.PokemonData.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsupp.PokemonData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationUploadPokemonParam.PokemonData. %s", err.Error())
 	}
 
-	err = gtsupp.Signature.ExtractFrom(readable)
-	if err != nil {
+	if err := gtsupp.Signature.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GlobalTradeStationUploadPokemonParam.Signature. %s", err.Error())
 	}
 

--- a/datastore/super-mario-maker/types/buffer_queue_param.go
+++ b/datastore/super-mario-maker/types/buffer_queue_param.go
@@ -31,20 +31,15 @@ func (bqp BufferQueueParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the BufferQueueParam from the given readable
 func (bqp *BufferQueueParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = bqp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := bqp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract BufferQueueParam header. %s", err.Error())
 	}
 
-	err = bqp.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := bqp.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract BufferQueueParam.DataID. %s", err.Error())
 	}
 
-	err = bqp.Slot.ExtractFrom(readable)
-	if err != nil {
+	if err := bqp.Slot.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract BufferQueueParam.Slot. %s", err.Error())
 	}
 

--- a/datastore/super-mario-maker/types/datastore_attach_file_param.go
+++ b/datastore/super-mario-maker/types/datastore_attach_file_param.go
@@ -34,25 +34,19 @@ func (dsafp DataStoreAttachFileParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreAttachFileParam from the given readable
 func (dsafp *DataStoreAttachFileParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsafp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsafp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreAttachFileParam header. %s", err.Error())
 	}
 
-	err = dsafp.PostParam.ExtractFrom(readable)
-	if err != nil {
+	if err := dsafp.PostParam.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreAttachFileParam.PostParam. %s", err.Error())
 	}
 
-	err = dsafp.ReferDataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsafp.ReferDataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreAttachFileParam.ReferDataID. %s", err.Error())
 	}
 
-	err = dsafp.ContentType.ExtractFrom(readable)
-	if err != nil {
+	if err := dsafp.ContentType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreAttachFileParam.ContentType. %s", err.Error())
 	}
 

--- a/datastore/super-mario-maker/types/datastore_change_playable_platform_param.go
+++ b/datastore/super-mario-maker/types/datastore_change_playable_platform_param.go
@@ -31,20 +31,15 @@ func (dscppp DataStoreChangePlayablePlatformParam) WriteTo(writable types.Writab
 
 // ExtractFrom extracts the DataStoreChangePlayablePlatformParam from the given readable
 func (dscppp *DataStoreChangePlayablePlatformParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dscppp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dscppp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangePlayablePlatformParam header. %s", err.Error())
 	}
 
-	err = dscppp.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dscppp.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangePlayablePlatformParam.DataID. %s", err.Error())
 	}
 
-	err = dscppp.PlayablePlatform.ExtractFrom(readable)
-	if err != nil {
+	if err := dscppp.PlayablePlatform.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangePlayablePlatformParam.PlayablePlatform. %s", err.Error())
 	}
 

--- a/datastore/super-mario-maker/types/datastore_custom_ranking_rating_condition.go
+++ b/datastore/super-mario-maker/types/datastore_custom_ranking_rating_condition.go
@@ -43,38 +43,30 @@ func (dscrrc DataStoreCustomRankingRatingCondition) WriteTo(writable types.Writa
 
 // ExtractFrom extracts the DataStoreCustomRankingRatingCondition from the given readable
 func (dscrrc *DataStoreCustomRankingRatingCondition) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dscrrc.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dscrrc.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCustomRankingRatingCondition header. %s", err.Error())
 	}
 
-	err = dscrrc.Slot.ExtractFrom(readable)
-	if err != nil {
+	if err := dscrrc.Slot.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCustomRankingRatingCondition.Slot. %s", err.Error())
 	}
 
-	err = dscrrc.MinValue.ExtractFrom(readable)
-	if err != nil {
+	if err := dscrrc.MinValue.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCustomRankingRatingCondition.MinValue. %s", err.Error())
 	}
 
-	err = dscrrc.MaxValue.ExtractFrom(readable)
-	if err != nil {
+	if err := dscrrc.MaxValue.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCustomRankingRatingCondition.MaxValue. %s", err.Error())
 	}
 
 	if dscrrc.StructureVersion >= 1 {
-		err = dscrrc.MinCount.ExtractFrom(readable)
-		if err != nil {
+		if err := dscrrc.MinCount.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract DataStoreCustomRankingRatingCondition.MinCount. %s", err.Error())
 		}
 	}
 
 	if dscrrc.StructureVersion >= 1 {
-		err = dscrrc.MaxCount.ExtractFrom(readable)
-		if err != nil {
+		if err := dscrrc.MaxCount.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract DataStoreCustomRankingRatingCondition.MaxCount. %s", err.Error())
 		}
 	}

--- a/datastore/super-mario-maker/types/datastore_custom_ranking_result.go
+++ b/datastore/super-mario-maker/types/datastore_custom_ranking_result.go
@@ -34,25 +34,19 @@ func (dscrr DataStoreCustomRankingResult) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreCustomRankingResult from the given readable
 func (dscrr *DataStoreCustomRankingResult) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dscrr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dscrr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCustomRankingResult header. %s", err.Error())
 	}
 
-	err = dscrr.Order.ExtractFrom(readable)
-	if err != nil {
+	if err := dscrr.Order.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCustomRankingResult.Order. %s", err.Error())
 	}
 
-	err = dscrr.Score.ExtractFrom(readable)
-	if err != nil {
+	if err := dscrr.Score.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCustomRankingResult.Score. %s", err.Error())
 	}
 
-	err = dscrr.MetaInfo.ExtractFrom(readable)
-	if err != nil {
+	if err := dscrr.MetaInfo.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCustomRankingResult.MetaInfo. %s", err.Error())
 	}
 

--- a/datastore/super-mario-maker/types/datastore_file_server_object_info.go
+++ b/datastore/super-mario-maker/types/datastore_file_server_object_info.go
@@ -32,20 +32,15 @@ func (dsfsoi DataStoreFileServerObjectInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreFileServerObjectInfo from the given readable
 func (dsfsoi *DataStoreFileServerObjectInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsfsoi.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsfsoi.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreFileServerObjectInfo header. %s", err.Error())
 	}
 
-	err = dsfsoi.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsfsoi.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreFileServerObjectInfo.DataID. %s", err.Error())
 	}
 
-	err = dsfsoi.GetInfo.ExtractFrom(readable)
-	if err != nil {
+	if err := dsfsoi.GetInfo.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreFileServerObjectInfo.GetInfo. %s", err.Error())
 	}
 

--- a/datastore/super-mario-maker/types/datastore_get_course_record_param.go
+++ b/datastore/super-mario-maker/types/datastore_get_course_record_param.go
@@ -31,20 +31,15 @@ func (dsgcrp DataStoreGetCourseRecordParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreGetCourseRecordParam from the given readable
 func (dsgcrp *DataStoreGetCourseRecordParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsgcrp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsgcrp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetCourseRecordParam header. %s", err.Error())
 	}
 
-	err = dsgcrp.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgcrp.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetCourseRecordParam.DataID. %s", err.Error())
 	}
 
-	err = dsgcrp.Slot.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgcrp.Slot.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetCourseRecordParam.Slot. %s", err.Error())
 	}
 

--- a/datastore/super-mario-maker/types/datastore_get_course_record_result.go
+++ b/datastore/super-mario-maker/types/datastore_get_course_record_result.go
@@ -41,45 +41,35 @@ func (dsgcrr DataStoreGetCourseRecordResult) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreGetCourseRecordResult from the given readable
 func (dsgcrr *DataStoreGetCourseRecordResult) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsgcrr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsgcrr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetCourseRecordResult header. %s", err.Error())
 	}
 
-	err = dsgcrr.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgcrr.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetCourseRecordResult.DataID. %s", err.Error())
 	}
 
-	err = dsgcrr.Slot.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgcrr.Slot.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetCourseRecordResult.Slot. %s", err.Error())
 	}
 
-	err = dsgcrr.FirstPID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgcrr.FirstPID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetCourseRecordResult.FirstPID. %s", err.Error())
 	}
 
-	err = dsgcrr.BestPID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgcrr.BestPID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetCourseRecordResult.BestPID. %s", err.Error())
 	}
 
-	err = dsgcrr.BestScore.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgcrr.BestScore.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetCourseRecordResult.BestScore. %s", err.Error())
 	}
 
-	err = dsgcrr.CreatedTime.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgcrr.CreatedTime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetCourseRecordResult.CreatedTime. %s", err.Error())
 	}
 
-	err = dsgcrr.UpdatedTime.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgcrr.UpdatedTime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetCourseRecordResult.UpdatedTime. %s", err.Error())
 	}
 

--- a/datastore/super-mario-maker/types/datastore_get_custom_ranking_by_data_id_param.go
+++ b/datastore/super-mario-maker/types/datastore_get_custom_ranking_by_data_id_param.go
@@ -33,25 +33,19 @@ func (dsgcrbdidp DataStoreGetCustomRankingByDataIDParam) WriteTo(writable types.
 
 // ExtractFrom extracts the DataStoreGetCustomRankingByDataIDParam from the given readable
 func (dsgcrbdidp *DataStoreGetCustomRankingByDataIDParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsgcrbdidp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsgcrbdidp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetCustomRankingByDataIDParam header. %s", err.Error())
 	}
 
-	err = dsgcrbdidp.ApplicationID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgcrbdidp.ApplicationID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetCustomRankingByDataIDParam.ApplicationID. %s", err.Error())
 	}
 
-	err = dsgcrbdidp.DataIDList.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgcrbdidp.DataIDList.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetCustomRankingByDataIDParam.DataIDList. %s", err.Error())
 	}
 
-	err = dsgcrbdidp.ResultOption.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgcrbdidp.ResultOption.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetCustomRankingByDataIDParam.ResultOption. %s", err.Error())
 	}
 

--- a/datastore/super-mario-maker/types/datastore_get_custom_ranking_param.go
+++ b/datastore/super-mario-maker/types/datastore_get_custom_ranking_param.go
@@ -35,30 +35,23 @@ func (dsgcrp DataStoreGetCustomRankingParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreGetCustomRankingParam from the given readable
 func (dsgcrp *DataStoreGetCustomRankingParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsgcrp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsgcrp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetCustomRankingParam header. %s", err.Error())
 	}
 
-	err = dsgcrp.ApplicationID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgcrp.ApplicationID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetCustomRankingParam.ApplicationID. %s", err.Error())
 	}
 
-	err = dsgcrp.Condition.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgcrp.Condition.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetCustomRankingParam.Condition. %s", err.Error())
 	}
 
-	err = dsgcrp.ResultOption.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgcrp.ResultOption.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetCustomRankingParam.ResultOption. %s", err.Error())
 	}
 
-	err = dsgcrp.ResultRange.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgcrp.ResultRange.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetCustomRankingParam.ResultRange. %s", err.Error())
 	}
 

--- a/datastore/super-mario-maker/types/datastore_get_meta_by_owner_id_param.go
+++ b/datastore/super-mario-maker/types/datastore_get_meta_by_owner_id_param.go
@@ -35,30 +35,23 @@ func (dsgmboidp DataStoreGetMetaByOwnerIDParam) WriteTo(writable types.Writable)
 
 // ExtractFrom extracts the DataStoreGetMetaByOwnerIDParam from the given readable
 func (dsgmboidp *DataStoreGetMetaByOwnerIDParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsgmboidp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsgmboidp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetMetaByOwnerIDParam header. %s", err.Error())
 	}
 
-	err = dsgmboidp.OwnerIDs.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgmboidp.OwnerIDs.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetMetaByOwnerIDParam.OwnerIDs. %s", err.Error())
 	}
 
-	err = dsgmboidp.DataTypes.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgmboidp.DataTypes.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetMetaByOwnerIDParam.DataTypes. %s", err.Error())
 	}
 
-	err = dsgmboidp.ResultOption.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgmboidp.ResultOption.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetMetaByOwnerIDParam.ResultOption. %s", err.Error())
 	}
 
-	err = dsgmboidp.ResultRange.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgmboidp.ResultRange.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetMetaByOwnerIDParam.ResultRange. %s", err.Error())
 	}
 

--- a/datastore/super-mario-maker/types/datastore_rate_custom_ranking_param.go
+++ b/datastore/super-mario-maker/types/datastore_rate_custom_ranking_param.go
@@ -35,30 +35,23 @@ func (dsrcrp DataStoreRateCustomRankingParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreRateCustomRankingParam from the given readable
 func (dsrcrp *DataStoreRateCustomRankingParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsrcrp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsrcrp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRateCustomRankingParam header. %s", err.Error())
 	}
 
-	err = dsrcrp.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrcrp.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRateCustomRankingParam.DataID. %s", err.Error())
 	}
 
-	err = dsrcrp.ApplicationID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrcrp.ApplicationID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRateCustomRankingParam.ApplicationID. %s", err.Error())
 	}
 
-	err = dsrcrp.Score.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrcrp.Score.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRateCustomRankingParam.Score. %s", err.Error())
 	}
 
-	err = dsrcrp.Period.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrcrp.Period.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRateCustomRankingParam.Period. %s", err.Error())
 	}
 

--- a/datastore/super-mario-maker/types/datastore_report_course_param.go
+++ b/datastore/super-mario-maker/types/datastore_report_course_param.go
@@ -35,30 +35,23 @@ func (dsrcp DataStoreReportCourseParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreReportCourseParam from the given readable
 func (dsrcp *DataStoreReportCourseParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsrcp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsrcp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReportCourseParam header. %s", err.Error())
 	}
 
-	err = dsrcp.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrcp.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReportCourseParam.DataID. %s", err.Error())
 	}
 
-	err = dsrcp.MiiName.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrcp.MiiName.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReportCourseParam.MiiName. %s", err.Error())
 	}
 
-	err = dsrcp.ReportCategory.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrcp.ReportCategory.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReportCourseParam.ReportCategory. %s", err.Error())
 	}
 
-	err = dsrcp.ReportReason.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrcp.ReportReason.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReportCourseParam.ReportReason. %s", err.Error())
 	}
 

--- a/datastore/super-mario-maker/types/datastore_upload_course_record_param.go
+++ b/datastore/super-mario-maker/types/datastore_upload_course_record_param.go
@@ -33,25 +33,19 @@ func (dsucrp DataStoreUploadCourseRecordParam) WriteTo(writable types.Writable) 
 
 // ExtractFrom extracts the DataStoreUploadCourseRecordParam from the given readable
 func (dsucrp *DataStoreUploadCourseRecordParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsucrp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsucrp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreUploadCourseRecordParam header. %s", err.Error())
 	}
 
-	err = dsucrp.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsucrp.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreUploadCourseRecordParam.DataID. %s", err.Error())
 	}
 
-	err = dsucrp.Slot.ExtractFrom(readable)
-	if err != nil {
+	if err := dsucrp.Slot.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreUploadCourseRecordParam.Slot. %s", err.Error())
 	}
 
-	err = dsucrp.Score.ExtractFrom(readable)
-	if err != nil {
+	if err := dsucrp.Score.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreUploadCourseRecordParam.Score. %s", err.Error())
 	}
 

--- a/datastore/super-smash-bros-4/types/datastore_complete_post_replay_param.go
+++ b/datastore/super-smash-bros-4/types/datastore_complete_post_replay_param.go
@@ -34,25 +34,19 @@ func (dscprp DataStoreCompletePostReplayParam) WriteTo(writable types.Writable) 
 
 // ExtractFrom extracts the DataStoreCompletePostReplayParam from the given readable
 func (dscprp *DataStoreCompletePostReplayParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dscprp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dscprp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCompletePostReplayParam header. %s", err.Error())
 	}
 
-	err = dscprp.ReplayID.ExtractFrom(readable)
-	if err != nil {
+	if err := dscprp.ReplayID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCompletePostReplayParam.ReplayID. %s", err.Error())
 	}
 
-	err = dscprp.CompleteParam.ExtractFrom(readable)
-	if err != nil {
+	if err := dscprp.CompleteParam.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCompletePostReplayParam.CompleteParam. %s", err.Error())
 	}
 
-	err = dscprp.PrepareParam.ExtractFrom(readable)
-	if err != nil {
+	if err := dscprp.PrepareParam.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCompletePostReplayParam.PrepareParam. %s", err.Error())
 	}
 

--- a/datastore/super-smash-bros-4/types/datastore_complete_post_shared_data_param.go
+++ b/datastore/super-smash-bros-4/types/datastore_complete_post_shared_data_param.go
@@ -34,25 +34,19 @@ func (dscpsdp DataStoreCompletePostSharedDataParam) WriteTo(writable types.Writa
 
 // ExtractFrom extracts the DataStoreCompletePostSharedDataParam from the given readable
 func (dscpsdp *DataStoreCompletePostSharedDataParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dscpsdp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dscpsdp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCompletePostSharedDataParam header. %s", err.Error())
 	}
 
-	err = dscpsdp.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dscpsdp.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCompletePostSharedDataParam.DataID. %s", err.Error())
 	}
 
-	err = dscpsdp.CompleteParam.ExtractFrom(readable)
-	if err != nil {
+	if err := dscpsdp.CompleteParam.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCompletePostSharedDataParam.CompleteParam. %s", err.Error())
 	}
 
-	err = dscpsdp.PrepareParam.ExtractFrom(readable)
-	if err != nil {
+	if err := dscpsdp.PrepareParam.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCompletePostSharedDataParam.PrepareParam. %s", err.Error())
 	}
 

--- a/datastore/super-smash-bros-4/types/datastore_fighting_power_chart.go
+++ b/datastore/super-smash-bros-4/types/datastore_fighting_power_chart.go
@@ -31,20 +31,15 @@ func (dsfpc DataStoreFightingPowerChart) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreFightingPowerChart from the given readable
 func (dsfpc *DataStoreFightingPowerChart) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsfpc.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsfpc.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreFightingPowerChart header. %s", err.Error())
 	}
 
-	err = dsfpc.UserNum.ExtractFrom(readable)
-	if err != nil {
+	if err := dsfpc.UserNum.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreFightingPowerChart.UserNum. %s", err.Error())
 	}
 
-	err = dsfpc.Chart.ExtractFrom(readable)
-	if err != nil {
+	if err := dsfpc.Chart.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreFightingPowerChart.Chart. %s", err.Error())
 	}
 

--- a/datastore/super-smash-bros-4/types/datastore_fighting_power_score.go
+++ b/datastore/super-smash-bros-4/types/datastore_fighting_power_score.go
@@ -31,20 +31,15 @@ func (dsfps DataStoreFightingPowerScore) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreFightingPowerScore from the given readable
 func (dsfps *DataStoreFightingPowerScore) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsfps.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsfps.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreFightingPowerScore header. %s", err.Error())
 	}
 
-	err = dsfps.Score.ExtractFrom(readable)
-	if err != nil {
+	if err := dsfps.Score.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreFightingPowerScore.Score. %s", err.Error())
 	}
 
-	err = dsfps.Rank.ExtractFrom(readable)
-	if err != nil {
+	if err := dsfps.Rank.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreFightingPowerScore.Rank. %s", err.Error())
 	}
 

--- a/datastore/super-smash-bros-4/types/datastore_file_object_server_info.go
+++ b/datastore/super-smash-bros-4/types/datastore_file_object_server_info.go
@@ -32,20 +32,15 @@ func (dsfsoi DataStoreFileServerObjectInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreFileServerObjectInfo from the given readable
 func (dsfsoi *DataStoreFileServerObjectInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsfsoi.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsfsoi.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreFileServerObjectInfo header. %s", err.Error())
 	}
 
-	err = dsfsoi.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsfsoi.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreFileServerObjectInfo.DataID. %s", err.Error())
 	}
 
-	err = dsfsoi.GetInfo.ExtractFrom(readable)
-	if err != nil {
+	if err := dsfsoi.GetInfo.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreFileServerObjectInfo.GetInfo. %s", err.Error())
 	}
 

--- a/datastore/super-smash-bros-4/types/datastore_get_replay_meta_param.go
+++ b/datastore/super-smash-bros-4/types/datastore_get_replay_meta_param.go
@@ -31,20 +31,15 @@ func (dsgrmp DataStoreGetReplayMetaParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreGetReplayMetaParam from the given readable
 func (dsgrmp *DataStoreGetReplayMetaParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsgrmp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsgrmp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetReplayMetaParam header. %s", err.Error())
 	}
 
-	err = dsgrmp.ReplayID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgrmp.ReplayID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetReplayMetaParam.ReplayID. %s", err.Error())
 	}
 
-	err = dsgrmp.MetaType.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgrmp.MetaType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetReplayMetaParam.MetaType. %s", err.Error())
 	}
 

--- a/datastore/super-smash-bros-4/types/datastore_post_fighting_power_score_param.go
+++ b/datastore/super-smash-bros-4/types/datastore_post_fighting_power_score_param.go
@@ -33,25 +33,19 @@ func (dspfpsp DataStorePostFightingPowerScoreParam) WriteTo(writable types.Writa
 
 // ExtractFrom extracts the DataStorePostFightingPowerScoreParam from the given readable
 func (dspfpsp *DataStorePostFightingPowerScoreParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dspfpsp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dspfpsp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePostFightingPowerScoreParam header. %s", err.Error())
 	}
 
-	err = dspfpsp.Mode.ExtractFrom(readable)
-	if err != nil {
+	if err := dspfpsp.Mode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePostFightingPowerScoreParam.Mode. %s", err.Error())
 	}
 
-	err = dspfpsp.Score.ExtractFrom(readable)
-	if err != nil {
+	if err := dspfpsp.Score.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePostFightingPowerScoreParam.Score. %s", err.Error())
 	}
 
-	err = dspfpsp.IsWorldHighScore.ExtractFrom(readable)
-	if err != nil {
+	if err := dspfpsp.IsWorldHighScore.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePostFightingPowerScoreParam.IsWorldHighScore. %s", err.Error())
 	}
 

--- a/datastore/super-smash-bros-4/types/datastore_post_profile_param.go
+++ b/datastore/super-smash-bros-4/types/datastore_post_profile_param.go
@@ -29,15 +29,11 @@ func (dsppp DataStorePostProfileParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStorePostProfileParam from the given readable
 func (dsppp *DataStorePostProfileParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsppp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsppp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePostProfileParam header. %s", err.Error())
 	}
 
-	err = dsppp.Profile.ExtractFrom(readable)
-	if err != nil {
+	if err := dsppp.Profile.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePostProfileParam.Profile. %s", err.Error())
 	}
 

--- a/datastore/super-smash-bros-4/types/datastore_prepare_get_replay_param.go
+++ b/datastore/super-smash-bros-4/types/datastore_prepare_get_replay_param.go
@@ -31,20 +31,15 @@ func (dspgrp DataStorePrepareGetReplayParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStorePrepareGetReplayParam from the given readable
 func (dspgrp *DataStorePrepareGetReplayParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dspgrp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dspgrp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePrepareGetReplayParam header. %s", err.Error())
 	}
 
-	err = dspgrp.ReplayID.ExtractFrom(readable)
-	if err != nil {
+	if err := dspgrp.ReplayID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePrepareGetReplayParam.ReplayID. %s", err.Error())
 	}
 
-	err = dspgrp.ExtraData.ExtractFrom(readable)
-	if err != nil {
+	if err := dspgrp.ExtraData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePrepareGetReplayParam.ExtraData. %s", err.Error())
 	}
 

--- a/datastore/super-smash-bros-4/types/datastore_prepare_post_replay_param.go
+++ b/datastore/super-smash-bros-4/types/datastore_prepare_post_replay_param.go
@@ -51,70 +51,55 @@ func (dspprp DataStorePreparePostReplayParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStorePreparePostReplayParam from the given readable
 func (dspprp *DataStorePreparePostReplayParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dspprp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dspprp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostReplayParam header. %s", err.Error())
 	}
 
-	err = dspprp.Size.ExtractFrom(readable)
-	if err != nil {
+	if err := dspprp.Size.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostReplayParam.Size. %s", err.Error())
 	}
 
-	err = dspprp.Mode.ExtractFrom(readable)
-	if err != nil {
+	if err := dspprp.Mode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostReplayParam.Mode. %s", err.Error())
 	}
 
-	err = dspprp.Style.ExtractFrom(readable)
-	if err != nil {
+	if err := dspprp.Style.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostReplayParam.Style. %s", err.Error())
 	}
 
-	err = dspprp.Rule.ExtractFrom(readable)
-	if err != nil {
+	if err := dspprp.Rule.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostReplayParam.Rule. %s", err.Error())
 	}
 
-	err = dspprp.Stage.ExtractFrom(readable)
-	if err != nil {
+	if err := dspprp.Stage.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostReplayParam.Stage. %s", err.Error())
 	}
 
-	err = dspprp.ReplayType.ExtractFrom(readable)
-	if err != nil {
+	if err := dspprp.ReplayType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostReplayParam.ReplayType. %s", err.Error())
 	}
 
-	err = dspprp.CompetitionID.ExtractFrom(readable)
-	if err != nil {
+	if err := dspprp.CompetitionID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostReplayParam.CompetitionID. %s", err.Error())
 	}
 
-	err = dspprp.Score.ExtractFrom(readable)
-	if err != nil {
+	if err := dspprp.Score.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostReplayParam.Score. %s", err.Error())
 	}
 
-	err = dspprp.Players.ExtractFrom(readable)
-	if err != nil {
+	if err := dspprp.Players.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostReplayParam.Players. %s", err.Error())
 	}
 
-	err = dspprp.Winners.ExtractFrom(readable)
-	if err != nil {
+	if err := dspprp.Winners.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostReplayParam.Winners. %s", err.Error())
 	}
 
-	err = dspprp.KeyVersion.ExtractFrom(readable)
-	if err != nil {
+	if err := dspprp.KeyVersion.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostReplayParam.KeyVersion. %s", err.Error())
 	}
 
-	err = dspprp.ExtraData.ExtractFrom(readable)
-	if err != nil {
+	if err := dspprp.ExtraData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostReplayParam.ExtraData. %s", err.Error())
 	}
 

--- a/datastore/super-smash-bros-4/types/datastore_prepare_post_shared_data_param.go
+++ b/datastore/super-smash-bros-4/types/datastore_prepare_post_shared_data_param.go
@@ -45,55 +45,43 @@ func (dsppsdp DataStorePreparePostSharedDataParam) WriteTo(writable types.Writab
 
 // ExtractFrom extracts the DataStorePreparePostSharedDataParam from the given readable
 func (dsppsdp *DataStorePreparePostSharedDataParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsppsdp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsppsdp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostSharedDataParam header. %s", err.Error())
 	}
 
-	err = dsppsdp.DataType.ExtractFrom(readable)
-	if err != nil {
+	if err := dsppsdp.DataType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostSharedDataParam.DataType. %s", err.Error())
 	}
 
-	err = dsppsdp.Region.ExtractFrom(readable)
-	if err != nil {
+	if err := dsppsdp.Region.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostSharedDataParam.Region. %s", err.Error())
 	}
 
-	err = dsppsdp.Attribute1.ExtractFrom(readable)
-	if err != nil {
+	if err := dsppsdp.Attribute1.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostSharedDataParam.Attribute1. %s", err.Error())
 	}
 
-	err = dsppsdp.Attribute2.ExtractFrom(readable)
-	if err != nil {
+	if err := dsppsdp.Attribute2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostSharedDataParam.Attribute2. %s", err.Error())
 	}
 
-	err = dsppsdp.Fighter.ExtractFrom(readable)
-	if err != nil {
+	if err := dsppsdp.Fighter.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostSharedDataParam.Fighter. %s", err.Error())
 	}
 
-	err = dsppsdp.Size.ExtractFrom(readable)
-	if err != nil {
+	if err := dsppsdp.Size.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostSharedDataParam.Size. %s", err.Error())
 	}
 
-	err = dsppsdp.Comment.ExtractFrom(readable)
-	if err != nil {
+	if err := dsppsdp.Comment.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostSharedDataParam.Comment. %s", err.Error())
 	}
 
-	err = dsppsdp.MetaBinary.ExtractFrom(readable)
-	if err != nil {
+	if err := dsppsdp.MetaBinary.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostSharedDataParam.MetaBinary. %s", err.Error())
 	}
 
-	err = dsppsdp.ExtraData.ExtractFrom(readable)
-	if err != nil {
+	if err := dsppsdp.ExtraData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostSharedDataParam.ExtraData. %s", err.Error())
 	}
 

--- a/datastore/super-smash-bros-4/types/datastore_profile_info.go
+++ b/datastore/super-smash-bros-4/types/datastore_profile_info.go
@@ -31,20 +31,15 @@ func (dspi DataStoreProfileInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreProfileInfo from the given readable
 func (dspi *DataStoreProfileInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dspi.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dspi.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreProfileInfo header. %s", err.Error())
 	}
 
-	err = dspi.PID.ExtractFrom(readable)
-	if err != nil {
+	if err := dspi.PID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreProfileInfo.PID. %s", err.Error())
 	}
 
-	err = dspi.Profile.ExtractFrom(readable)
-	if err != nil {
+	if err := dspi.Profile.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreProfileInfo.Profile. %s", err.Error())
 	}
 

--- a/datastore/super-smash-bros-4/types/datastore_replay_meta_info.go
+++ b/datastore/super-smash-bros-4/types/datastore_replay_meta_info.go
@@ -45,55 +45,43 @@ func (dsrmi DataStoreReplayMetaInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreReplayMetaInfo from the given readable
 func (dsrmi *DataStoreReplayMetaInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsrmi.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsrmi.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReplayMetaInfo header. %s", err.Error())
 	}
 
-	err = dsrmi.ReplayID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrmi.ReplayID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReplayMetaInfo.ReplayID. %s", err.Error())
 	}
 
-	err = dsrmi.Size.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrmi.Size.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReplayMetaInfo.Size. %s", err.Error())
 	}
 
-	err = dsrmi.Mode.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrmi.Mode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReplayMetaInfo.Mode. %s", err.Error())
 	}
 
-	err = dsrmi.Style.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrmi.Style.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReplayMetaInfo.Style. %s", err.Error())
 	}
 
-	err = dsrmi.Rule.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrmi.Rule.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReplayMetaInfo.Rule. %s", err.Error())
 	}
 
-	err = dsrmi.Stage.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrmi.Stage.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReplayMetaInfo.Stage. %s", err.Error())
 	}
 
-	err = dsrmi.ReplayType.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrmi.ReplayType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReplayMetaInfo.ReplayType. %s", err.Error())
 	}
 
-	err = dsrmi.Players.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrmi.Players.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReplayMetaInfo.Players. %s", err.Error())
 	}
 
-	err = dsrmi.Winners.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrmi.Winners.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReplayMetaInfo.Winners. %s", err.Error())
 	}
 

--- a/datastore/super-smash-bros-4/types/datastore_replay_player.go
+++ b/datastore/super-smash-bros-4/types/datastore_replay_player.go
@@ -45,55 +45,43 @@ func (dsrp DataStoreReplayPlayer) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreReplayPlayer from the given readable
 func (dsrp *DataStoreReplayPlayer) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsrp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsrp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReplayPlayer header. %s", err.Error())
 	}
 
-	err = dsrp.Fighter.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrp.Fighter.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReplayPlayer.Fighter. %s", err.Error())
 	}
 
-	err = dsrp.Health.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrp.Health.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReplayPlayer.Health. %s", err.Error())
 	}
 
-	err = dsrp.WinningRate.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrp.WinningRate.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReplayPlayer.WinningRate. %s", err.Error())
 	}
 
-	err = dsrp.Color.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrp.Color.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReplayPlayer.Color. %s", err.Error())
 	}
 
-	err = dsrp.Color2.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrp.Color2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReplayPlayer.Color2. %s", err.Error())
 	}
 
-	err = dsrp.PrincipalID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrp.PrincipalID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReplayPlayer.PrincipalID. %s", err.Error())
 	}
 
-	err = dsrp.Country.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrp.Country.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReplayPlayer.Country. %s", err.Error())
 	}
 
-	err = dsrp.Region.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrp.Region.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReplayPlayer.Region. %s", err.Error())
 	}
 
-	err = dsrp.Number.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrp.Number.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReplayPlayer.Number. %s", err.Error())
 	}
 

--- a/datastore/super-smash-bros-4/types/datastore_search_replay_param.go
+++ b/datastore/super-smash-bros-4/types/datastore_search_replay_param.go
@@ -35,30 +35,23 @@ func (dssrp DataStoreSearchReplayParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreSearchReplayParam from the given readable
 func (dssrp *DataStoreSearchReplayParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dssrp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dssrp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchReplayParam header. %s", err.Error())
 	}
 
-	err = dssrp.Mode.ExtractFrom(readable)
-	if err != nil {
+	if err := dssrp.Mode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchReplayParam.Mode. %s", err.Error())
 	}
 
-	err = dssrp.Style.ExtractFrom(readable)
-	if err != nil {
+	if err := dssrp.Style.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchReplayParam.Style. %s", err.Error())
 	}
 
-	err = dssrp.Fighter.ExtractFrom(readable)
-	if err != nil {
+	if err := dssrp.Fighter.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchReplayParam.Fighter. %s", err.Error())
 	}
 
-	err = dssrp.ResultRange.ExtractFrom(readable)
-	if err != nil {
+	if err := dssrp.ResultRange.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchReplayParam.ResultRange. %s", err.Error())
 	}
 

--- a/datastore/super-smash-bros-4/types/datastore_search_shared_data_param.go
+++ b/datastore/super-smash-bros-4/types/datastore_search_shared_data_param.go
@@ -41,45 +41,35 @@ func (dsssdp DataStoreSearchSharedDataParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreSearchSharedDataParam from the given readable
 func (dsssdp *DataStoreSearchSharedDataParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsssdp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsssdp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchSharedDataParam header. %s", err.Error())
 	}
 
-	err = dsssdp.DataType.ExtractFrom(readable)
-	if err != nil {
+	if err := dsssdp.DataType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchSharedDataParam.DataType. %s", err.Error())
 	}
 
-	err = dsssdp.Owner.ExtractFrom(readable)
-	if err != nil {
+	if err := dsssdp.Owner.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchSharedDataParam.Owner. %s", err.Error())
 	}
 
-	err = dsssdp.Region.ExtractFrom(readable)
-	if err != nil {
+	if err := dsssdp.Region.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchSharedDataParam.Region. %s", err.Error())
 	}
 
-	err = dsssdp.Attribute1.ExtractFrom(readable)
-	if err != nil {
+	if err := dsssdp.Attribute1.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchSharedDataParam.Attribute1. %s", err.Error())
 	}
 
-	err = dsssdp.Attribute2.ExtractFrom(readable)
-	if err != nil {
+	if err := dsssdp.Attribute2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchSharedDataParam.Attribute2. %s", err.Error())
 	}
 
-	err = dsssdp.Fighter.ExtractFrom(readable)
-	if err != nil {
+	if err := dsssdp.Fighter.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchSharedDataParam.Fighter. %s", err.Error())
 	}
 
-	err = dsssdp.ResultRange.ExtractFrom(readable)
-	if err != nil {
+	if err := dsssdp.ResultRange.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchSharedDataParam.ResultRange. %s", err.Error())
 	}
 

--- a/datastore/super-smash-bros-4/types/datastore_shared_data_info.go
+++ b/datastore/super-smash-bros-4/types/datastore_shared_data_info.go
@@ -45,55 +45,43 @@ func (dssdi DataStoreSharedDataInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreSharedDataInfo from the given readable
 func (dssdi *DataStoreSharedDataInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dssdi.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dssdi.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSharedDataInfo header. %s", err.Error())
 	}
 
-	err = dssdi.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dssdi.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSharedDataInfo.DataID. %s", err.Error())
 	}
 
-	err = dssdi.OwnerID.ExtractFrom(readable)
-	if err != nil {
+	if err := dssdi.OwnerID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSharedDataInfo.OwnerID. %s", err.Error())
 	}
 
-	err = dssdi.DataType.ExtractFrom(readable)
-	if err != nil {
+	if err := dssdi.DataType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSharedDataInfo.DataType. %s", err.Error())
 	}
 
-	err = dssdi.Comment.ExtractFrom(readable)
-	if err != nil {
+	if err := dssdi.Comment.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSharedDataInfo.Comment. %s", err.Error())
 	}
 
-	err = dssdi.MetaBinary.ExtractFrom(readable)
-	if err != nil {
+	if err := dssdi.MetaBinary.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSharedDataInfo.MetaBinary. %s", err.Error())
 	}
 
-	err = dssdi.Profile.ExtractFrom(readable)
-	if err != nil {
+	if err := dssdi.Profile.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSharedDataInfo.Profile. %s", err.Error())
 	}
 
-	err = dssdi.Rating.ExtractFrom(readable)
-	if err != nil {
+	if err := dssdi.Rating.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSharedDataInfo.Rating. %s", err.Error())
 	}
 
-	err = dssdi.CreatedTime.ExtractFrom(readable)
-	if err != nil {
+	if err := dssdi.CreatedTime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSharedDataInfo.CreatedTime. %s", err.Error())
 	}
 
-	err = dssdi.Info.ExtractFrom(readable)
-	if err != nil {
+	if err := dssdi.Info.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSharedDataInfo.Info. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_change_meta_compare_param.go
+++ b/datastore/types/datastore_change_meta_compare_param.go
@@ -48,60 +48,47 @@ func (dscmcp DataStoreChangeMetaCompareParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreChangeMetaCompareParam from the given readable
 func (dscmcp *DataStoreChangeMetaCompareParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dscmcp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dscmcp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaCompareParam header. %s", err.Error())
 	}
 
-	err = dscmcp.ComparisonFlag.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmcp.ComparisonFlag.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaCompareParam.ComparisonFlag. %s", err.Error())
 	}
 
-	err = dscmcp.Name.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmcp.Name.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaCompareParam.Name. %s", err.Error())
 	}
 
-	err = dscmcp.Permission.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmcp.Permission.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaCompareParam.Permission. %s", err.Error())
 	}
 
-	err = dscmcp.DelPermission.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmcp.DelPermission.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaCompareParam.DelPermission. %s", err.Error())
 	}
 
-	err = dscmcp.Period.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmcp.Period.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaCompareParam.Period. %s", err.Error())
 	}
 
-	err = dscmcp.MetaBinary.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmcp.MetaBinary.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaCompareParam.MetaBinary. %s", err.Error())
 	}
 
-	err = dscmcp.Tags.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmcp.Tags.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaCompareParam.Tags. %s", err.Error())
 	}
 
-	err = dscmcp.ReferredCnt.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmcp.ReferredCnt.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaCompareParam.ReferredCnt. %s", err.Error())
 	}
 
-	err = dscmcp.DataType.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmcp.DataType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaCompareParam.DataType. %s", err.Error())
 	}
 
-	err = dscmcp.Status.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmcp.Status.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaCompareParam.Status. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_change_meta_param.go
+++ b/datastore/types/datastore_change_meta_param.go
@@ -59,81 +59,64 @@ func (dscmp DataStoreChangeMetaParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreChangeMetaParam from the given readable
 func (dscmp *DataStoreChangeMetaParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dscmp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dscmp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParam header. %s", err.Error())
 	}
 
-	err = dscmp.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmp.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParam.DataID. %s", err.Error())
 	}
 
-	err = dscmp.ModifiesFlag.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmp.ModifiesFlag.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParam.ModifiesFlag. %s", err.Error())
 	}
 
-	err = dscmp.Name.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmp.Name.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParam.Name. %s", err.Error())
 	}
 
-	err = dscmp.Permission.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmp.Permission.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParam.Permission. %s", err.Error())
 	}
 
-	err = dscmp.DelPermission.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmp.DelPermission.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParam.DelPermission. %s", err.Error())
 	}
 
-	err = dscmp.Period.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmp.Period.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParam.Period. %s", err.Error())
 	}
 
-	err = dscmp.MetaBinary.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmp.MetaBinary.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParam.MetaBinary. %s", err.Error())
 	}
 
-	err = dscmp.Tags.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmp.Tags.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParam.Tags. %s", err.Error())
 	}
 
-	err = dscmp.UpdatePassword.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmp.UpdatePassword.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParam.UpdatePassword. %s", err.Error())
 	}
 
-	err = dscmp.ReferredCnt.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmp.ReferredCnt.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParam.ReferredCnt. %s", err.Error())
 	}
 
-	err = dscmp.DataType.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmp.DataType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParam.DataType. %s", err.Error())
 	}
 
-	err = dscmp.Status.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmp.Status.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParam.Status. %s", err.Error())
 	}
 
-	err = dscmp.CompareParam.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmp.CompareParam.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParam.CompareParam. %s", err.Error())
 	}
 
 	if dscmp.StructureVersion >= 1 {
-		err = dscmp.PersistenceTarget.ExtractFrom(readable)
-		if err != nil {
+		if err := dscmp.PersistenceTarget.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract DataStoreChangeMetaParam.PersistenceTarget. %s", err.Error())
 		}
 	}

--- a/datastore/types/datastore_change_meta_param_v1.go
+++ b/datastore/types/datastore_change_meta_param_v1.go
@@ -46,55 +46,43 @@ func (dscmpv DataStoreChangeMetaParamV1) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreChangeMetaParamV1 from the given readable
 func (dscmpv *DataStoreChangeMetaParamV1) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dscmpv.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dscmpv.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParamV1 header. %s", err.Error())
 	}
 
-	err = dscmpv.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmpv.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParamV1.DataID. %s", err.Error())
 	}
 
-	err = dscmpv.ModifiesFlag.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmpv.ModifiesFlag.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParamV1.ModifiesFlag. %s", err.Error())
 	}
 
-	err = dscmpv.Name.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmpv.Name.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParamV1.Name. %s", err.Error())
 	}
 
-	err = dscmpv.Permission.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmpv.Permission.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParamV1.Permission. %s", err.Error())
 	}
 
-	err = dscmpv.DelPermission.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmpv.DelPermission.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParamV1.DelPermission. %s", err.Error())
 	}
 
-	err = dscmpv.Period.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmpv.Period.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParamV1.Period. %s", err.Error())
 	}
 
-	err = dscmpv.MetaBinary.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmpv.MetaBinary.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParamV1.MetaBinary. %s", err.Error())
 	}
 
-	err = dscmpv.Tags.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmpv.Tags.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParamV1.Tags. %s", err.Error())
 	}
 
-	err = dscmpv.UpdatePassword.ExtractFrom(readable)
-	if err != nil {
+	if err := dscmpv.UpdatePassword.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreChangeMetaParamV1.UpdatePassword. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_complete_post_param.go
+++ b/datastore/types/datastore_complete_post_param.go
@@ -31,20 +31,15 @@ func (dscpp DataStoreCompletePostParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreCompletePostParam from the given readable
 func (dscpp *DataStoreCompletePostParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dscpp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dscpp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCompletePostParam header. %s", err.Error())
 	}
 
-	err = dscpp.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dscpp.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCompletePostParam.DataID. %s", err.Error())
 	}
 
-	err = dscpp.IsSuccess.ExtractFrom(readable)
-	if err != nil {
+	if err := dscpp.IsSuccess.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCompletePostParam.IsSuccess. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_complete_post_param_v1.go
+++ b/datastore/types/datastore_complete_post_param_v1.go
@@ -31,20 +31,15 @@ func (dscppv DataStoreCompletePostParamV1) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreCompletePostParamV1 from the given readable
 func (dscppv *DataStoreCompletePostParamV1) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dscppv.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dscppv.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCompletePostParamV1 header. %s", err.Error())
 	}
 
-	err = dscppv.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dscppv.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCompletePostParamV1.DataID. %s", err.Error())
 	}
 
-	err = dscppv.IsSuccess.ExtractFrom(readable)
-	if err != nil {
+	if err := dscppv.IsSuccess.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCompletePostParamV1.IsSuccess. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_complete_update_param.go
+++ b/datastore/types/datastore_complete_update_param.go
@@ -50,16 +50,12 @@ func (dscup *DataStoreCompleteUpdateParam) ExtractFrom(readable types.Readable) 
 	stream := readable.(*nex.ByteStreamIn)
 	libraryVersion := stream.LibraryVersions.DataStore
 
-	var err error
-
-	err = dscup.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dscup.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCompleteUpdateParam header. %s", err.Error())
 	}
 
 	if libraryVersion.GreaterOrEqual("3.0.0") {
-		err = dscup.DataID.ExtractFrom(readable)
-		if err != nil {
+		if err := dscup.DataID.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract DataStoreCompleteUpdateParam.DataID. %s", err.Error())
 		}
 	} else {
@@ -72,8 +68,7 @@ func (dscup *DataStoreCompleteUpdateParam) ExtractFrom(readable types.Readable) 
 	}
 
 	if libraryVersion.GreaterOrEqual("3.0.0") {
-		err = dscup.Version.ExtractFrom(readable)
-		if err != nil {
+		if err := dscup.Version.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract DataStoreCompleteUpdateParam.Version. %s", err.Error())
 		}
 	} else {
@@ -85,8 +80,7 @@ func (dscup *DataStoreCompleteUpdateParam) ExtractFrom(readable types.Readable) 
 		dscup.Version = types.UInt32(version)
 	}
 
-	err = dscup.IsSuccess.ExtractFrom(readable)
-	if err != nil {
+	if err := dscup.IsSuccess.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreCompleteUpdateParam.IsSuccess. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_delete_param.go
+++ b/datastore/types/datastore_delete_param.go
@@ -31,20 +31,15 @@ func (dsdp DataStoreDeleteParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreDeleteParam from the given readable
 func (dsdp *DataStoreDeleteParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsdp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsdp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreDeleteParam header. %s", err.Error())
 	}
 
-	err = dsdp.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsdp.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreDeleteParam.DataID. %s", err.Error())
 	}
 
-	err = dsdp.UpdatePassword.ExtractFrom(readable)
-	if err != nil {
+	if err := dsdp.UpdatePassword.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreDeleteParam.UpdatePassword. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_get_meta_param.go
+++ b/datastore/types/datastore_get_meta_param.go
@@ -36,30 +36,23 @@ func (dsgmp DataStoreGetMetaParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreGetMetaParam from the given readable
 func (dsgmp *DataStoreGetMetaParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsgmp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsgmp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetMetaParam header. %s", err.Error())
 	}
 
-	err = dsgmp.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgmp.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetMetaParam.DataID. %s", err.Error())
 	}
 
-	err = dsgmp.PersistenceTarget.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgmp.PersistenceTarget.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetMetaParam.PersistenceTarget. %s", err.Error())
 	}
 
-	err = dsgmp.ResultOption.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgmp.ResultOption.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetMetaParam.ResultOption. %s", err.Error())
 	}
 
-	err = dsgmp.AccessPassword.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgmp.AccessPassword.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetMetaParam.AccessPassword. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_get_new_arrived_notifications_param.go
+++ b/datastore/types/datastore_get_new_arrived_notifications_param.go
@@ -31,20 +31,15 @@ func (dsgnanp DataStoreGetNewArrivedNotificationsParam) WriteTo(writable types.W
 
 // ExtractFrom extracts the DataStoreGetNewArrivedNotificationsParam from the given readable
 func (dsgnanp *DataStoreGetNewArrivedNotificationsParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsgnanp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsgnanp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetNewArrivedNotificationsParam header. %s", err.Error())
 	}
 
-	err = dsgnanp.LastNotificationID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgnanp.LastNotificationID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetNewArrivedNotificationsParam.LastNotificationID. %s", err.Error())
 	}
 
-	err = dsgnanp.Limit.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgnanp.Limit.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetNewArrivedNotificationsParam.Limit. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_get_notification_url_param.go
+++ b/datastore/types/datastore_get_notification_url_param.go
@@ -29,15 +29,11 @@ func (dsgnurlp DataStoreGetNotificationURLParam) WriteTo(writable types.Writable
 
 // ExtractFrom extracts the DataStoreGetNotificationURLParam from the given readable
 func (dsgnurlp *DataStoreGetNotificationURLParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsgnurlp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsgnurlp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetNotificationURLParam header. %s", err.Error())
 	}
 
-	err = dsgnurlp.PreviousURL.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgnurlp.PreviousURL.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetNotificationURLParam.PreviousURL. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_get_specific_meta_param.go
+++ b/datastore/types/datastore_get_specific_meta_param.go
@@ -29,15 +29,11 @@ func (dsgsmp DataStoreGetSpecificMetaParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreGetSpecificMetaParam from the given readable
 func (dsgsmp *DataStoreGetSpecificMetaParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsgsmp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsgsmp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetSpecificMetaParam header. %s", err.Error())
 	}
 
-	err = dsgsmp.DataIDs.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgsmp.DataIDs.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetSpecificMetaParam.DataIDs. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_get_specific_meta_param_v1.go
+++ b/datastore/types/datastore_get_specific_meta_param_v1.go
@@ -29,15 +29,11 @@ func (dsgsmpv DataStoreGetSpecificMetaParamV1) WriteTo(writable types.Writable) 
 
 // ExtractFrom extracts the DataStoreGetSpecificMetaParamV1 from the given readable
 func (dsgsmpv *DataStoreGetSpecificMetaParamV1) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsgsmpv.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsgsmpv.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetSpecificMetaParamV1 header. %s", err.Error())
 	}
 
-	err = dsgsmpv.DataIDs.ExtractFrom(readable)
-	if err != nil {
+	if err := dsgsmpv.DataIDs.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreGetSpecificMetaParamV1.DataIDs. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_key_value.go
+++ b/datastore/types/datastore_key_value.go
@@ -31,20 +31,15 @@ func (dskv DataStoreKeyValue) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreKeyValue from the given readable
 func (dskv *DataStoreKeyValue) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dskv.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dskv.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreKeyValue header. %s", err.Error())
 	}
 
-	err = dskv.Key.ExtractFrom(readable)
-	if err != nil {
+	if err := dskv.Key.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreKeyValue.Key. %s", err.Error())
 	}
 
-	err = dskv.Value.ExtractFrom(readable)
-	if err != nil {
+	if err := dskv.Value.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreKeyValue.Value. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_meta_info.go
+++ b/datastore/types/datastore_meta_info.go
@@ -66,105 +66,83 @@ func (dsmi DataStoreMetaInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreMetaInfo from the given readable
 func (dsmi *DataStoreMetaInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsmi.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsmi.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreMetaInfo header. %s", err.Error())
 	}
 
-	err = dsmi.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsmi.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreMetaInfo.DataID. %s", err.Error())
 	}
 
-	err = dsmi.OwnerID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsmi.OwnerID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreMetaInfo.OwnerID. %s", err.Error())
 	}
 
-	err = dsmi.Size.ExtractFrom(readable)
-	if err != nil {
+	if err := dsmi.Size.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreMetaInfo.Size. %s", err.Error())
 	}
 
-	err = dsmi.Name.ExtractFrom(readable)
-	if err != nil {
+	if err := dsmi.Name.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreMetaInfo.Name. %s", err.Error())
 	}
 
-	err = dsmi.DataType.ExtractFrom(readable)
-	if err != nil {
+	if err := dsmi.DataType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreMetaInfo.DataType. %s", err.Error())
 	}
 
-	err = dsmi.MetaBinary.ExtractFrom(readable)
-	if err != nil {
+	if err := dsmi.MetaBinary.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreMetaInfo.MetaBinary. %s", err.Error())
 	}
 
-	err = dsmi.Permission.ExtractFrom(readable)
-	if err != nil {
+	if err := dsmi.Permission.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreMetaInfo.Permission. %s", err.Error())
 	}
 
-	err = dsmi.DelPermission.ExtractFrom(readable)
-	if err != nil {
+	if err := dsmi.DelPermission.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreMetaInfo.DelPermission. %s", err.Error())
 	}
 
-	err = dsmi.CreatedTime.ExtractFrom(readable)
-	if err != nil {
+	if err := dsmi.CreatedTime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreMetaInfo.CreatedTime. %s", err.Error())
 	}
 
-	err = dsmi.UpdatedTime.ExtractFrom(readable)
-	if err != nil {
+	if err := dsmi.UpdatedTime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreMetaInfo.UpdatedTime. %s", err.Error())
 	}
 
-	err = dsmi.Period.ExtractFrom(readable)
-	if err != nil {
+	if err := dsmi.Period.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreMetaInfo.Period. %s", err.Error())
 	}
 
-	err = dsmi.Status.ExtractFrom(readable)
-	if err != nil {
+	if err := dsmi.Status.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreMetaInfo.Status. %s", err.Error())
 	}
 
-	err = dsmi.ReferredCnt.ExtractFrom(readable)
-	if err != nil {
+	if err := dsmi.ReferredCnt.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreMetaInfo.ReferredCnt. %s", err.Error())
 	}
 
-	err = dsmi.ReferDataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsmi.ReferDataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreMetaInfo.ReferDataID. %s", err.Error())
 	}
 
-	err = dsmi.Flag.ExtractFrom(readable)
-	if err != nil {
+	if err := dsmi.Flag.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreMetaInfo.Flag. %s", err.Error())
 	}
 
-	err = dsmi.ReferredTime.ExtractFrom(readable)
-	if err != nil {
+	if err := dsmi.ReferredTime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreMetaInfo.ReferredTime. %s", err.Error())
 	}
 
-	err = dsmi.ExpireTime.ExtractFrom(readable)
-	if err != nil {
+	if err := dsmi.ExpireTime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreMetaInfo.ExpireTime. %s", err.Error())
 	}
 
-	err = dsmi.Tags.ExtractFrom(readable)
-	if err != nil {
+	if err := dsmi.Tags.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreMetaInfo.Tags. %s", err.Error())
 	}
 
-	err = dsmi.Ratings.ExtractFrom(readable)
-	if err != nil {
+	if err := dsmi.Ratings.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreMetaInfo.Ratings. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_notification.go
+++ b/datastore/types/datastore_notification.go
@@ -31,20 +31,15 @@ func (dsn DataStoreNotification) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreNotification from the given readable
 func (dsn *DataStoreNotification) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsn.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsn.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreNotification header. %s", err.Error())
 	}
 
-	err = dsn.NotificationID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsn.NotificationID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreNotification.NotificationID. %s", err.Error())
 	}
 
-	err = dsn.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsn.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreNotification.DataID. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_notification_v1.go
+++ b/datastore/types/datastore_notification_v1.go
@@ -31,20 +31,15 @@ func (dsnv DataStoreNotificationV1) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreNotificationV1 from the given readable
 func (dsnv *DataStoreNotificationV1) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsnv.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsnv.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreNotificationV1 header. %s", err.Error())
 	}
 
-	err = dsnv.NotificationID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsnv.NotificationID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreNotificationV1.NotificationID. %s", err.Error())
 	}
 
-	err = dsnv.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsnv.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreNotificationV1.DataID. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_password_info.go
+++ b/datastore/types/datastore_password_info.go
@@ -33,25 +33,19 @@ func (dspi DataStorePasswordInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStorePasswordInfo from the given readable
 func (dspi *DataStorePasswordInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dspi.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dspi.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePasswordInfo header. %s", err.Error())
 	}
 
-	err = dspi.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dspi.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePasswordInfo.DataID. %s", err.Error())
 	}
 
-	err = dspi.AccessPassword.ExtractFrom(readable)
-	if err != nil {
+	if err := dspi.AccessPassword.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePasswordInfo.AccessPassword. %s", err.Error())
 	}
 
-	err = dspi.UpdatePassword.ExtractFrom(readable)
-	if err != nil {
+	if err := dspi.UpdatePassword.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePasswordInfo.UpdatePassword. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_permission.go
+++ b/datastore/types/datastore_permission.go
@@ -32,20 +32,15 @@ func (dsp DataStorePermission) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStorePermission from the given readable
 func (dsp *DataStorePermission) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePermission header. %s", err.Error())
 	}
 
-	err = dsp.Permission.ExtractFrom(readable)
-	if err != nil {
+	if err := dsp.Permission.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePermission.Permission. %s", err.Error())
 	}
 
-	err = dsp.RecipientIDs.ExtractFrom(readable)
-	if err != nil {
+	if err := dsp.RecipientIDs.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePermission.RecipientIDs. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_persistence_info.go
+++ b/datastore/types/datastore_persistence_info.go
@@ -33,25 +33,19 @@ func (dspi DataStorePersistenceInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStorePersistenceInfo from the given readable
 func (dspi *DataStorePersistenceInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dspi.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dspi.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePersistenceInfo header. %s", err.Error())
 	}
 
-	err = dspi.OwnerID.ExtractFrom(readable)
-	if err != nil {
+	if err := dspi.OwnerID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePersistenceInfo.OwnerID. %s", err.Error())
 	}
 
-	err = dspi.PersistenceSlotID.ExtractFrom(readable)
-	if err != nil {
+	if err := dspi.PersistenceSlotID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePersistenceInfo.PersistenceSlotID. %s", err.Error())
 	}
 
-	err = dspi.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dspi.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePersistenceInfo.DataID. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_persistence_init_param.go
+++ b/datastore/types/datastore_persistence_init_param.go
@@ -31,20 +31,15 @@ func (dspip DataStorePersistenceInitParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStorePersistenceInitParam from the given readable
 func (dspip *DataStorePersistenceInitParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dspip.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dspip.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePersistenceInitParam header. %s", err.Error())
 	}
 
-	err = dspip.PersistenceSlotID.ExtractFrom(readable)
-	if err != nil {
+	if err := dspip.PersistenceSlotID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePersistenceInitParam.PersistenceSlotID. %s", err.Error())
 	}
 
-	err = dspip.DeleteLastObject.ExtractFrom(readable)
-	if err != nil {
+	if err := dspip.DeleteLastObject.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePersistenceInitParam.DeleteLastObject. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_persistence_target.go
+++ b/datastore/types/datastore_persistence_target.go
@@ -31,20 +31,15 @@ func (dspt DataStorePersistenceTarget) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStorePersistenceTarget from the given readable
 func (dspt *DataStorePersistenceTarget) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dspt.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dspt.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePersistenceTarget header. %s", err.Error())
 	}
 
-	err = dspt.OwnerID.ExtractFrom(readable)
-	if err != nil {
+	if err := dspt.OwnerID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePersistenceTarget.OwnerID. %s", err.Error())
 	}
 
-	err = dspt.PersistenceSlotID.ExtractFrom(readable)
-	if err != nil {
+	if err := dspt.PersistenceSlotID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePersistenceTarget.PersistenceSlotID. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_prepare_get_param.go
+++ b/datastore/types/datastore_prepare_get_param.go
@@ -47,36 +47,28 @@ func (dspgp *DataStorePrepareGetParam) ExtractFrom(readable types.Readable) erro
 	stream := readable.(*nex.ByteStreamIn)
 	libraryVersion := stream.LibraryVersions.DataStore
 
-	var err error
-
-	err = dspgp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dspgp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePrepareGetParam header. %s", err.Error())
 	}
 
-	err = dspgp.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dspgp.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePrepareGetParam.DataID. %s", err.Error())
 	}
 
-	err = dspgp.LockID.ExtractFrom(readable)
-	if err != nil {
+	if err := dspgp.LockID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePrepareGetParam.LockID. %s", err.Error())
 	}
 
-	err = dspgp.PersistenceTarget.ExtractFrom(readable)
-	if err != nil {
+	if err := dspgp.PersistenceTarget.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePrepareGetParam.PersistenceTarget. %s", err.Error())
 	}
 
-	err = dspgp.AccessPassword.ExtractFrom(readable)
-	if err != nil {
+	if err := dspgp.AccessPassword.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePrepareGetParam.AccessPassword. %s", err.Error())
 	}
 
 	if libraryVersion.GreaterOrEqual("3.5.0") {
-		err = dspgp.ExtraData.ExtractFrom(readable)
-		if err != nil {
+		if err := dspgp.ExtraData.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract DataStorePrepareGetParam.ExtraData. %s", err.Error())
 		}
 	}

--- a/datastore/types/datastore_prepare_get_param_v1.go
+++ b/datastore/types/datastore_prepare_get_param_v1.go
@@ -31,20 +31,15 @@ func (dspgpv DataStorePrepareGetParamV1) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStorePrepareGetParamV1 from the given readable
 func (dspgpv *DataStorePrepareGetParamV1) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dspgpv.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dspgpv.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePrepareGetParamV1 header. %s", err.Error())
 	}
 
-	err = dspgpv.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dspgpv.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePrepareGetParamV1.DataID. %s", err.Error())
 	}
 
-	err = dspgpv.LockID.ExtractFrom(readable)
-	if err != nil {
+	if err := dspgpv.LockID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePrepareGetParamV1.LockID. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_prepare_post_param.go
+++ b/datastore/types/datastore_prepare_post_param.go
@@ -64,76 +64,60 @@ func (dsppp *DataStorePreparePostParam) ExtractFrom(readable types.Readable) err
 	stream := readable.(*nex.ByteStreamIn)
 	libraryVersion := stream.LibraryVersions.DataStore
 
-	var err error
-
-	err = dsppp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsppp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParam header. %s", err.Error())
 	}
 
-	err = dsppp.Size.ExtractFrom(readable)
-	if err != nil {
+	if err := dsppp.Size.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParam.Size. %s", err.Error())
 	}
 
-	err = dsppp.Name.ExtractFrom(readable)
-	if err != nil {
+	if err := dsppp.Name.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParam.Name. %s", err.Error())
 	}
 
-	err = dsppp.DataType.ExtractFrom(readable)
-	if err != nil {
+	if err := dsppp.DataType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParam.DataType. %s", err.Error())
 	}
 
-	err = dsppp.MetaBinary.ExtractFrom(readable)
-	if err != nil {
+	if err := dsppp.MetaBinary.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParam.MetaBinary. %s", err.Error())
 	}
 
-	err = dsppp.Permission.ExtractFrom(readable)
-	if err != nil {
+	if err := dsppp.Permission.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParam.Permission. %s", err.Error())
 	}
 
-	err = dsppp.DelPermission.ExtractFrom(readable)
-	if err != nil {
+	if err := dsppp.DelPermission.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParam.DelPermission. %s", err.Error())
 	}
 
-	err = dsppp.Flag.ExtractFrom(readable)
-	if err != nil {
+	if err := dsppp.Flag.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParam.Flag. %s", err.Error())
 	}
 
-	err = dsppp.Period.ExtractFrom(readable)
-	if err != nil {
+	if err := dsppp.Period.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParam.Period. %s", err.Error())
 	}
 
-	err = dsppp.ReferDataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsppp.ReferDataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParam.ReferDataID. %s", err.Error())
 	}
 
-	err = dsppp.Tags.ExtractFrom(readable)
-	if err != nil {
+	if err := dsppp.Tags.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParam.Tags. %s", err.Error())
 	}
 
-	err = dsppp.RatingInitParams.ExtractFrom(readable)
-	if err != nil {
+	if err := dsppp.RatingInitParams.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParam.RatingInitParams. %s", err.Error())
 	}
 
-	err = dsppp.PersistenceInitParam.ExtractFrom(readable)
-	if err != nil {
+	if err := dsppp.PersistenceInitParam.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParam.PersistenceInitParam. %s", err.Error())
 	}
 
 	if libraryVersion.GreaterOrEqual("3.5.0") {
-		err = dsppp.ExtraData.ExtractFrom(readable)
-		if err != nil {
+		if err := dsppp.ExtraData.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract DataStorePreparePostParam.ExtraData. %s", err.Error())
 		}
 	}

--- a/datastore/types/datastore_prepare_post_param_v1.go
+++ b/datastore/types/datastore_prepare_post_param_v1.go
@@ -50,65 +50,51 @@ func (dspppv DataStorePreparePostParamV1) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStorePreparePostParamV1 from the given readable
 func (dspppv *DataStorePreparePostParamV1) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dspppv.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dspppv.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParamV1 header. %s", err.Error())
 	}
 
-	err = dspppv.Size.ExtractFrom(readable)
-	if err != nil {
+	if err := dspppv.Size.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParamV1.Size. %s", err.Error())
 	}
 
-	err = dspppv.Name.ExtractFrom(readable)
-	if err != nil {
+	if err := dspppv.Name.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParamV1.Name. %s", err.Error())
 	}
 
-	err = dspppv.DataType.ExtractFrom(readable)
-	if err != nil {
+	if err := dspppv.DataType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParamV1.DataType. %s", err.Error())
 	}
 
-	err = dspppv.MetaBinary.ExtractFrom(readable)
-	if err != nil {
+	if err := dspppv.MetaBinary.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParamV1.MetaBinary. %s", err.Error())
 	}
 
-	err = dspppv.Permission.ExtractFrom(readable)
-	if err != nil {
+	if err := dspppv.Permission.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParamV1.Permission. %s", err.Error())
 	}
 
-	err = dspppv.DelPermission.ExtractFrom(readable)
-	if err != nil {
+	if err := dspppv.DelPermission.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParamV1.DelPermission. %s", err.Error())
 	}
 
-	err = dspppv.Flag.ExtractFrom(readable)
-	if err != nil {
+	if err := dspppv.Flag.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParamV1.Flag. %s", err.Error())
 	}
 
-	err = dspppv.Period.ExtractFrom(readable)
-	if err != nil {
+	if err := dspppv.Period.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParamV1.Period. %s", err.Error())
 	}
 
-	err = dspppv.ReferDataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dspppv.ReferDataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParamV1.ReferDataID. %s", err.Error())
 	}
 
-	err = dspppv.Tags.ExtractFrom(readable)
-	if err != nil {
+	if err := dspppv.Tags.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParamV1.Tags. %s", err.Error())
 	}
 
-	err = dspppv.RatingInitParams.ExtractFrom(readable)
-	if err != nil {
+	if err := dspppv.RatingInitParams.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePreparePostParamV1.RatingInitParams. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_prepare_update_param.go
+++ b/datastore/types/datastore_prepare_update_param.go
@@ -53,16 +53,12 @@ func (dspup *DataStorePrepareUpdateParam) ExtractFrom(readable types.Readable) e
 	stream := readable.(*nex.ByteStreamIn)
 	libraryVersion := stream.LibraryVersions.DataStore
 
-	var err error
-
-	err = dspup.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dspup.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePrepareUpdateParam header. %s", err.Error())
 	}
 
 	if libraryVersion.GreaterOrEqual("3.0.0") {
-		err = dspup.DataID.ExtractFrom(readable)
-		if err != nil {
+		if err := dspup.DataID.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract DataStoreCompleteUpdateParam.DataID. %s", err.Error())
 		}
 	} else {
@@ -74,21 +70,18 @@ func (dspup *DataStorePrepareUpdateParam) ExtractFrom(readable types.Readable) e
 		dspup.DataID = types.UInt64(dataID)
 	}
 
-	err = dspup.Size.ExtractFrom(readable)
-	if err != nil {
+	if err := dspup.Size.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStorePrepareUpdateParam.Size. %s", err.Error())
 	}
 
 	if libraryVersion.GreaterOrEqual("3.0.0") {
-		err = dspup.UpdatePassword.ExtractFrom(readable)
-		if err != nil {
+		if err := dspup.UpdatePassword.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract DataStorePrepareUpdateParam.UpdatePassword. %s", err.Error())
 		}
 	}
 
 	if libraryVersion.GreaterOrEqual("3.5.0") {
-		err = dspup.ExtraData.ExtractFrom(readable)
-		if err != nil {
+		if err := dspup.ExtraData.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract DataStorePrepareUpdateParam.ExtraData. %s", err.Error())
 		}
 	}

--- a/datastore/types/datastore_rate_object_param.go
+++ b/datastore/types/datastore_rate_object_param.go
@@ -31,20 +31,15 @@ func (dsrop DataStoreRateObjectParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreRateObjectParam from the given readable
 func (dsrop *DataStoreRateObjectParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsrop.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsrop.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRateObjectParam header. %s", err.Error())
 	}
 
-	err = dsrop.RatingValue.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrop.RatingValue.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRateObjectParam.RatingValue. %s", err.Error())
 	}
 
-	err = dsrop.AccessPassword.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrop.AccessPassword.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRateObjectParam.AccessPassword. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_rating_info.go
+++ b/datastore/types/datastore_rating_info.go
@@ -33,25 +33,19 @@ func (dsri DataStoreRatingInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreRatingInfo from the given readable
 func (dsri *DataStoreRatingInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsri.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsri.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingInfo header. %s", err.Error())
 	}
 
-	err = dsri.TotalValue.ExtractFrom(readable)
-	if err != nil {
+	if err := dsri.TotalValue.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingInfo.TotalValue. %s", err.Error())
 	}
 
-	err = dsri.Count.ExtractFrom(readable)
-	if err != nil {
+	if err := dsri.Count.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingInfo.Count. %s", err.Error())
 	}
 
-	err = dsri.InitialValue.ExtractFrom(readable)
-	if err != nil {
+	if err := dsri.InitialValue.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingInfo.InitialValue. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_rating_info_with_slot.go
+++ b/datastore/types/datastore_rating_info_with_slot.go
@@ -31,20 +31,15 @@ func (dsriws DataStoreRatingInfoWithSlot) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreRatingInfoWithSlot from the given readable
 func (dsriws *DataStoreRatingInfoWithSlot) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsriws.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsriws.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingInfoWithSlot header. %s", err.Error())
 	}
 
-	err = dsriws.Slot.ExtractFrom(readable)
-	if err != nil {
+	if err := dsriws.Slot.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingInfoWithSlot.Slot. %s", err.Error())
 	}
 
-	err = dsriws.Rating.ExtractFrom(readable)
-	if err != nil {
+	if err := dsriws.Rating.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingInfoWithSlot.Rating. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_rating_init_param.go
+++ b/datastore/types/datastore_rating_init_param.go
@@ -44,50 +44,39 @@ func (dsrip DataStoreRatingInitParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreRatingInitParam from the given readable
 func (dsrip *DataStoreRatingInitParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsrip.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsrip.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingInitParam header. %s", err.Error())
 	}
 
-	err = dsrip.Flag.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrip.Flag.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingInitParam.Flag. %s", err.Error())
 	}
 
-	err = dsrip.InternalFlag.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrip.InternalFlag.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingInitParam.InternalFlag. %s", err.Error())
 	}
 
-	err = dsrip.LockType.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrip.LockType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingInitParam.LockType. %s", err.Error())
 	}
 
-	err = dsrip.InitialValue.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrip.InitialValue.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingInitParam.InitialValue. %s", err.Error())
 	}
 
-	err = dsrip.RangeMin.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrip.RangeMin.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingInitParam.RangeMin. %s", err.Error())
 	}
 
-	err = dsrip.RangeMax.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrip.RangeMax.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingInitParam.RangeMax. %s", err.Error())
 	}
 
-	err = dsrip.PeriodHour.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrip.PeriodHour.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingInitParam.PeriodHour. %s", err.Error())
 	}
 
-	err = dsrip.PeriodDuration.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrip.PeriodDuration.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingInitParam.PeriodDuration. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_rating_init_param_with_slot.go
+++ b/datastore/types/datastore_rating_init_param_with_slot.go
@@ -31,20 +31,15 @@ func (dsripws DataStoreRatingInitParamWithSlot) WriteTo(writable types.Writable)
 
 // ExtractFrom extracts the DataStoreRatingInitParamWithSlot from the given readable
 func (dsripws *DataStoreRatingInitParamWithSlot) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsripws.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsripws.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingInitParamWithSlot header. %s", err.Error())
 	}
 
-	err = dsripws.Slot.ExtractFrom(readable)
-	if err != nil {
+	if err := dsripws.Slot.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingInitParamWithSlot.Slot. %s", err.Error())
 	}
 
-	err = dsripws.Param.ExtractFrom(readable)
-	if err != nil {
+	if err := dsripws.Param.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingInitParamWithSlot.Param. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_rating_log.go
+++ b/datastore/types/datastore_rating_log.go
@@ -35,30 +35,23 @@ func (dsrl DataStoreRatingLog) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreRatingLog from the given readable
 func (dsrl *DataStoreRatingLog) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsrl.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsrl.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingLog header. %s", err.Error())
 	}
 
-	err = dsrl.IsRated.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrl.IsRated.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingLog.IsRated. %s", err.Error())
 	}
 
-	err = dsrl.PID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrl.PID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingLog.PID. %s", err.Error())
 	}
 
-	err = dsrl.RatingValue.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrl.RatingValue.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingLog.RatingValue. %s", err.Error())
 	}
 
-	err = dsrl.LockExpirationTime.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrl.LockExpirationTime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingLog.LockExpirationTime. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_rating_target.go
+++ b/datastore/types/datastore_rating_target.go
@@ -31,20 +31,15 @@ func (dsrt DataStoreRatingTarget) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreRatingTarget from the given readable
 func (dsrt *DataStoreRatingTarget) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsrt.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsrt.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingTarget header. %s", err.Error())
 	}
 
-	err = dsrt.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrt.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingTarget.DataID. %s", err.Error())
 	}
 
-	err = dsrt.Slot.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrt.Slot.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreRatingTarget.Slot. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_req_get_additional_meta.go
+++ b/datastore/types/datastore_req_get_additional_meta.go
@@ -35,30 +35,23 @@ func (dsrgam DataStoreReqGetAdditionalMeta) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreReqGetAdditionalMeta from the given readable
 func (dsrgam *DataStoreReqGetAdditionalMeta) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsrgam.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsrgam.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqGetAdditionalMeta header. %s", err.Error())
 	}
 
-	err = dsrgam.OwnerID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrgam.OwnerID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqGetAdditionalMeta.OwnerID. %s", err.Error())
 	}
 
-	err = dsrgam.DataType.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrgam.DataType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqGetAdditionalMeta.DataType. %s", err.Error())
 	}
 
-	err = dsrgam.Version.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrgam.Version.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqGetAdditionalMeta.Version. %s", err.Error())
 	}
 
-	err = dsrgam.MetaBinary.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrgam.MetaBinary.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqGetAdditionalMeta.MetaBinary. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_req_get_info.go
+++ b/datastore/types/datastore_req_get_info.go
@@ -47,36 +47,28 @@ func (dsrgi *DataStoreReqGetInfo) ExtractFrom(readable types.Readable) error {
 	stream := readable.(*nex.ByteStreamIn)
 	libraryVersion := stream.LibraryVersions.DataStore
 
-	var err error
-
-	err = dsrgi.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsrgi.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqGetInfo header. %s", err.Error())
 	}
 
-	err = dsrgi.URL.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrgi.URL.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqGetInfo.URL. %s", err.Error())
 	}
 
-	err = dsrgi.RequestHeaders.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrgi.RequestHeaders.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqGetInfo.RequestHeaders. %s", err.Error())
 	}
 
-	err = dsrgi.Size.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrgi.Size.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqGetInfo.Size. %s", err.Error())
 	}
 
-	err = dsrgi.RootCACert.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrgi.RootCACert.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqGetInfo.RootCACert. %s", err.Error())
 	}
 
 	if libraryVersion.GreaterOrEqual("3.5.0") {
-		err = dsrgi.DataID.ExtractFrom(readable)
-		if err != nil {
+		if err := dsrgi.DataID.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract DataStoreReqGetInfo.DataID. %s", err.Error())
 		}
 	}

--- a/datastore/types/datastore_req_get_info_v1.go
+++ b/datastore/types/datastore_req_get_info_v1.go
@@ -35,30 +35,23 @@ func (dsrgiv DataStoreReqGetInfoV1) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreReqGetInfoV1 from the given readable
 func (dsrgiv *DataStoreReqGetInfoV1) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsrgiv.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsrgiv.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqGetInfoV1 header. %s", err.Error())
 	}
 
-	err = dsrgiv.URL.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrgiv.URL.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqGetInfoV1.URL. %s", err.Error())
 	}
 
-	err = dsrgiv.RequestHeaders.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrgiv.RequestHeaders.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqGetInfoV1.RequestHeaders. %s", err.Error())
 	}
 
-	err = dsrgiv.Size.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrgiv.Size.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqGetInfoV1.Size. %s", err.Error())
 	}
 
-	err = dsrgiv.RootCACert.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrgiv.RootCACert.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqGetInfoV1.RootCACert. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_req_get_notification_url_info.go
+++ b/datastore/types/datastore_req_get_notification_url_info.go
@@ -35,30 +35,23 @@ func (dsrgnurli DataStoreReqGetNotificationURLInfo) WriteTo(writable types.Writa
 
 // ExtractFrom extracts the DataStoreReqGetNotificationURLInfo from the given readable
 func (dsrgnurli *DataStoreReqGetNotificationURLInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsrgnurli.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsrgnurli.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqGetNotificationURLInfo header. %s", err.Error())
 	}
 
-	err = dsrgnurli.URL.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrgnurli.URL.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqGetNotificationURLInfo.URL. %s", err.Error())
 	}
 
-	err = dsrgnurli.Key.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrgnurli.Key.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqGetNotificationURLInfo.Key. %s", err.Error())
 	}
 
-	err = dsrgnurli.Query.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrgnurli.Query.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqGetNotificationURLInfo.Query. %s", err.Error())
 	}
 
-	err = dsrgnurli.RootCACert.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrgnurli.RootCACert.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqGetNotificationURLInfo.RootCACert. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_req_post_info.go
+++ b/datastore/types/datastore_req_post_info.go
@@ -37,35 +37,27 @@ func (dsrpi DataStoreReqPostInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreReqPostInfo from the given readable
 func (dsrpi *DataStoreReqPostInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsrpi.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsrpi.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqPostInfo header. %s", err.Error())
 	}
 
-	err = dsrpi.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrpi.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqPostInfo.DataID. %s", err.Error())
 	}
 
-	err = dsrpi.URL.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrpi.URL.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqPostInfo.URL. %s", err.Error())
 	}
 
-	err = dsrpi.RequestHeaders.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrpi.RequestHeaders.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqPostInfo.RequestHeaders. %s", err.Error())
 	}
 
-	err = dsrpi.FormFields.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrpi.FormFields.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqPostInfo.FormFields. %s", err.Error())
 	}
 
-	err = dsrpi.RootCACert.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrpi.RootCACert.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqPostInfo.RootCACert. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_req_post_info_v1.go
+++ b/datastore/types/datastore_req_post_info_v1.go
@@ -37,35 +37,27 @@ func (dsrpiv DataStoreReqPostInfoV1) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreReqPostInfoV1 from the given readable
 func (dsrpiv *DataStoreReqPostInfoV1) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dsrpiv.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsrpiv.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqPostInfoV1 header. %s", err.Error())
 	}
 
-	err = dsrpiv.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrpiv.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqPostInfoV1.DataID. %s", err.Error())
 	}
 
-	err = dsrpiv.URL.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrpiv.URL.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqPostInfoV1.URL. %s", err.Error())
 	}
 
-	err = dsrpiv.RequestHeaders.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrpiv.RequestHeaders.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqPostInfoV1.RequestHeaders. %s", err.Error())
 	}
 
-	err = dsrpiv.FormFields.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrpiv.FormFields.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqPostInfoV1.FormFields. %s", err.Error())
 	}
 
-	err = dsrpiv.RootCACert.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrpiv.RootCACert.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqPostInfoV1.RootCACert. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_req_update_info.go
+++ b/datastore/types/datastore_req_update_info.go
@@ -49,16 +49,12 @@ func (dsrui *DataStoreReqUpdateInfo) ExtractFrom(readable types.Readable) error 
 	stream := readable.(*nex.ByteStreamIn)
 	libraryVersion := stream.LibraryVersions.DataStore
 
-	var err error
-
-	err = dsrui.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dsrui.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqUpdateInfo header. %s", err.Error())
 	}
 
 	if libraryVersion.GreaterOrEqual("3.0.0") {
-		err = dsrui.Version.ExtractFrom(readable)
-		if err != nil {
+		if err := dsrui.Version.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract DataStoreCompleteUpdateParam.Version. %s", err.Error())
 		}
 	} else {
@@ -70,23 +66,19 @@ func (dsrui *DataStoreReqUpdateInfo) ExtractFrom(readable types.Readable) error 
 		dsrui.Version = types.UInt32(version)
 	}
 
-	err = dsrui.URL.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrui.URL.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqUpdateInfo.URL. %s", err.Error())
 	}
 
-	err = dsrui.RequestHeaders.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrui.RequestHeaders.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqUpdateInfo.RequestHeaders. %s", err.Error())
 	}
 
-	err = dsrui.FormFields.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrui.FormFields.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqUpdateInfo.FormFields. %s", err.Error())
 	}
 
-	err = dsrui.RootCACert.ExtractFrom(readable)
-	if err != nil {
+	if err := dsrui.RootCACert.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreReqUpdateInfo.RootCACert. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_search_param.go
+++ b/datastore/types/datastore_search_param.go
@@ -82,110 +82,88 @@ func (dssp *DataStoreSearchParam) ExtractFrom(readable types.Readable) error {
 	stream := readable.(*nex.ByteStreamIn)
 	libraryVersion := stream.LibraryVersions.DataStore
 
-	var err error
-
-	err = dssp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dssp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchParam header. %s", err.Error())
 	}
 
-	err = dssp.SearchTarget.ExtractFrom(readable)
-	if err != nil {
+	if err := dssp.SearchTarget.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchParam.SearchTarget. %s", err.Error())
 	}
 
-	err = dssp.OwnerIDs.ExtractFrom(readable)
-	if err != nil {
+	if err := dssp.OwnerIDs.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchParam.OwnerIDs. %s", err.Error())
 	}
 
-	err = dssp.OwnerType.ExtractFrom(readable)
-	if err != nil {
+	if err := dssp.OwnerType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchParam.OwnerType. %s", err.Error())
 	}
 
-	err = dssp.DestinationIDs.ExtractFrom(readable)
-	if err != nil {
+	if err := dssp.DestinationIDs.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchParam.DestinationIDs. %s", err.Error())
 	}
 
-	err = dssp.DataType.ExtractFrom(readable)
-	if err != nil {
+	if err := dssp.DataType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchParam.DataType. %s", err.Error())
 	}
 
-	err = dssp.CreatedAfter.ExtractFrom(readable)
-	if err != nil {
+	if err := dssp.CreatedAfter.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchParam.CreatedAfter. %s", err.Error())
 	}
 
-	err = dssp.CreatedBefore.ExtractFrom(readable)
-	if err != nil {
+	if err := dssp.CreatedBefore.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchParam.CreatedBefore. %s", err.Error())
 	}
 
-	err = dssp.UpdatedAfter.ExtractFrom(readable)
-	if err != nil {
+	if err := dssp.UpdatedAfter.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchParam.UpdatedAfter. %s", err.Error())
 	}
 
-	err = dssp.UpdatedBefore.ExtractFrom(readable)
-	if err != nil {
+	if err := dssp.UpdatedBefore.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchParam.UpdatedBefore. %s", err.Error())
 	}
 
-	err = dssp.ReferDataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dssp.ReferDataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchParam.ReferDataID. %s", err.Error())
 	}
 
-	err = dssp.Tags.ExtractFrom(readable)
-	if err != nil {
+	if err := dssp.Tags.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchParam.Tags. %s", err.Error())
 	}
 
-	err = dssp.ResultOrderColumn.ExtractFrom(readable)
-	if err != nil {
+	if err := dssp.ResultOrderColumn.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchParam.ResultOrderColumn. %s", err.Error())
 	}
 
-	err = dssp.ResultOrder.ExtractFrom(readable)
-	if err != nil {
+	if err := dssp.ResultOrder.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchParam.ResultOrder. %s", err.Error())
 	}
 
-	err = dssp.ResultRange.ExtractFrom(readable)
-	if err != nil {
+	if err := dssp.ResultRange.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchParam.ResultRange. %s", err.Error())
 	}
 
-	err = dssp.ResultOption.ExtractFrom(readable)
-	if err != nil {
+	if err := dssp.ResultOption.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchParam.ResultOption. %s", err.Error())
 	}
 
-	err = dssp.MinimalRatingFrequency.ExtractFrom(readable)
-	if err != nil {
+	if err := dssp.MinimalRatingFrequency.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchParam.MinimalRatingFrequency. %s", err.Error())
 	}
 
 	if dssp.StructureVersion >= 1 || libraryVersion.GreaterOrEqual("4.0.0") {
-		err = dssp.UseCache.ExtractFrom(readable)
-		if err != nil {
+		if err := dssp.UseCache.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract DataStoreSearchParam.UseCache. %s", err.Error())
 		}
 	}
 
 	if dssp.StructureVersion >= 3 || libraryVersion.GreaterOrEqual("4.0.0") {
-		err = dssp.TotalCountEnabled.ExtractFrom(readable)
-		if err != nil {
+		if err := dssp.TotalCountEnabled.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract DataStoreSearchParam.TotalCountEnabled. %s", err.Error())
 		}
 	}
 
 	if dssp.StructureVersion >= 2 || libraryVersion.GreaterOrEqual("4.0.0") {
-		err = dssp.DataTypes.ExtractFrom(readable)
-		if err != nil {
+		if err := dssp.DataTypes.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract DataStoreSearchParam.DataTypes. %s", err.Error())
 		}
 	}

--- a/datastore/types/datastore_search_result.go
+++ b/datastore/types/datastore_search_result.go
@@ -34,25 +34,19 @@ func (dssr DataStoreSearchResult) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreSearchResult from the given readable
 func (dssr *DataStoreSearchResult) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dssr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dssr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchResult header. %s", err.Error())
 	}
 
-	err = dssr.TotalCount.ExtractFrom(readable)
-	if err != nil {
+	if err := dssr.TotalCount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchResult.TotalCount. %s", err.Error())
 	}
 
-	err = dssr.Result.ExtractFrom(readable)
-	if err != nil {
+	if err := dssr.Result.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchResult.Result. %s", err.Error())
 	}
 
-	err = dssr.TotalCountType.ExtractFrom(readable)
-	if err != nil {
+	if err := dssr.TotalCountType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSearchResult.TotalCountType. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_specific_meta_info.go
+++ b/datastore/types/datastore_specific_meta_info.go
@@ -37,35 +37,27 @@ func (dssmi DataStoreSpecificMetaInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreSpecificMetaInfo from the given readable
 func (dssmi *DataStoreSpecificMetaInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dssmi.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dssmi.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSpecificMetaInfo header. %s", err.Error())
 	}
 
-	err = dssmi.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dssmi.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSpecificMetaInfo.DataID. %s", err.Error())
 	}
 
-	err = dssmi.OwnerID.ExtractFrom(readable)
-	if err != nil {
+	if err := dssmi.OwnerID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSpecificMetaInfo.OwnerID. %s", err.Error())
 	}
 
-	err = dssmi.Size.ExtractFrom(readable)
-	if err != nil {
+	if err := dssmi.Size.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSpecificMetaInfo.Size. %s", err.Error())
 	}
 
-	err = dssmi.DataType.ExtractFrom(readable)
-	if err != nil {
+	if err := dssmi.DataType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSpecificMetaInfo.DataType. %s", err.Error())
 	}
 
-	err = dssmi.Version.ExtractFrom(readable)
-	if err != nil {
+	if err := dssmi.Version.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSpecificMetaInfo.Version. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_specific_meta_info_v1.go
+++ b/datastore/types/datastore_specific_meta_info_v1.go
@@ -37,35 +37,27 @@ func (dssmiv DataStoreSpecificMetaInfoV1) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreSpecificMetaInfoV1 from the given readable
 func (dssmiv *DataStoreSpecificMetaInfoV1) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dssmiv.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dssmiv.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSpecificMetaInfoV1 header. %s", err.Error())
 	}
 
-	err = dssmiv.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dssmiv.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSpecificMetaInfoV1.DataID. %s", err.Error())
 	}
 
-	err = dssmiv.OwnerID.ExtractFrom(readable)
-	if err != nil {
+	if err := dssmiv.OwnerID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSpecificMetaInfoV1.OwnerID. %s", err.Error())
 	}
 
-	err = dssmiv.Size.ExtractFrom(readable)
-	if err != nil {
+	if err := dssmiv.Size.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSpecificMetaInfoV1.Size. %s", err.Error())
 	}
 
-	err = dssmiv.DataType.ExtractFrom(readable)
-	if err != nil {
+	if err := dssmiv.DataType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSpecificMetaInfoV1.DataType. %s", err.Error())
 	}
 
-	err = dssmiv.Version.ExtractFrom(readable)
-	if err != nil {
+	if err := dssmiv.Version.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreSpecificMetaInfoV1.Version. %s", err.Error())
 	}
 

--- a/datastore/types/datastore_touch_object_param.go
+++ b/datastore/types/datastore_touch_object_param.go
@@ -33,25 +33,19 @@ func (dstop DataStoreTouchObjectParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DataStoreTouchObjectParam from the given readable
 func (dstop *DataStoreTouchObjectParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = dstop.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := dstop.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreTouchObjectParam header. %s", err.Error())
 	}
 
-	err = dstop.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := dstop.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreTouchObjectParam.DataID. %s", err.Error())
 	}
 
-	err = dstop.LockID.ExtractFrom(readable)
-	if err != nil {
+	if err := dstop.LockID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreTouchObjectParam.LockID. %s", err.Error())
 	}
 
-	err = dstop.AccessPassword.ExtractFrom(readable)
-	if err != nil {
+	if err := dstop.AccessPassword.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DataStoreTouchObjectParam.AccessPassword. %s", err.Error())
 	}
 

--- a/friends-3ds/types/friend_comment.go
+++ b/friends-3ds/types/friend_comment.go
@@ -36,30 +36,23 @@ func (fc FriendComment) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the FriendComment from the given readable
 func (fc *FriendComment) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = fc.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := fc.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendComment.Data. %s", err.Error())
 	}
 
-	err = fc.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := fc.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendComment header. %s", err.Error())
 	}
 
-	err = fc.PID.ExtractFrom(readable)
-	if err != nil {
+	if err := fc.PID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendComment.PID. %s", err.Error())
 	}
 
-	err = fc.Comment.ExtractFrom(readable)
-	if err != nil {
+	if err := fc.Comment.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendComment.Comment. %s", err.Error())
 	}
 
-	err = fc.ModifiedAt.ExtractFrom(readable)
-	if err != nil {
+	if err := fc.ModifiedAt.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendComment.ModifiedAt. %s", err.Error())
 	}
 

--- a/friends-3ds/types/friend_info.go
+++ b/friends-3ds/types/friend_info.go
@@ -31,20 +31,15 @@ func (fi FriendInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the FriendInfo from the given readable
 func (fi *FriendInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = fi.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := fi.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendInfo header. %s", err.Error())
 	}
 
-	err = fi.PID.ExtractFrom(readable)
-	if err != nil {
+	if err := fi.PID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendInfo.PID. %s", err.Error())
 	}
 
-	err = fi.Unknown.ExtractFrom(readable)
-	if err != nil {
+	if err := fi.Unknown.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendInfo.Unknown. %s", err.Error())
 	}
 

--- a/friends-3ds/types/friend_mii.go
+++ b/friends-3ds/types/friend_mii.go
@@ -36,30 +36,23 @@ func (fm FriendMii) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the FriendMii from the given readable
 func (fm *FriendMii) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = fm.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := fm.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendMii.Data. %s", err.Error())
 	}
 
-	err = fm.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := fm.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendMii header. %s", err.Error())
 	}
 
-	err = fm.PID.ExtractFrom(readable)
-	if err != nil {
+	if err := fm.PID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendMii.PID. %s", err.Error())
 	}
 
-	err = fm.Mii.ExtractFrom(readable)
-	if err != nil {
+	if err := fm.Mii.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendMii.Mii. %s", err.Error())
 	}
 
-	err = fm.ModifiedAt.ExtractFrom(readable)
-	if err != nil {
+	if err := fm.ModifiedAt.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendMii.ModifiedAt. %s", err.Error())
 	}
 

--- a/friends-3ds/types/friend_mii_list.go
+++ b/friends-3ds/types/friend_mii_list.go
@@ -36,30 +36,23 @@ func (fml FriendMiiList) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the FriendMiiList from the given readable
 func (fml *FriendMiiList) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = fml.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := fml.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendMiiList.Data. %s", err.Error())
 	}
 
-	err = fml.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := fml.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendMiiList header. %s", err.Error())
 	}
 
-	err = fml.Unknown1.ExtractFrom(readable)
-	if err != nil {
+	if err := fml.Unknown1.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendMiiList.Unknown1. %s", err.Error())
 	}
 
-	err = fml.MiiList.ExtractFrom(readable)
-	if err != nil {
+	if err := fml.MiiList.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendMiiList.MiiList. %s", err.Error())
 	}
 
-	err = fml.Unknown2.ExtractFrom(readable)
-	if err != nil {
+	if err := fml.Unknown2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendMiiList.Unknown2. %s", err.Error())
 	}
 

--- a/friends-3ds/types/friend_persistent_info.go
+++ b/friends-3ds/types/friend_persistent_info.go
@@ -52,70 +52,55 @@ func (fpi FriendPersistentInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the FriendPersistentInfo from the given readable
 func (fpi *FriendPersistentInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = fpi.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := fpi.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendPersistentInfo.Data. %s", err.Error())
 	}
 
-	err = fpi.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := fpi.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendPersistentInfo header. %s", err.Error())
 	}
 
-	err = fpi.PID.ExtractFrom(readable)
-	if err != nil {
+	if err := fpi.PID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendPersistentInfo.PID. %s", err.Error())
 	}
 
-	err = fpi.Region.ExtractFrom(readable)
-	if err != nil {
+	if err := fpi.Region.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendPersistentInfo.Region. %s", err.Error())
 	}
 
-	err = fpi.Country.ExtractFrom(readable)
-	if err != nil {
+	if err := fpi.Country.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendPersistentInfo.Country. %s", err.Error())
 	}
 
-	err = fpi.Area.ExtractFrom(readable)
-	if err != nil {
+	if err := fpi.Area.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendPersistentInfo.Area. %s", err.Error())
 	}
 
-	err = fpi.Language.ExtractFrom(readable)
-	if err != nil {
+	if err := fpi.Language.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendPersistentInfo.Language. %s", err.Error())
 	}
 
-	err = fpi.Platform.ExtractFrom(readable)
-	if err != nil {
+	if err := fpi.Platform.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendPersistentInfo.Platform. %s", err.Error())
 	}
 
-	err = fpi.GameKey.ExtractFrom(readable)
-	if err != nil {
+	if err := fpi.GameKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendPersistentInfo.GameKey. %s", err.Error())
 	}
 
-	err = fpi.Message.ExtractFrom(readable)
-	if err != nil {
+	if err := fpi.Message.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendPersistentInfo.Message. %s", err.Error())
 	}
 
-	err = fpi.MessageUpdatedAt.ExtractFrom(readable)
-	if err != nil {
+	if err := fpi.MessageUpdatedAt.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendPersistentInfo.MessageUpdatedAt. %s", err.Error())
 	}
 
-	err = fpi.MiiModifiedAt.ExtractFrom(readable)
-	if err != nil {
+	if err := fpi.MiiModifiedAt.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendPersistentInfo.MiiModifiedAt. %s", err.Error())
 	}
 
-	err = fpi.LastOnline.ExtractFrom(readable)
-	if err != nil {
+	if err := fpi.LastOnline.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendPersistentInfo.LastOnline. %s", err.Error())
 	}
 

--- a/friends-3ds/types/friend_picture.go
+++ b/friends-3ds/types/friend_picture.go
@@ -36,30 +36,23 @@ func (fp FriendPicture) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the FriendPicture from the given readable
 func (fp *FriendPicture) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = fp.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := fp.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendPicture.Data. %s", err.Error())
 	}
 
-	err = fp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := fp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendPicture header. %s", err.Error())
 	}
 
-	err = fp.Unknown1.ExtractFrom(readable)
-	if err != nil {
+	if err := fp.Unknown1.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendPicture.Unknown1. %s", err.Error())
 	}
 
-	err = fp.PictureData.ExtractFrom(readable)
-	if err != nil {
+	if err := fp.PictureData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendPicture.PictureData. %s", err.Error())
 	}
 
-	err = fp.Unknown2.ExtractFrom(readable)
-	if err != nil {
+	if err := fp.Unknown2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendPicture.Unknown2. %s", err.Error())
 	}
 

--- a/friends-3ds/types/friend_presence.go
+++ b/friends-3ds/types/friend_presence.go
@@ -34,25 +34,19 @@ func (fp FriendPresence) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the FriendPresence from the given readable
 func (fp *FriendPresence) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = fp.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := fp.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendPresence.Data. %s", err.Error())
 	}
 
-	err = fp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := fp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendPresence header. %s", err.Error())
 	}
 
-	err = fp.PID.ExtractFrom(readable)
-	if err != nil {
+	if err := fp.PID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendPresence.PID. %s", err.Error())
 	}
 
-	err = fp.Presence.ExtractFrom(readable)
-	if err != nil {
+	if err := fp.Presence.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendPresence.Presence. %s", err.Error())
 	}
 

--- a/friends-3ds/types/friend_relationship.go
+++ b/friends-3ds/types/friend_relationship.go
@@ -37,30 +37,23 @@ func (fr FriendRelationship) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the FriendRelationship from the given readable
 func (fr *FriendRelationship) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = fr.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := fr.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendRelationship.Data. %s", err.Error())
 	}
 
-	err = fr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := fr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendRelationship header. %s", err.Error())
 	}
 
-	err = fr.PID.ExtractFrom(readable)
-	if err != nil {
+	if err := fr.PID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendRelationship.PID. %s", err.Error())
 	}
 
-	err = fr.LFC.ExtractFrom(readable)
-	if err != nil {
+	if err := fr.LFC.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendRelationship.LFC. %s", err.Error())
 	}
 
-	err = fr.RelationshipType.ExtractFrom(readable)
-	if err != nil {
+	if err := fr.RelationshipType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendRelationship.RelationshipType. %s", err.Error())
 	}
 

--- a/friends-3ds/types/game_key.go
+++ b/friends-3ds/types/game_key.go
@@ -44,25 +44,19 @@ func (gk GameKey) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the GameKey from the given readable
 func (gk *GameKey) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gk.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := gk.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GameKey.Data. %s", err.Error())
 	}
 
-	err = gk.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gk.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GameKey header. %s", err.Error())
 	}
 
-	err = gk.TitleID.ExtractFrom(readable)
-	if err != nil {
+	if err := gk.TitleID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GameKey.TitleID. %s", err.Error())
 	}
 
-	err = gk.TitleVersion.ExtractFrom(readable)
-	if err != nil {
+	if err := gk.TitleVersion.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GameKey.TitleVersion. %s", err.Error())
 	}
 

--- a/friends-3ds/types/mii.go
+++ b/friends-3ds/types/mii.go
@@ -39,35 +39,27 @@ func (m Mii) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the Mii from the given readable
 func (m *Mii) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = m.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := m.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Mii.Data. %s", err.Error())
 	}
 
-	err = m.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := m.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Mii header. %s", err.Error())
 	}
 
-	err = m.Name.ExtractFrom(readable)
-	if err != nil {
+	if err := m.Name.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Mii.Name. %s", err.Error())
 	}
 
-	err = m.ProfanityFlag.ExtractFrom(readable)
-	if err != nil {
+	if err := m.ProfanityFlag.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Mii.ProfanityFlag. %s", err.Error())
 	}
 
-	err = m.CharacterSet.ExtractFrom(readable)
-	if err != nil {
+	if err := m.CharacterSet.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Mii.CharacterSet. %s", err.Error())
 	}
 
-	err = m.MiiData.ExtractFrom(readable)
-	if err != nil {
+	if err := m.MiiData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Mii.MiiData. %s", err.Error())
 	}
 

--- a/friends-3ds/types/mii_list.go
+++ b/friends-3ds/types/mii_list.go
@@ -38,35 +38,27 @@ func (ml MiiList) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the MiiList from the given readable
 func (ml *MiiList) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = ml.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := ml.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiList.Data. %s", err.Error())
 	}
 
-	err = ml.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := ml.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiList header. %s", err.Error())
 	}
 
-	err = ml.Unknown1.ExtractFrom(readable)
-	if err != nil {
+	if err := ml.Unknown1.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiList.Unknown1. %s", err.Error())
 	}
 
-	err = ml.Unknown2.ExtractFrom(readable)
-	if err != nil {
+	if err := ml.Unknown2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiList.Unknown2. %s", err.Error())
 	}
 
-	err = ml.Unknown3.ExtractFrom(readable)
-	if err != nil {
+	if err := ml.Unknown3.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiList.Unknown3. %s", err.Error())
 	}
 
-	err = ml.MiiDataList.ExtractFrom(readable)
-	if err != nil {
+	if err := ml.MiiDataList.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiList.MiiDataList. %s", err.Error())
 	}
 

--- a/friends-3ds/types/my_profile.go
+++ b/friends-3ds/types/my_profile.go
@@ -46,55 +46,43 @@ func (mp MyProfile) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the MyProfile from the given readable
 func (mp *MyProfile) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = mp.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := mp.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MyProfile.Data. %s", err.Error())
 	}
 
-	err = mp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := mp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MyProfile header. %s", err.Error())
 	}
 
-	err = mp.Region.ExtractFrom(readable)
-	if err != nil {
+	if err := mp.Region.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MyProfile.Region. %s", err.Error())
 	}
 
-	err = mp.Country.ExtractFrom(readable)
-	if err != nil {
+	if err := mp.Country.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MyProfile.Country. %s", err.Error())
 	}
 
-	err = mp.Area.ExtractFrom(readable)
-	if err != nil {
+	if err := mp.Area.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MyProfile.Area. %s", err.Error())
 	}
 
-	err = mp.Language.ExtractFrom(readable)
-	if err != nil {
+	if err := mp.Language.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MyProfile.Language. %s", err.Error())
 	}
 
-	err = mp.Platform.ExtractFrom(readable)
-	if err != nil {
+	if err := mp.Platform.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MyProfile.Platform. %s", err.Error())
 	}
 
-	err = mp.LocalFriendCodeSeed.ExtractFrom(readable)
-	if err != nil {
+	if err := mp.LocalFriendCodeSeed.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MyProfile.LocalFriendCodeSeed. %s", err.Error())
 	}
 
-	err = mp.MACAddress.ExtractFrom(readable)
-	if err != nil {
+	if err := mp.MACAddress.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MyProfile.MACAddress. %s", err.Error())
 	}
 
-	err = mp.SerialNumber.ExtractFrom(readable)
-	if err != nil {
+	if err := mp.SerialNumber.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MyProfile.SerialNumber. %s", err.Error())
 	}
 

--- a/friends-3ds/types/nintendo_presence.go
+++ b/friends-3ds/types/nintendo_presence.go
@@ -61,65 +61,51 @@ func (np NintendoPresence) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the NintendoPresence from the given readable
 func (np *NintendoPresence) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = np.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := np.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresence.Data. %s", err.Error())
 	}
 
-	err = np.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := np.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresence header. %s", err.Error())
 	}
 
-	err = np.ChangedFlags.ExtractFrom(readable)
-	if err != nil {
+	if err := np.ChangedFlags.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresence.ChangedFlags. %s", err.Error())
 	}
 
-	err = np.GameKey.ExtractFrom(readable)
-	if err != nil {
+	if err := np.GameKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresence.GameKey. %s", err.Error())
 	}
 
-	err = np.Message.ExtractFrom(readable)
-	if err != nil {
+	if err := np.Message.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresence.Message. %s", err.Error())
 	}
 
-	err = np.JoinAvailableFlag.ExtractFrom(readable)
-	if err != nil {
+	if err := np.JoinAvailableFlag.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresence.JoinAvailableFlag. %s", err.Error())
 	}
 
-	err = np.MatchmakeType.ExtractFrom(readable)
-	if err != nil {
+	if err := np.MatchmakeType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresence.MatchmakeType. %s", err.Error())
 	}
 
-	err = np.JoinGameID.ExtractFrom(readable)
-	if err != nil {
+	if err := np.JoinGameID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresence.JoinGameID. %s", err.Error())
 	}
 
-	err = np.JoinGameMode.ExtractFrom(readable)
-	if err != nil {
+	if err := np.JoinGameMode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresence.JoinGameMode. %s", err.Error())
 	}
 
-	err = np.OwnerPID.ExtractFrom(readable)
-	if err != nil {
+	if err := np.OwnerPID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresence.OwnerPID. %s", err.Error())
 	}
 
-	err = np.JoinGroupID.ExtractFrom(readable)
-	if err != nil {
+	if err := np.JoinGroupID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresence.JoinGroupID. %s", err.Error())
 	}
 
-	err = np.ApplicationArg.ExtractFrom(readable)
-	if err != nil {
+	if err := np.ApplicationArg.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresence.ApplicationArg. %s", err.Error())
 	}
 

--- a/friends-3ds/types/played_game.go
+++ b/friends-3ds/types/played_game.go
@@ -31,20 +31,15 @@ func (pg PlayedGame) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the PlayedGame from the given readable
 func (pg *PlayedGame) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = pg.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := pg.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PlayedGame header. %s", err.Error())
 	}
 
-	err = pg.GameKey.ExtractFrom(readable)
-	if err != nil {
+	if err := pg.GameKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PlayedGame.GameKey. %s", err.Error())
 	}
 
-	err = pg.Unknown.ExtractFrom(readable)
-	if err != nil {
+	if err := pg.Unknown.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PlayedGame.Unknown. %s", err.Error())
 	}
 

--- a/friends-wiiu/types/blacklisted_principal.go
+++ b/friends-wiiu/types/blacklisted_principal.go
@@ -36,30 +36,23 @@ func (bp BlacklistedPrincipal) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the BlacklistedPrincipal from the given readable
 func (bp *BlacklistedPrincipal) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = bp.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := bp.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract BlacklistedPrincipal.Data. %s", err.Error())
 	}
 
-	err = bp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := bp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract BlacklistedPrincipal header. %s", err.Error())
 	}
 
-	err = bp.PrincipalBasicInfo.ExtractFrom(readable)
-	if err != nil {
+	if err := bp.PrincipalBasicInfo.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract BlacklistedPrincipal.PrincipalBasicInfo. %s", err.Error())
 	}
 
-	err = bp.GameKey.ExtractFrom(readable)
-	if err != nil {
+	if err := bp.GameKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract BlacklistedPrincipal.GameKey. %s", err.Error())
 	}
 
-	err = bp.BlackListedSince.ExtractFrom(readable)
-	if err != nil {
+	if err := bp.BlackListedSince.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract BlacklistedPrincipal.BlackListedSince. %s", err.Error())
 	}
 

--- a/friends-wiiu/types/comment.go
+++ b/friends-wiiu/types/comment.go
@@ -36,30 +36,23 @@ func (c Comment) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the Comment from the given readable
 func (c *Comment) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = c.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := c.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Comment.Data. %s", err.Error())
 	}
 
-	err = c.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := c.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Comment header. %s", err.Error())
 	}
 
-	err = c.Unknown.ExtractFrom(readable)
-	if err != nil {
+	if err := c.Unknown.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Comment.Unknown. %s", err.Error())
 	}
 
-	err = c.Contents.ExtractFrom(readable)
-	if err != nil {
+	if err := c.Contents.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Comment.Contents. %s", err.Error())
 	}
 
-	err = c.LastChanged.ExtractFrom(readable)
-	if err != nil {
+	if err := c.LastChanged.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Comment.LastChanged. %s", err.Error())
 	}
 

--- a/friends-wiiu/types/friend_info.go
+++ b/friends-wiiu/types/friend_info.go
@@ -52,45 +52,35 @@ func (fi FriendInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the FriendInfo from the given readable
 func (fi *FriendInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = fi.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := fi.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendInfo.Data. %s", err.Error())
 	}
 
-	err = fi.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := fi.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendInfo header. %s", err.Error())
 	}
 
-	err = fi.NNAInfo.ExtractFrom(readable)
-	if err != nil {
+	if err := fi.NNAInfo.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendInfo.NNAInfo. %s", err.Error())
 	}
 
-	err = fi.Presence.ExtractFrom(readable)
-	if err != nil {
+	if err := fi.Presence.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendInfo.Presence. %s", err.Error())
 	}
 
-	err = fi.Status.ExtractFrom(readable)
-	if err != nil {
+	if err := fi.Status.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendInfo.Status. %s", err.Error())
 	}
 
-	err = fi.BecameFriend.ExtractFrom(readable)
-	if err != nil {
+	if err := fi.BecameFriend.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendInfo.BecameFriend. %s", err.Error())
 	}
 
-	err = fi.LastOnline.ExtractFrom(readable)
-	if err != nil {
+	if err := fi.LastOnline.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendInfo.LastOnline. %s", err.Error())
 	}
 
-	err = fi.Unknown.ExtractFrom(readable)
-	if err != nil {
+	if err := fi.Unknown.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendInfo.Unknown. %s", err.Error())
 	}
 

--- a/friends-wiiu/types/friend_request.go
+++ b/friends-wiiu/types/friend_request.go
@@ -46,30 +46,23 @@ func (fr FriendRequest) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the FriendRequest from the given readable
 func (fr *FriendRequest) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = fr.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := fr.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendRequest.Data. %s", err.Error())
 	}
 
-	err = fr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := fr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendRequest header. %s", err.Error())
 	}
 
-	err = fr.PrincipalInfo.ExtractFrom(readable)
-	if err != nil {
+	if err := fr.PrincipalInfo.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendRequest.PrincipalInfo. %s", err.Error())
 	}
 
-	err = fr.Message.ExtractFrom(readable)
-	if err != nil {
+	if err := fr.Message.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendRequest.Message. %s", err.Error())
 	}
 
-	err = fr.SentOn.ExtractFrom(readable)
-	if err != nil {
+	if err := fr.SentOn.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendRequest.SentOn. %s", err.Error())
 	}
 

--- a/friends-wiiu/types/friend_request_message.go
+++ b/friends-wiiu/types/friend_request_message.go
@@ -48,60 +48,47 @@ func (frm FriendRequestMessage) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the FriendRequestMessage from the given readable
 func (frm *FriendRequestMessage) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = frm.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := frm.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendRequestMessage.Data. %s", err.Error())
 	}
 
-	err = frm.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := frm.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendRequestMessage header. %s", err.Error())
 	}
 
-	err = frm.FriendRequestID.ExtractFrom(readable)
-	if err != nil {
+	if err := frm.FriendRequestID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendRequestMessage.FriendRequestID. %s", err.Error())
 	}
 
-	err = frm.Received.ExtractFrom(readable)
-	if err != nil {
+	if err := frm.Received.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendRequestMessage.Received. %s", err.Error())
 	}
 
-	err = frm.Unknown2.ExtractFrom(readable)
-	if err != nil {
+	if err := frm.Unknown2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendRequestMessage.Unknown2. %s", err.Error())
 	}
 
-	err = frm.Message.ExtractFrom(readable)
-	if err != nil {
+	if err := frm.Message.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendRequestMessage.Message. %s", err.Error())
 	}
 
-	err = frm.Unknown3.ExtractFrom(readable)
-	if err != nil {
+	if err := frm.Unknown3.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendRequestMessage.Unknown3. %s", err.Error())
 	}
 
-	err = frm.Unknown4.ExtractFrom(readable)
-	if err != nil {
+	if err := frm.Unknown4.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendRequestMessage.Unknown4. %s", err.Error())
 	}
 
-	err = frm.GameKey.ExtractFrom(readable)
-	if err != nil {
+	if err := frm.GameKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendRequestMessage.GameKey. %s", err.Error())
 	}
 
-	err = frm.Unknown5.ExtractFrom(readable)
-	if err != nil {
+	if err := frm.Unknown5.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendRequestMessage.Unknown5. %s", err.Error())
 	}
 
-	err = frm.ExpiresOn.ExtractFrom(readable)
-	if err != nil {
+	if err := frm.ExpiresOn.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendRequestMessage.ExpiresOn. %s", err.Error())
 	}
 

--- a/friends-wiiu/types/game_key.go
+++ b/friends-wiiu/types/game_key.go
@@ -34,25 +34,19 @@ func (gk GameKey) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the GameKey from the given readable
 func (gk *GameKey) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gk.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := gk.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GameKey.Data. %s", err.Error())
 	}
 
-	err = gk.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gk.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GameKey header. %s", err.Error())
 	}
 
-	err = gk.TitleID.ExtractFrom(readable)
-	if err != nil {
+	if err := gk.TitleID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GameKey.TitleID. %s", err.Error())
 	}
 
-	err = gk.TitleVersion.ExtractFrom(readable)
-	if err != nil {
+	if err := gk.TitleVersion.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GameKey.TitleVersion. %s", err.Error())
 	}
 

--- a/friends-wiiu/types/mii_v2.go
+++ b/friends-wiiu/types/mii_v2.go
@@ -40,40 +40,31 @@ func (mv MiiV2) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the MiiV2 from the given readable
 func (mv *MiiV2) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = mv.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := mv.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiV2.Data. %s", err.Error())
 	}
 
-	err = mv.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := mv.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiV2 header. %s", err.Error())
 	}
 
-	err = mv.Name.ExtractFrom(readable)
-	if err != nil {
+	if err := mv.Name.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiV2.Name. %s", err.Error())
 	}
 
-	err = mv.Unknown1.ExtractFrom(readable)
-	if err != nil {
+	if err := mv.Unknown1.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiV2.Unknown1. %s", err.Error())
 	}
 
-	err = mv.Unknown2.ExtractFrom(readable)
-	if err != nil {
+	if err := mv.Unknown2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiV2.Unknown2. %s", err.Error())
 	}
 
-	err = mv.MiiData.ExtractFrom(readable)
-	if err != nil {
+	if err := mv.MiiData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiV2.MiiData. %s", err.Error())
 	}
 
-	err = mv.Datetime.ExtractFrom(readable)
-	if err != nil {
+	if err := mv.Datetime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MiiV2.Datetime. %s", err.Error())
 	}
 

--- a/friends-wiiu/types/nintendo_presence_v2.go
+++ b/friends-wiiu/types/nintendo_presence_v2.go
@@ -71,90 +71,71 @@ func (npv NintendoPresenceV2) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the NintendoPresenceV2 from the given readable
 func (npv *NintendoPresenceV2) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = npv.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := npv.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresenceV2.Data. %s", err.Error())
 	}
 
-	err = npv.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := npv.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresenceV2 header. %s", err.Error())
 	}
 
-	err = npv.ChangedFlags.ExtractFrom(readable)
-	if err != nil {
+	if err := npv.ChangedFlags.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresenceV2.ChangedFlags. %s", err.Error())
 	}
 
-	err = npv.Online.ExtractFrom(readable)
-	if err != nil {
+	if err := npv.Online.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresenceV2.Online. %s", err.Error())
 	}
 
-	err = npv.GameKey.ExtractFrom(readable)
-	if err != nil {
+	if err := npv.GameKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresenceV2.GameKey. %s", err.Error())
 	}
 
-	err = npv.Unknown1.ExtractFrom(readable)
-	if err != nil {
+	if err := npv.Unknown1.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresenceV2.Unknown1. %s", err.Error())
 	}
 
-	err = npv.Message.ExtractFrom(readable)
-	if err != nil {
+	if err := npv.Message.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresenceV2.Message. %s", err.Error())
 	}
 
-	err = npv.Unknown2.ExtractFrom(readable)
-	if err != nil {
+	if err := npv.Unknown2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresenceV2.Unknown2. %s", err.Error())
 	}
 
-	err = npv.Unknown3.ExtractFrom(readable)
-	if err != nil {
+	if err := npv.Unknown3.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresenceV2.Unknown3. %s", err.Error())
 	}
 
-	err = npv.GameServerID.ExtractFrom(readable)
-	if err != nil {
+	if err := npv.GameServerID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresenceV2.GameServerID. %s", err.Error())
 	}
 
-	err = npv.Unknown4.ExtractFrom(readable)
-	if err != nil {
+	if err := npv.Unknown4.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresenceV2.Unknown4. %s", err.Error())
 	}
 
-	err = npv.PID.ExtractFrom(readable)
-	if err != nil {
+	if err := npv.PID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresenceV2.PID. %s", err.Error())
 	}
 
-	err = npv.GatheringID.ExtractFrom(readable)
-	if err != nil {
+	if err := npv.GatheringID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresenceV2.GatheringID. %s", err.Error())
 	}
 
-	err = npv.ApplicationData.ExtractFrom(readable)
-	if err != nil {
+	if err := npv.ApplicationData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresenceV2.ApplicationData. %s", err.Error())
 	}
 
-	err = npv.Unknown5.ExtractFrom(readable)
-	if err != nil {
+	if err := npv.Unknown5.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresenceV2.Unknown5. %s", err.Error())
 	}
 
-	err = npv.Unknown6.ExtractFrom(readable)
-	if err != nil {
+	if err := npv.Unknown6.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresenceV2.Unknown6. %s", err.Error())
 	}
 
-	err = npv.Unknown7.ExtractFrom(readable)
-	if err != nil {
+	if err := npv.Unknown7.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoPresenceV2.Unknown7. %s", err.Error())
 	}
 

--- a/friends-wiiu/types/nna_info.go
+++ b/friends-wiiu/types/nna_info.go
@@ -46,30 +46,23 @@ func (nnai NNAInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the NNAInfo from the given readable
 func (nnai *NNAInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = nnai.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := nnai.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NNAInfo.Data. %s", err.Error())
 	}
 
-	err = nnai.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := nnai.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NNAInfo header. %s", err.Error())
 	}
 
-	err = nnai.PrincipalBasicInfo.ExtractFrom(readable)
-	if err != nil {
+	if err := nnai.PrincipalBasicInfo.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NNAInfo.PrincipalBasicInfo. %s", err.Error())
 	}
 
-	err = nnai.Unknown1.ExtractFrom(readable)
-	if err != nil {
+	if err := nnai.Unknown1.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NNAInfo.Unknown1. %s", err.Error())
 	}
 
-	err = nnai.Unknown2.ExtractFrom(readable)
-	if err != nil {
+	if err := nnai.Unknown2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NNAInfo.Unknown2. %s", err.Error())
 	}
 

--- a/friends-wiiu/types/persistent_notification.go
+++ b/friends-wiiu/types/persistent_notification.go
@@ -40,40 +40,31 @@ func (pn PersistentNotification) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the PersistentNotification from the given readable
 func (pn *PersistentNotification) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = pn.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := pn.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PersistentNotification.Data. %s", err.Error())
 	}
 
-	err = pn.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := pn.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PersistentNotification header. %s", err.Error())
 	}
 
-	err = pn.Unknown1.ExtractFrom(readable)
-	if err != nil {
+	if err := pn.Unknown1.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PersistentNotification.Unknown1. %s", err.Error())
 	}
 
-	err = pn.Unknown2.ExtractFrom(readable)
-	if err != nil {
+	if err := pn.Unknown2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PersistentNotification.Unknown2. %s", err.Error())
 	}
 
-	err = pn.Unknown3.ExtractFrom(readable)
-	if err != nil {
+	if err := pn.Unknown3.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PersistentNotification.Unknown3. %s", err.Error())
 	}
 
-	err = pn.Unknown4.ExtractFrom(readable)
-	if err != nil {
+	if err := pn.Unknown4.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PersistentNotification.Unknown4. %s", err.Error())
 	}
 
-	err = pn.Unknown5.ExtractFrom(readable)
-	if err != nil {
+	if err := pn.Unknown5.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PersistentNotification.Unknown5. %s", err.Error())
 	}
 

--- a/friends-wiiu/types/persistent_notification_list.go
+++ b/friends-wiiu/types/persistent_notification_list.go
@@ -42,20 +42,15 @@ func (pnl PersistentNotificationList) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the PersistentNotificationList from the given readable
 func (pnl *PersistentNotificationList) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = pnl.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := pnl.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PersistentNotificationList.Data. %s", err.Error())
 	}
 
-	err = pnl.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := pnl.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PersistentNotificationList header. %s", err.Error())
 	}
 
-	err = pnl.Notifications.ExtractFrom(readable)
-	if err != nil {
+	if err := pnl.Notifications.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PersistentNotificationList.Notifications. %s", err.Error())
 	}
 

--- a/friends-wiiu/types/principal_basic_info.go
+++ b/friends-wiiu/types/principal_basic_info.go
@@ -38,35 +38,27 @@ func (pbi PrincipalBasicInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the PrincipalBasicInfo from the given readable
 func (pbi *PrincipalBasicInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = pbi.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := pbi.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PrincipalBasicInfo.Data. %s", err.Error())
 	}
 
-	err = pbi.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := pbi.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PrincipalBasicInfo header. %s", err.Error())
 	}
 
-	err = pbi.PID.ExtractFrom(readable)
-	if err != nil {
+	if err := pbi.PID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PrincipalBasicInfo.PID. %s", err.Error())
 	}
 
-	err = pbi.NNID.ExtractFrom(readable)
-	if err != nil {
+	if err := pbi.NNID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PrincipalBasicInfo.NNID. %s", err.Error())
 	}
 
-	err = pbi.Mii.ExtractFrom(readable)
-	if err != nil {
+	if err := pbi.Mii.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PrincipalBasicInfo.Mii. %s", err.Error())
 	}
 
-	err = pbi.Unknown.ExtractFrom(readable)
-	if err != nil {
+	if err := pbi.Unknown.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PrincipalBasicInfo.Unknown. %s", err.Error())
 	}
 

--- a/friends-wiiu/types/principal_preference.go
+++ b/friends-wiiu/types/principal_preference.go
@@ -46,30 +46,23 @@ func (pp PrincipalPreference) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the PrincipalPreference from the given readable
 func (pp *PrincipalPreference) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = pp.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := pp.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PrincipalPreference.Data. %s", err.Error())
 	}
 
-	err = pp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := pp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PrincipalPreference header. %s", err.Error())
 	}
 
-	err = pp.ShowOnlinePresence.ExtractFrom(readable)
-	if err != nil {
+	if err := pp.ShowOnlinePresence.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PrincipalPreference.ShowOnlinePresence. %s", err.Error())
 	}
 
-	err = pp.ShowCurrentTitle.ExtractFrom(readable)
-	if err != nil {
+	if err := pp.ShowCurrentTitle.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PrincipalPreference.ShowCurrentTitle. %s", err.Error())
 	}
 
-	err = pp.BlockFriendRequests.ExtractFrom(readable)
-	if err != nil {
+	if err := pp.BlockFriendRequests.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PrincipalPreference.BlockFriendRequests. %s", err.Error())
 	}
 

--- a/friends-wiiu/types/principal_request_block_setting.go
+++ b/friends-wiiu/types/principal_request_block_setting.go
@@ -34,25 +34,19 @@ func (prbs PrincipalRequestBlockSetting) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the PrincipalRequestBlockSetting from the given readable
 func (prbs *PrincipalRequestBlockSetting) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = prbs.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := prbs.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PrincipalRequestBlockSetting.Data. %s", err.Error())
 	}
 
-	err = prbs.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := prbs.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PrincipalRequestBlockSetting header. %s", err.Error())
 	}
 
-	err = prbs.PID.ExtractFrom(readable)
-	if err != nil {
+	if err := prbs.PID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PrincipalRequestBlockSetting.PID. %s", err.Error())
 	}
 
-	err = prbs.IsBlocked.ExtractFrom(readable)
-	if err != nil {
+	if err := prbs.IsBlocked.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PrincipalRequestBlockSetting.IsBlocked. %s", err.Error())
 	}
 

--- a/friends/types/friend_data.go
+++ b/friends/types/friend_data.go
@@ -37,35 +37,27 @@ func (fd FriendData) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the FriendData from the given readable
 func (fd *FriendData) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = fd.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := fd.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendData header. %s", err.Error())
 	}
 
-	err = fd.PID.ExtractFrom(readable)
-	if err != nil {
+	if err := fd.PID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendData.PID. %s", err.Error())
 	}
 
-	err = fd.StrName.ExtractFrom(readable)
-	if err != nil {
+	if err := fd.StrName.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendData.StrName. %s", err.Error())
 	}
 
-	err = fd.ByRelationship.ExtractFrom(readable)
-	if err != nil {
+	if err := fd.ByRelationship.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendData.ByRelationship. %s", err.Error())
 	}
 
-	err = fd.UIDetails.ExtractFrom(readable)
-	if err != nil {
+	if err := fd.UIDetails.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendData.UIDetails. %s", err.Error())
 	}
 
-	err = fd.StrStatus.ExtractFrom(readable)
-	if err != nil {
+	if err := fd.StrStatus.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendData.StrStatus. %s", err.Error())
 	}
 

--- a/friends/types/relationship_data.go
+++ b/friends/types/relationship_data.go
@@ -37,35 +37,27 @@ func (rd RelationshipData) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the RelationshipData from the given readable
 func (rd *RelationshipData) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = rd.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := rd.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RelationshipData header. %s", err.Error())
 	}
 
-	err = rd.PID.ExtractFrom(readable)
-	if err != nil {
+	if err := rd.PID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RelationshipData.PID. %s", err.Error())
 	}
 
-	err = rd.StrName.ExtractFrom(readable)
-	if err != nil {
+	if err := rd.StrName.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RelationshipData.StrName. %s", err.Error())
 	}
 
-	err = rd.ByRelationship.ExtractFrom(readable)
-	if err != nil {
+	if err := rd.ByRelationship.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RelationshipData.ByRelationship. %s", err.Error())
 	}
 
-	err = rd.UIDetails.ExtractFrom(readable)
-	if err != nil {
+	if err := rd.UIDetails.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RelationshipData.UIDetails. %s", err.Error())
 	}
 
-	err = rd.ByStatus.ExtractFrom(readable)
-	if err != nil {
+	if err := rd.ByStatus.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RelationshipData.ByStatus. %s", err.Error())
 	}
 

--- a/match-making/constants/participation_policy.go
+++ b/match-making/constants/participation_policy.go
@@ -28,6 +28,9 @@ func (pp *ParticipationPolicy) ExtractFrom(readable types.Readable) error {
 
 const (
 	// ParticipationPolicyPasswordProtected indicates that a session is protected by as password.
+	//
+	// When used, the PolicyArgument is the first four bytes of the MD5 hash of the key given
+	// to the participant
 	ParticipationPolicyPasswordProtected ParticipationPolicy = 4
 
 	// ParticipationPolicyOpenParticipation indicates that a session is open to anyone.

--- a/match-making/types/auto_matchmake_param.go
+++ b/match-making/types/auto_matchmake_param.go
@@ -44,50 +44,39 @@ func (amp AutoMatchmakeParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the AutoMatchmakeParam from the given readable
 func (amp *AutoMatchmakeParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = amp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := amp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AutoMatchmakeParam header. %s", err.Error())
 	}
 
-	err = amp.SourceMatchmakeSession.ExtractFrom(readable)
-	if err != nil {
+	if err := amp.SourceMatchmakeSession.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AutoMatchmakeParam.SourceMatchmakeSession. %s", err.Error())
 	}
 
-	err = amp.AdditionalParticipants.ExtractFrom(readable)
-	if err != nil {
+	if err := amp.AdditionalParticipants.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AutoMatchmakeParam.AdditionalParticipants. %s", err.Error())
 	}
 
-	err = amp.GIDForParticipationCheck.ExtractFrom(readable)
-	if err != nil {
+	if err := amp.GIDForParticipationCheck.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AutoMatchmakeParam.GIDForParticipationCheck. %s", err.Error())
 	}
 
-	err = amp.AutoMatchmakeOption.ExtractFrom(readable)
-	if err != nil {
+	if err := amp.AutoMatchmakeOption.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AutoMatchmakeParam.AutoMatchmakeOption. %s", err.Error())
 	}
 
-	err = amp.JoinMessage.ExtractFrom(readable)
-	if err != nil {
+	if err := amp.JoinMessage.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AutoMatchmakeParam.JoinMessage. %s", err.Error())
 	}
 
-	err = amp.ParticipationCount.ExtractFrom(readable)
-	if err != nil {
+	if err := amp.ParticipationCount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AutoMatchmakeParam.ParticipationCount. %s", err.Error())
 	}
 
-	err = amp.LstSearchCriteria.ExtractFrom(readable)
-	if err != nil {
+	if err := amp.LstSearchCriteria.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AutoMatchmakeParam.LstSearchCriteria. %s", err.Error())
 	}
 
-	err = amp.TargetGIDs.ExtractFrom(readable)
-	if err != nil {
+	if err := amp.TargetGIDs.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AutoMatchmakeParam.TargetGIDs. %s", err.Error())
 	}
 

--- a/match-making/types/create_matchmake_session_param.go
+++ b/match-making/types/create_matchmake_session_param.go
@@ -39,40 +39,31 @@ func (cmsp CreateMatchmakeSessionParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the CreateMatchmakeSessionParam from the given readable
 func (cmsp *CreateMatchmakeSessionParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = cmsp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := cmsp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract CreateMatchmakeSessionParam header. %s", err.Error())
 	}
 
-	err = cmsp.SourceMatchmakeSession.ExtractFrom(readable)
-	if err != nil {
+	if err := cmsp.SourceMatchmakeSession.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract CreateMatchmakeSessionParam.SourceMatchmakeSession. %s", err.Error())
 	}
 
-	err = cmsp.AdditionalParticipants.ExtractFrom(readable)
-	if err != nil {
+	if err := cmsp.AdditionalParticipants.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract CreateMatchmakeSessionParam.AdditionalParticipants. %s", err.Error())
 	}
 
-	err = cmsp.GIDForParticipationCheck.ExtractFrom(readable)
-	if err != nil {
+	if err := cmsp.GIDForParticipationCheck.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract CreateMatchmakeSessionParam.GIDForParticipationCheck. %s", err.Error())
 	}
 
-	err = cmsp.CreateMatchmakeSessionOption.ExtractFrom(readable)
-	if err != nil {
+	if err := cmsp.CreateMatchmakeSessionOption.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract CreateMatchmakeSessionParam.CreateMatchmakeSessionOption. %s", err.Error())
 	}
 
-	err = cmsp.JoinMessage.ExtractFrom(readable)
-	if err != nil {
+	if err := cmsp.JoinMessage.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract CreateMatchmakeSessionParam.JoinMessage. %s", err.Error())
 	}
 
-	err = cmsp.ParticipationCount.ExtractFrom(readable)
-	if err != nil {
+	if err := cmsp.ParticipationCount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract CreateMatchmakeSessionParam.ParticipationCount. %s", err.Error())
 	}
 

--- a/match-making/types/deletion_entry.go
+++ b/match-making/types/deletion_entry.go
@@ -33,25 +33,19 @@ func (de DeletionEntry) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the DeletionEntry from the given readable
 func (de *DeletionEntry) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = de.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := de.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DeletionEntry header. %s", err.Error())
 	}
 
-	err = de.IDGathering.ExtractFrom(readable)
-	if err != nil {
+	if err := de.IDGathering.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DeletionEntry.IDGathering. %s", err.Error())
 	}
 
-	err = de.PID.ExtractFrom(readable)
-	if err != nil {
+	if err := de.PID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DeletionEntry.PID. %s", err.Error())
 	}
 
-	err = de.UIReason.ExtractFrom(readable)
-	if err != nil {
+	if err := de.UIReason.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract DeletionEntry.UIReason. %s", err.Error())
 	}
 

--- a/match-making/types/find_matchmake_session_by_participant_param.go
+++ b/match-making/types/find_matchmake_session_by_participant_param.go
@@ -34,25 +34,19 @@ func (fmsbpp FindMatchmakeSessionByParticipantParam) WriteTo(writable types.Writ
 
 // ExtractFrom extracts the FindMatchmakeSessionByParticipantParam from the given readable
 func (fmsbpp *FindMatchmakeSessionByParticipantParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = fmsbpp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := fmsbpp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FindMatchmakeSessionByParticipantParam header. %s", err.Error())
 	}
 
-	err = fmsbpp.PrincipalIDList.ExtractFrom(readable)
-	if err != nil {
+	if err := fmsbpp.PrincipalIDList.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FindMatchmakeSessionByParticipantParam.PrincipalIDList. %s", err.Error())
 	}
 
-	err = fmsbpp.ResultOptions.ExtractFrom(readable)
-	if err != nil {
+	if err := fmsbpp.ResultOptions.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FindMatchmakeSessionByParticipantParam.ResultOptions. %s", err.Error())
 	}
 
-	err = fmsbpp.BlockListParam.ExtractFrom(readable)
-	if err != nil {
+	if err := fmsbpp.BlockListParam.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FindMatchmakeSessionByParticipantParam.BlockListParam. %s", err.Error())
 	}
 

--- a/match-making/types/find_matchmake_session_by_participant_result.go
+++ b/match-making/types/find_matchmake_session_by_participant_result.go
@@ -31,20 +31,15 @@ func (fmsbpr FindMatchmakeSessionByParticipantResult) WriteTo(writable types.Wri
 
 // ExtractFrom extracts the FindMatchmakeSessionByParticipantResult from the given readable
 func (fmsbpr *FindMatchmakeSessionByParticipantResult) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = fmsbpr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := fmsbpr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FindMatchmakeSessionByParticipantResult header. %s", err.Error())
 	}
 
-	err = fmsbpr.PrincipalID.ExtractFrom(readable)
-	if err != nil {
+	if err := fmsbpr.PrincipalID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FindMatchmakeSessionByParticipantResult.PrincipalID. %s", err.Error())
 	}
 
-	err = fmsbpr.Session.ExtractFrom(readable)
-	if err != nil {
+	if err := fmsbpr.Session.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FindMatchmakeSessionByParticipantResult.Session. %s", err.Error())
 	}
 

--- a/match-making/types/gathering.go
+++ b/match-making/types/gathering.go
@@ -58,60 +58,47 @@ func (g Gathering) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the Gathering from the given readable
 func (g *Gathering) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = g.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := g.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Gathering header. %s", err.Error())
 	}
 
-	err = g.ID.ExtractFrom(readable)
-	if err != nil {
+	if err := g.ID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Gathering.ID. %s", err.Error())
 	}
 
-	err = g.OwnerPID.ExtractFrom(readable)
-	if err != nil {
+	if err := g.OwnerPID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Gathering.OwnerPID. %s", err.Error())
 	}
 
-	err = g.HostPID.ExtractFrom(readable)
-	if err != nil {
+	if err := g.HostPID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Gathering.HostPID. %s", err.Error())
 	}
 
-	err = g.MinimumParticipants.ExtractFrom(readable)
-	if err != nil {
+	if err := g.MinimumParticipants.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Gathering.MinimumParticipants. %s", err.Error())
 	}
 
-	err = g.MaximumParticipants.ExtractFrom(readable)
-	if err != nil {
+	if err := g.MaximumParticipants.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Gathering.MaximumParticipants. %s", err.Error())
 	}
 
-	err = g.ParticipationPolicy.ExtractFrom(readable)
-	if err != nil {
+	if err := g.ParticipationPolicy.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Gathering.ParticipationPolicy. %s", err.Error())
 	}
 
-	err = g.PolicyArgument.ExtractFrom(readable)
-	if err != nil {
+	if err := g.PolicyArgument.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Gathering.PolicyArgument. %s", err.Error())
 	}
 
-	err = g.Flags.ExtractFrom(readable)
-	if err != nil {
+	if err := g.Flags.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Gathering.Flags. %s", err.Error())
 	}
 
-	err = g.State.ExtractFrom(readable)
-	if err != nil {
+	if err := g.State.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Gathering.State. %s", err.Error())
 	}
 
-	err = g.Description.ExtractFrom(readable)
-	if err != nil {
+	if err := g.Description.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Gathering.Description. %s", err.Error())
 	}
 

--- a/match-making/types/gathering_stats.go
+++ b/match-making/types/gathering_stats.go
@@ -33,25 +33,19 @@ func (gs GatheringStats) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the GatheringStats from the given readable
 func (gs *GatheringStats) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gs.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gs.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GatheringStats header. %s", err.Error())
 	}
 
-	err = gs.PIDParticipant.ExtractFrom(readable)
-	if err != nil {
+	if err := gs.PIDParticipant.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GatheringStats.PIDParticipant. %s", err.Error())
 	}
 
-	err = gs.UIFlags.ExtractFrom(readable)
-	if err != nil {
+	if err := gs.UIFlags.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GatheringStats.UIFlags. %s", err.Error())
 	}
 
-	err = gs.LstValues.ExtractFrom(readable)
-	if err != nil {
+	if err := gs.LstValues.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GatheringStats.LstValues. %s", err.Error())
 	}
 

--- a/match-making/types/gathering_urls.go
+++ b/match-making/types/gathering_urls.go
@@ -31,20 +31,15 @@ func (gurl GatheringURLs) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the GatheringURLs from the given readable
 func (gurl *GatheringURLs) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = gurl.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := gurl.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GatheringURLs header. %s", err.Error())
 	}
 
-	err = gurl.GID.ExtractFrom(readable)
-	if err != nil {
+	if err := gurl.GID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GatheringURLs.GID. %s", err.Error())
 	}
 
-	err = gurl.LstStationURLs.ExtractFrom(readable)
-	if err != nil {
+	if err := gurl.LstStationURLs.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract GatheringURLs.LstStationURLs. %s", err.Error())
 	}
 

--- a/match-making/types/invitation.go
+++ b/match-making/types/invitation.go
@@ -33,25 +33,19 @@ func (i Invitation) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the Invitation from the given readable
 func (i *Invitation) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = i.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := i.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Invitation header. %s", err.Error())
 	}
 
-	err = i.IDGathering.ExtractFrom(readable)
-	if err != nil {
+	if err := i.IDGathering.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Invitation.IDGathering. %s", err.Error())
 	}
 
-	err = i.IDGuest.ExtractFrom(readable)
-	if err != nil {
+	if err := i.IDGuest.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Invitation.IDGuest. %s", err.Error())
 	}
 
-	err = i.StrMessage.ExtractFrom(readable)
-	if err != nil {
+	if err := i.StrMessage.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Invitation.StrMessage. %s", err.Error())
 	}
 

--- a/match-making/types/join_matchmake_session_param.go
+++ b/match-making/types/join_matchmake_session_param.go
@@ -63,68 +63,54 @@ func (jmsp *JoinMatchmakeSessionParam) ExtractFrom(readable types.Readable) erro
 	stream := readable.(*nex.ByteStreamIn)
 	libraryVersion := stream.LibraryVersions.MatchMaking
 
-	var err error
-
-	err = jmsp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := jmsp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract JoinMatchmakeSessionParam header. %s", err.Error())
 	}
 
-	err = jmsp.GID.ExtractFrom(readable)
-	if err != nil {
+	if err := jmsp.GID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract JoinMatchmakeSessionParam.GID. %s", err.Error())
 	}
 
-	err = jmsp.AdditionalParticipants.ExtractFrom(readable)
-	if err != nil {
+	if err := jmsp.AdditionalParticipants.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract JoinMatchmakeSessionParam.AdditionalParticipants. %s", err.Error())
 	}
 
-	err = jmsp.GIDForParticipationCheck.ExtractFrom(readable)
-	if err != nil {
+	if err := jmsp.GIDForParticipationCheck.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract JoinMatchmakeSessionParam.GIDForParticipationCheck. %s", err.Error())
 	}
 
-	err = jmsp.JoinMatchmakeSessionOption.ExtractFrom(readable)
-	if err != nil {
+	if err := jmsp.JoinMatchmakeSessionOption.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract JoinMatchmakeSessionParam.JoinMatchmakeSessionOption. %s", err.Error())
 	}
 
-	err = jmsp.JoinMatchmakeSessionBehavior.ExtractFrom(readable)
-	if err != nil {
+	if err := jmsp.JoinMatchmakeSessionBehavior.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract JoinMatchmakeSessionParam.JoinMatchmakeSessionBehavior. %s", err.Error())
 	}
 
-	err = jmsp.StrUserPassword.ExtractFrom(readable)
-	if err != nil {
+	if err := jmsp.StrUserPassword.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract JoinMatchmakeSessionParam.StrUserPassword. %s", err.Error())
 	}
 
-	err = jmsp.StrSystemPassword.ExtractFrom(readable)
-	if err != nil {
+	if err := jmsp.StrSystemPassword.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract JoinMatchmakeSessionParam.StrSystemPassword. %s", err.Error())
 	}
 
-	err = jmsp.JoinMessage.ExtractFrom(readable)
-	if err != nil {
+	if err := jmsp.JoinMessage.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract JoinMatchmakeSessionParam.JoinMessage. %s", err.Error())
 	}
 
-	err = jmsp.ParticipationCount.ExtractFrom(readable)
-	if err != nil {
+	if err := jmsp.ParticipationCount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract JoinMatchmakeSessionParam.ParticipationCount. %s", err.Error())
 	}
 
 	if jmsp.StructureVersion >= 1 || libraryVersion.GreaterOrEqual("4.0") {
-		err = jmsp.ExtraParticipants.ExtractFrom(readable)
-		if err != nil {
+		if err := jmsp.ExtraParticipants.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract JoinMatchmakeSessionParam.ExtraParticipants. %s", err.Error())
 		}
 	}
 
 	if libraryVersion.GreaterOrEqual("4.0") {
-		err = jmsp.BlockListParam.ExtractFrom(readable)
-		if err != nil {
+		if err := jmsp.BlockListParam.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract JoinMatchmakeSessionParam.BlockListParam. %s", err.Error())
 		}
 	}

--- a/match-making/types/matchmake_block_list_param.go
+++ b/match-making/types/matchmake_block_list_param.go
@@ -29,15 +29,11 @@ func (mblp MatchmakeBlockListParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the MatchmakeBlockListParam from the given readable
 func (mblp *MatchmakeBlockListParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = mblp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := mblp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeBlockListParam header. %s", err.Error())
 	}
 
-	err = mblp.OptionFlag.ExtractFrom(readable)
-	if err != nil {
+	if err := mblp.OptionFlag.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeBlockListParam.OptionFlag. %s", err.Error())
 	}
 

--- a/match-making/types/matchmake_param.go
+++ b/match-making/types/matchmake_param.go
@@ -29,15 +29,11 @@ func (mp MatchmakeParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the MatchmakeParam from the given readable
 func (mp *MatchmakeParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = mp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := mp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeParam header. %s", err.Error())
 	}
 
-	err = mp.Params.ExtractFrom(readable)
-	if err != nil {
+	if err := mp.Params.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeParam.Params. %s", err.Error())
 	}
 

--- a/match-making/types/matchmake_session.go
+++ b/match-making/types/matchmake_session.go
@@ -110,114 +110,94 @@ func (ms *MatchmakeSession) ExtractFrom(readable types.Readable) error {
 	stream := readable.(*nex.ByteStreamIn)
 	libraryVersion := stream.LibraryVersions.MatchMaking
 
-	var err error
-
-	err = ms.Gathering.ExtractFrom(readable)
-	if err != nil {
+	if err := ms.Gathering.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeSession.Gathering. %s", err.Error())
 	}
 
-	err = ms.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := ms.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeSession header. %s", err.Error())
 	}
 
-	err = ms.GameMode.ExtractFrom(readable)
-	if err != nil {
+	if err := ms.GameMode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeSession.GameMode. %s", err.Error())
 	}
 
-	err = ms.Attributes.ExtractFrom(readable)
-	if err != nil {
+	if err := ms.Attributes.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeSession.Attributes. %s", err.Error())
 	}
 
-	err = ms.OpenParticipation.ExtractFrom(readable)
-	if err != nil {
+	if err := ms.OpenParticipation.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeSession.OpenParticipation. %s", err.Error())
 	}
 
-	err = ms.MatchmakeSystemType.ExtractFrom(readable)
-	if err != nil {
+	if err := ms.MatchmakeSystemType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeSession.MatchmakeSystemType. %s", err.Error())
 	}
 
-	err = ms.ApplicationBuffer.ExtractFrom(readable)
-	if err != nil {
+	if err := ms.ApplicationBuffer.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeSession.ApplicationBuffer. %s", err.Error())
 	}
 
-	err = ms.ParticipationCount.ExtractFrom(readable)
-	if err != nil {
+	if err := ms.ParticipationCount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeSession.ParticipationCount. %s", err.Error())
 	}
 
 	if libraryVersion.GreaterOrEqual("3.4.0") {
-		err = ms.ProgressScore.ExtractFrom(readable)
-		if err != nil {
+		if err := ms.ProgressScore.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract MatchmakeSession.ProgressScore. %s", err.Error())
 		}
 	}
 
 	if libraryVersion.GreaterOrEqual("3.0.0") {
-		err = ms.SessionKey.ExtractFrom(readable)
-		if err != nil {
+		if err := ms.SessionKey.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract MatchmakeSession.SessionKey. %s", err.Error())
 		}
 	}
 
 	if libraryVersion.GreaterOrEqual("3.5.0") {
-		err = ms.Option0.ExtractFrom(readable)
-		if err != nil {
+		if err := ms.Option0.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract MatchmakeSession.Option0. %s", err.Error())
 		}
 	}
 
 	if libraryVersion.GreaterOrEqual("3.6.0") {
-		err = ms.MatchmakeParam.ExtractFrom(readable)
-		if err != nil {
+		if err := ms.MatchmakeParam.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract MatchmakeSession.MatchmakeParam. %s", err.Error())
 		}
 	}
 
 	if libraryVersion.GreaterOrEqual("3.6.0") {
-		err = ms.StartedTime.ExtractFrom(readable)
-		if err != nil {
+		if err := ms.StartedTime.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract MatchmakeSession.StartedTime. %s", err.Error())
 		}
 	}
 
 	if libraryVersion.GreaterOrEqual("3.7.0") {
-		err = ms.UserPassword.ExtractFrom(readable)
-		if err != nil {
+		if err := ms.UserPassword.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract MatchmakeSession.UserPassword. %s", err.Error())
 		}
 	}
 
 	if libraryVersion.GreaterOrEqual("3.8.0") {
-		err = ms.ReferGID.ExtractFrom(readable)
-		if err != nil {
+		if err := ms.ReferGID.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract MatchmakeSession.ReferGID. %s", err.Error())
 		}
 	}
 
 	if libraryVersion.GreaterOrEqual("3.8.0") {
-		err = ms.UserPasswordEnabled.ExtractFrom(readable)
-		if err != nil {
+		if err := ms.UserPasswordEnabled.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract MatchmakeSession.UserPasswordEnabled. %s", err.Error())
 		}
 	}
 
 	if libraryVersion.GreaterOrEqual("3.8.0") {
-		err = ms.SystemPasswordEnabled.ExtractFrom(readable)
-		if err != nil {
+		if err := ms.SystemPasswordEnabled.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract MatchmakeSession.SystemPasswordEnabled. %s", err.Error())
 		}
 	}
 
 	if libraryVersion.GreaterOrEqual("4.0.0") {
-		err = ms.CodeWord.ExtractFrom(readable)
-		if err = ms.CodeWord.ExtractFrom(readable); err != nil {
+		if err := ms.CodeWord.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract MatchmakeSession.CodeWord. %s", err.Error())
 		}
 	}

--- a/match-making/types/matchmake_session_search_criteria.go
+++ b/match-making/types/matchmake_session_search_criteria.go
@@ -98,109 +98,90 @@ func (mssc *MatchmakeSessionSearchCriteria) ExtractFrom(readable types.Readable)
 	stream := readable.(*nex.ByteStreamIn)
 	libraryVersion := stream.LibraryVersions.MatchMaking
 
-	var err error
-
-	err = mssc.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := mssc.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria header. %s", err.Error())
 	}
 
-	err = mssc.Attribs.ExtractFrom(readable)
-	if err != nil {
+	if err := mssc.Attribs.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.Attribs. %s", err.Error())
 	}
 
-	err = mssc.GameMode.ExtractFrom(readable)
-	if err != nil {
+	if err := mssc.GameMode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.GameMode. %s", err.Error())
 	}
 
 	if libraryVersion.GreaterOrEqual("2.0.0") {
-		err = mssc.MinParticipants.ExtractFrom(readable)
-		if err != nil {
+		if err := mssc.MinParticipants.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.MinParticipants. %s", err.Error())
 		}
 	}
 
 	if libraryVersion.GreaterOrEqual("2.0.0") {
-		err = mssc.MaxParticipants.ExtractFrom(readable)
-		if err != nil {
+		if err := mssc.MaxParticipants.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.MaxParticipants. %s", err.Error())
 		}
 	}
 
-	err = mssc.MatchmakeSystemType.ExtractFrom(readable)
-	if err != nil {
+	if err := mssc.MatchmakeSystemType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.MatchmakeSystemType. %s", err.Error())
 	}
 
-	err = mssc.VacantOnly.ExtractFrom(readable)
-	if err != nil {
+	if err := mssc.VacantOnly.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.VacantOnly. %s", err.Error())
 	}
 
-	err = mssc.ExcludeLocked.ExtractFrom(readable)
-	if err != nil {
+	if err := mssc.ExcludeLocked.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.ExcludeLocked. %s", err.Error())
 	}
 
-	err = mssc.ExcludeNonHostPID.ExtractFrom(readable)
-	if err != nil {
+	if err := mssc.ExcludeNonHostPID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.ExcludeNonHostPID. %s", err.Error())
 	}
 
 	if libraryVersion.GreaterOrEqual("3.0.0") {
-		err = mssc.SelectionMethod.ExtractFrom(readable)
-		if err != nil {
+		if err := mssc.SelectionMethod.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.SelectionMethod. %s", err.Error())
 		}
 	}
 
 	if libraryVersion.GreaterOrEqual("3.4.0") {
-		err = mssc.VacantParticipants.ExtractFrom(readable)
-		if err != nil {
+		if err := mssc.VacantParticipants.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.VacantParticipants. %s", err.Error())
 		}
 	}
 
 	if libraryVersion.GreaterOrEqual("3.6.0") {
-		err = mssc.MatchmakeParam.ExtractFrom(readable)
-		if err != nil {
+		if err := mssc.MatchmakeParam.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.MatchmakeParam. %s", err.Error())
 		}
 	}
 
 	if libraryVersion.GreaterOrEqual("3.7.0") {
-		err = mssc.ExcludeUserPasswordSet.ExtractFrom(readable)
-		if err != nil {
+		if err := mssc.ExcludeUserPasswordSet.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.ExcludeUserPasswordSet. %s", err.Error())
 		}
 	}
 
 	if libraryVersion.GreaterOrEqual("3.7.0") {
-		err = mssc.ExcludeSystemPasswordSet.ExtractFrom(readable)
-		if err != nil {
+		if err := mssc.ExcludeSystemPasswordSet.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.ExcludeSystemPasswordSet. %s", err.Error())
 		}
 	}
 
 	if libraryVersion.GreaterOrEqual("3.8.0") {
-		err = mssc.ReferGID.ExtractFrom(readable)
-		if err != nil {
+		if err := mssc.ReferGID.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.ReferGID. %s", err.Error())
 		}
 	}
 
 	if libraryVersion.GreaterOrEqual("4.0.0") {
-		err = mssc.CodeWord.ExtractFrom(readable)
-		if err != nil {
+		if err := mssc.CodeWord.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.CodeWord. %s", err.Error())
 		}
 	}
 
 	if libraryVersion.GreaterOrEqual("4.0.0") {
-		err = mssc.ResultRange.ExtractFrom(readable)
-		if err != nil {
+		if err := mssc.ResultRange.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract MatchmakeSessionSearchCriteria.ResultRange. %s", err.Error())
 		}
 	}

--- a/match-making/types/participant_details.go
+++ b/match-making/types/participant_details.go
@@ -35,30 +35,23 @@ func (pd ParticipantDetails) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ParticipantDetails from the given readable
 func (pd *ParticipantDetails) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = pd.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := pd.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ParticipantDetails header. %s", err.Error())
 	}
 
-	err = pd.IDParticipant.ExtractFrom(readable)
-	if err != nil {
+	if err := pd.IDParticipant.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ParticipantDetails.IDParticipant. %s", err.Error())
 	}
 
-	err = pd.StrName.ExtractFrom(readable)
-	if err != nil {
+	if err := pd.StrName.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ParticipantDetails.StrName. %s", err.Error())
 	}
 
-	err = pd.StrMessage.ExtractFrom(readable)
-	if err != nil {
+	if err := pd.StrMessage.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ParticipantDetails.StrMessage. %s", err.Error())
 	}
 
-	err = pd.UIParticipants.ExtractFrom(readable)
-	if err != nil {
+	if err := pd.UIParticipants.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ParticipantDetails.UIParticipants. %s", err.Error())
 	}
 

--- a/match-making/types/persistent_gathering.go
+++ b/match-making/types/persistent_gathering.go
@@ -46,55 +46,43 @@ func (pg PersistentGathering) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the PersistentGathering from the given readable
 func (pg *PersistentGathering) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = pg.Gathering.ExtractFrom(readable)
-	if err != nil {
+	if err := pg.Gathering.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PersistentGathering.Gathering. %s", err.Error())
 	}
 
-	err = pg.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := pg.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PersistentGathering header. %s", err.Error())
 	}
 
-	err = pg.CommunityType.ExtractFrom(readable)
-	if err != nil {
+	if err := pg.CommunityType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PersistentGathering.CommunityType. %s", err.Error())
 	}
 
-	err = pg.Password.ExtractFrom(readable)
-	if err != nil {
+	if err := pg.Password.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PersistentGathering.Password. %s", err.Error())
 	}
 
-	err = pg.Attribs.ExtractFrom(readable)
-	if err != nil {
+	if err := pg.Attribs.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PersistentGathering.Attribs. %s", err.Error())
 	}
 
-	err = pg.ApplicationBuffer.ExtractFrom(readable)
-	if err != nil {
+	if err := pg.ApplicationBuffer.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PersistentGathering.ApplicationBuffer. %s", err.Error())
 	}
 
-	err = pg.ParticipationStartDate.ExtractFrom(readable)
-	if err != nil {
+	if err := pg.ParticipationStartDate.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PersistentGathering.ParticipationStartDate. %s", err.Error())
 	}
 
-	err = pg.ParticipationEndDate.ExtractFrom(readable)
-	if err != nil {
+	if err := pg.ParticipationEndDate.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PersistentGathering.ParticipationEndDate. %s", err.Error())
 	}
 
-	err = pg.MatchmakeSessionCount.ExtractFrom(readable)
-	if err != nil {
+	if err := pg.MatchmakeSessionCount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PersistentGathering.MatchmakeSessionCount. %s", err.Error())
 	}
 
-	err = pg.ParticipationCount.ExtractFrom(readable)
-	if err != nil {
+	if err := pg.ParticipationCount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PersistentGathering.ParticipationCount. %s", err.Error())
 	}
 

--- a/match-making/types/playing_session.go
+++ b/match-making/types/playing_session.go
@@ -31,20 +31,15 @@ func (ps PlayingSession) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the PlayingSession from the given readable
 func (ps *PlayingSession) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = ps.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := ps.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PlayingSession header. %s", err.Error())
 	}
 
-	err = ps.PrincipalID.ExtractFrom(readable)
-	if err != nil {
+	if err := ps.PrincipalID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PlayingSession.PrincipalID. %s", err.Error())
 	}
 
-	err = ps.Gathering.ExtractFrom(readable)
-	if err != nil {
+	if err := ps.Gathering.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract PlayingSession.Gathering. %s", err.Error())
 	}
 

--- a/match-making/types/simple_community.go
+++ b/match-making/types/simple_community.go
@@ -31,20 +31,15 @@ func (sc SimpleCommunity) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the SimpleCommunity from the given readable
 func (sc *SimpleCommunity) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sc.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sc.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleCommunity header. %s", err.Error())
 	}
 
-	err = sc.GatheringID.ExtractFrom(readable)
-	if err != nil {
+	if err := sc.GatheringID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleCommunity.GatheringID. %s", err.Error())
 	}
 
-	err = sc.MatchmakeSessionCount.ExtractFrom(readable)
-	if err != nil {
+	if err := sc.MatchmakeSessionCount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleCommunity.MatchmakeSessionCount. %s", err.Error())
 	}
 

--- a/match-making/types/simple_playing_session.go
+++ b/match-making/types/simple_playing_session.go
@@ -35,30 +35,23 @@ func (sps SimplePlayingSession) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the SimplePlayingSession from the given readable
 func (sps *SimplePlayingSession) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sps.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sps.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimplePlayingSession header. %s", err.Error())
 	}
 
-	err = sps.PrincipalID.ExtractFrom(readable)
-	if err != nil {
+	if err := sps.PrincipalID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimplePlayingSession.PrincipalID. %s", err.Error())
 	}
 
-	err = sps.GatheringID.ExtractFrom(readable)
-	if err != nil {
+	if err := sps.GatheringID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimplePlayingSession.GatheringID. %s", err.Error())
 	}
 
-	err = sps.GameMode.ExtractFrom(readable)
-	if err != nil {
+	if err := sps.GameMode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimplePlayingSession.GameMode. %s", err.Error())
 	}
 
-	err = sps.Attribute0.ExtractFrom(readable)
-	if err != nil {
+	if err := sps.Attribute0.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimplePlayingSession.Attribute0. %s", err.Error())
 	}
 

--- a/match-making/types/update_matchmake_session_param.go
+++ b/match-making/types/update_matchmake_session_param.go
@@ -62,95 +62,75 @@ func (umsp UpdateMatchmakeSessionParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the UpdateMatchmakeSessionParam from the given readable
 func (umsp *UpdateMatchmakeSessionParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = umsp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := umsp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UpdateMatchmakeSessionParam header. %s", err.Error())
 	}
 
-	err = umsp.GID.ExtractFrom(readable)
-	if err != nil {
+	if err := umsp.GID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UpdateMatchmakeSessionParam.GID. %s", err.Error())
 	}
 
-	err = umsp.ModificationFlag.ExtractFrom(readable)
-	if err != nil {
+	if err := umsp.ModificationFlag.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UpdateMatchmakeSessionParam.ModificationFlag. %s", err.Error())
 	}
 
-	err = umsp.Attributes.ExtractFrom(readable)
-	if err != nil {
+	if err := umsp.Attributes.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UpdateMatchmakeSessionParam.Attributes. %s", err.Error())
 	}
 
-	err = umsp.OpenParticipation.ExtractFrom(readable)
-	if err != nil {
+	if err := umsp.OpenParticipation.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UpdateMatchmakeSessionParam.OpenParticipation. %s", err.Error())
 	}
 
-	err = umsp.ApplicationBuffer.ExtractFrom(readable)
-	if err != nil {
+	if err := umsp.ApplicationBuffer.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UpdateMatchmakeSessionParam.ApplicationBuffer. %s", err.Error())
 	}
 
-	err = umsp.ProgressScore.ExtractFrom(readable)
-	if err != nil {
+	if err := umsp.ProgressScore.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UpdateMatchmakeSessionParam.ProgressScore. %s", err.Error())
 	}
 
-	err = umsp.MatchmakeParam.ExtractFrom(readable)
-	if err != nil {
+	if err := umsp.MatchmakeParam.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UpdateMatchmakeSessionParam.MatchmakeParam. %s", err.Error())
 	}
 
-	err = umsp.StartedTime.ExtractFrom(readable)
-	if err != nil {
+	if err := umsp.StartedTime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UpdateMatchmakeSessionParam.StartedTime. %s", err.Error())
 	}
 
-	err = umsp.UserPassword.ExtractFrom(readable)
-	if err != nil {
+	if err := umsp.UserPassword.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UpdateMatchmakeSessionParam.UserPassword. %s", err.Error())
 	}
 
-	err = umsp.GameMode.ExtractFrom(readable)
-	if err != nil {
+	if err := umsp.GameMode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UpdateMatchmakeSessionParam.GameMode. %s", err.Error())
 	}
 
-	err = umsp.Description.ExtractFrom(readable)
-	if err != nil {
+	if err := umsp.Description.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UpdateMatchmakeSessionParam.Description. %s", err.Error())
 	}
 
-	err = umsp.MinParticipants.ExtractFrom(readable)
-	if err != nil {
+	if err := umsp.MinParticipants.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UpdateMatchmakeSessionParam.MinParticipants. %s", err.Error())
 	}
 
-	err = umsp.MaxParticipants.ExtractFrom(readable)
-	if err != nil {
+	if err := umsp.MaxParticipants.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UpdateMatchmakeSessionParam.MaxParticipants. %s", err.Error())
 	}
 
-	err = umsp.MatchmakeSystemType.ExtractFrom(readable)
-	if err != nil {
+	if err := umsp.MatchmakeSystemType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UpdateMatchmakeSessionParam.MatchmakeSystemType. %s", err.Error())
 	}
 
-	err = umsp.ParticipationPolicy.ExtractFrom(readable)
-	if err != nil {
+	if err := umsp.ParticipationPolicy.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UpdateMatchmakeSessionParam.ParticipationPolicy. %s", err.Error())
 	}
 
-	err = umsp.PolicyArgument.ExtractFrom(readable)
-	if err != nil {
+	if err := umsp.PolicyArgument.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UpdateMatchmakeSessionParam.PolicyArgument. %s", err.Error())
 	}
 
-	err = umsp.Codeword.ExtractFrom(readable)
-	if err != nil {
+	if err := umsp.Codeword.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UpdateMatchmakeSessionParam.Codeword. %s", err.Error())
 	}
 

--- a/matchmake-extension/mario-kart-8/types/simple_search_condition.go
+++ b/matchmake-extension/mario-kart-8/types/simple_search_condition.go
@@ -31,20 +31,15 @@ func (ssc SimpleSearchCondition) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the SimpleSearchCondition from the given readable
 func (ssc *SimpleSearchCondition) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = ssc.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := ssc.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchCondition header. %s", err.Error())
 	}
 
-	err = ssc.Value.ExtractFrom(readable)
-	if err != nil {
+	if err := ssc.Value.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchCondition.Value. %s", err.Error())
 	}
 
-	err = ssc.ComparisonOperator.ExtractFrom(readable)
-	if err != nil {
+	if err := ssc.ComparisonOperator.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchCondition.ComparisonOperator. %s", err.Error())
 	}
 

--- a/matchmake-extension/mario-kart-8/types/simple_search_date_time_attribute.go
+++ b/matchmake-extension/mario-kart-8/types/simple_search_date_time_attribute.go
@@ -39,40 +39,31 @@ func (ssdta SimpleSearchDateTimeAttribute) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the SimpleSearchDateTimeAttribute from the given readable
 func (ssdta *SimpleSearchDateTimeAttribute) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = ssdta.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := ssdta.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchDateTimeAttribute header. %s", err.Error())
 	}
 
-	err = ssdta.Unknown.ExtractFrom(readable)
-	if err != nil {
+	if err := ssdta.Unknown.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchDateTimeAttribute.Unknown. %s", err.Error())
 	}
 
-	err = ssdta.Unknown2.ExtractFrom(readable)
-	if err != nil {
+	if err := ssdta.Unknown2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchDateTimeAttribute.Unknown2. %s", err.Error())
 	}
 
-	err = ssdta.Unknown3.ExtractFrom(readable)
-	if err != nil {
+	if err := ssdta.Unknown3.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchDateTimeAttribute.Unknown3. %s", err.Error())
 	}
 
-	err = ssdta.Unknown4.ExtractFrom(readable)
-	if err != nil {
+	if err := ssdta.Unknown4.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchDateTimeAttribute.Unknown4. %s", err.Error())
 	}
 
-	err = ssdta.StartTime.ExtractFrom(readable)
-	if err != nil {
+	if err := ssdta.StartTime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchDateTimeAttribute.StartTime. %s", err.Error())
 	}
 
-	err = ssdta.EndTime.ExtractFrom(readable)
-	if err != nil {
+	if err := ssdta.EndTime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchDateTimeAttribute.EndTime. %s", err.Error())
 	}
 

--- a/matchmake-extension/mario-kart-8/types/simple_search_object.go
+++ b/matchmake-extension/mario-kart-8/types/simple_search_object.go
@@ -41,45 +41,35 @@ func (sso SimpleSearchObject) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the SimpleSearchObject from the given readable
 func (sso *SimpleSearchObject) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sso.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sso.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchObject header. %s", err.Error())
 	}
 
-	err = sso.ObjectID.ExtractFrom(readable)
-	if err != nil {
+	if err := sso.ObjectID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchObject.ObjectID. %s", err.Error())
 	}
 
-	err = sso.OwnerPID.ExtractFrom(readable)
-	if err != nil {
+	if err := sso.OwnerPID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchObject.OwnerPID. %s", err.Error())
 	}
 
-	err = sso.Attributes.ExtractFrom(readable)
-	if err != nil {
+	if err := sso.Attributes.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchObject.Attributes. %s", err.Error())
 	}
 
-	err = sso.Metadata.ExtractFrom(readable)
-	if err != nil {
+	if err := sso.Metadata.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchObject.Metadata. %s", err.Error())
 	}
 
-	err = sso.CommunityIDMiiverse.ExtractFrom(readable)
-	if err != nil {
+	if err := sso.CommunityIDMiiverse.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchObject.CommunityIDMiiverse. %s", err.Error())
 	}
 
-	err = sso.CommunityCode.ExtractFrom(readable)
-	if err != nil {
+	if err := sso.CommunityCode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchObject.CommunityCode. %s", err.Error())
 	}
 
-	err = sso.DatetimeAttribute.ExtractFrom(readable)
-	if err != nil {
+	if err := sso.DatetimeAttribute.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchObject.DatetimeAttribute. %s", err.Error())
 	}
 

--- a/matchmake-extension/mario-kart-8/types/simple_search_param.go
+++ b/matchmake-extension/mario-kart-8/types/simple_search_param.go
@@ -39,40 +39,31 @@ func (ssp SimpleSearchParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the SimpleSearchParam from the given readable
 func (ssp *SimpleSearchParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = ssp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := ssp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchParam header. %s", err.Error())
 	}
 
-	err = ssp.Unknown.ExtractFrom(readable)
-	if err != nil {
+	if err := ssp.Unknown.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchParam.Unknown. %s", err.Error())
 	}
 
-	err = ssp.Unknown2.ExtractFrom(readable)
-	if err != nil {
+	if err := ssp.Unknown2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchParam.Unknown2. %s", err.Error())
 	}
 
-	err = ssp.Conditions.ExtractFrom(readable)
-	if err != nil {
+	if err := ssp.Conditions.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchParam.Conditions. %s", err.Error())
 	}
 
-	err = ssp.Unknown3.ExtractFrom(readable)
-	if err != nil {
+	if err := ssp.Unknown3.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchParam.Unknown3. %s", err.Error())
 	}
 
-	err = ssp.ResultRange.ExtractFrom(readable)
-	if err != nil {
+	if err := ssp.ResultRange.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchParam.ResultRange. %s", err.Error())
 	}
 
-	err = ssp.Unknown4.ExtractFrom(readable)
-	if err != nil {
+	if err := ssp.Unknown4.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SimpleSearchParam.Unknown4. %s", err.Error())
 	}
 

--- a/matchmake-extension/monster-hunter-xx/types/friend_user_info.go
+++ b/matchmake-extension/monster-hunter-xx/types/friend_user_info.go
@@ -33,25 +33,19 @@ func (fui FriendUserInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the FriendUserInfo from the given readable
 func (fui *FriendUserInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = fui.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := fui.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendUserInfo header. %s", err.Error())
 	}
 
-	err = fui.PID.ExtractFrom(readable)
-	if err != nil {
+	if err := fui.PID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendUserInfo.PID. %s", err.Error())
 	}
 
-	err = fui.Name.ExtractFrom(readable)
-	if err != nil {
+	if err := fui.Name.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendUserInfo.Name. %s", err.Error())
 	}
 
-	err = fui.Presence.ExtractFrom(readable)
-	if err != nil {
+	if err := fui.Presence.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendUserInfo.Presence. %s", err.Error())
 	}
 

--- a/matchmake-extension/monster-hunter-xx/types/friend_user_param.go
+++ b/matchmake-extension/monster-hunter-xx/types/friend_user_param.go
@@ -29,15 +29,11 @@ func (fup FriendUserParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the FriendUserParam from the given readable
 func (fup *FriendUserParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = fup.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := fup.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendUserParam header. %s", err.Error())
 	}
 
-	err = fup.Name.ExtractFrom(readable)
-	if err != nil {
+	if err := fup.Name.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract FriendUserParam.Name. %s", err.Error())
 	}
 

--- a/matchmake-referee/types/matchmake_referee_end_round_param.go
+++ b/matchmake-referee/types/matchmake_referee_end_round_param.go
@@ -34,25 +34,19 @@ func (mrerp MatchmakeRefereeEndRoundParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the MatchmakeRefereeEndRoundParam from the given readable
 func (mrerp *MatchmakeRefereeEndRoundParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = mrerp.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := mrerp.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeEndRoundParam.Data. %s", err.Error())
 	}
 
-	err = mrerp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := mrerp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeEndRoundParam header. %s", err.Error())
 	}
 
-	err = mrerp.RoundID.ExtractFrom(readable)
-	if err != nil {
+	if err := mrerp.RoundID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeEndRoundParam.RoundID. %s", err.Error())
 	}
 
-	err = mrerp.PersonalRoundResults.ExtractFrom(readable)
-	if err != nil {
+	if err := mrerp.PersonalRoundResults.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeEndRoundParam.PersonalRoundResults. %s", err.Error())
 	}
 

--- a/matchmake-referee/types/matchmake_referee_personal_round_result.go
+++ b/matchmake-referee/types/matchmake_referee_personal_round_result.go
@@ -40,40 +40,31 @@ func (mrprr MatchmakeRefereePersonalRoundResult) WriteTo(writable types.Writable
 
 // ExtractFrom extracts the MatchmakeRefereePersonalRoundResult from the given readable
 func (mrprr *MatchmakeRefereePersonalRoundResult) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = mrprr.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := mrprr.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereePersonalRoundResult.Data. %s", err.Error())
 	}
 
-	err = mrprr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := mrprr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereePersonalRoundResult header. %s", err.Error())
 	}
 
-	err = mrprr.PID.ExtractFrom(readable)
-	if err != nil {
+	if err := mrprr.PID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereePersonalRoundResult.PID. %s", err.Error())
 	}
 
-	err = mrprr.PersonalRoundResultFlag.ExtractFrom(readable)
-	if err != nil {
+	if err := mrprr.PersonalRoundResultFlag.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereePersonalRoundResult.PersonalRoundResultFlag. %s", err.Error())
 	}
 
-	err = mrprr.RoundWinLoss.ExtractFrom(readable)
-	if err != nil {
+	if err := mrprr.RoundWinLoss.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereePersonalRoundResult.RoundWinLoss. %s", err.Error())
 	}
 
-	err = mrprr.RatingValueChange.ExtractFrom(readable)
-	if err != nil {
+	if err := mrprr.RatingValueChange.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereePersonalRoundResult.RatingValueChange. %s", err.Error())
 	}
 
-	err = mrprr.Buffer.ExtractFrom(readable)
-	if err != nil {
+	if err := mrprr.Buffer.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereePersonalRoundResult.Buffer. %s", err.Error())
 	}
 

--- a/matchmake-referee/types/matchmake_referee_round.go
+++ b/matchmake-referee/types/matchmake_referee_round.go
@@ -40,40 +40,31 @@ func (mrr MatchmakeRefereeRound) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the MatchmakeRefereeRound from the given readable
 func (mrr *MatchmakeRefereeRound) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = mrr.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := mrr.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeRound.Data. %s", err.Error())
 	}
 
-	err = mrr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := mrr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeRound header. %s", err.Error())
 	}
 
-	err = mrr.RoundID.ExtractFrom(readable)
-	if err != nil {
+	if err := mrr.RoundID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeRound.RoundID. %s", err.Error())
 	}
 
-	err = mrr.GID.ExtractFrom(readable)
-	if err != nil {
+	if err := mrr.GID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeRound.GID. %s", err.Error())
 	}
 
-	err = mrr.State.ExtractFrom(readable)
-	if err != nil {
+	if err := mrr.State.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeRound.State. %s", err.Error())
 	}
 
-	err = mrr.PersonalDataCategory.ExtractFrom(readable)
-	if err != nil {
+	if err := mrr.PersonalDataCategory.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeRound.PersonalDataCategory. %s", err.Error())
 	}
 
-	err = mrr.NormalizedPersonalRoundResults.ExtractFrom(readable)
-	if err != nil {
+	if err := mrr.NormalizedPersonalRoundResults.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeRound.NormalizedPersonalRoundResults. %s", err.Error())
 	}
 

--- a/matchmake-referee/types/matchmake_referee_start_round_param.go
+++ b/matchmake-referee/types/matchmake_referee_start_round_param.go
@@ -36,30 +36,23 @@ func (mrsrp MatchmakeRefereeStartRoundParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the MatchmakeRefereeStartRoundParam from the given readable
 func (mrsrp *MatchmakeRefereeStartRoundParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = mrsrp.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := mrsrp.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStartRoundParam.Data. %s", err.Error())
 	}
 
-	err = mrsrp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := mrsrp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStartRoundParam header. %s", err.Error())
 	}
 
-	err = mrsrp.PersonalDataCategory.ExtractFrom(readable)
-	if err != nil {
+	if err := mrsrp.PersonalDataCategory.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStartRoundParam.PersonalDataCategory. %s", err.Error())
 	}
 
-	err = mrsrp.GID.ExtractFrom(readable)
-	if err != nil {
+	if err := mrsrp.GID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStartRoundParam.GID. %s", err.Error())
 	}
 
-	err = mrsrp.PIDs.ExtractFrom(readable)
-	if err != nil {
+	if err := mrsrp.PIDs.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStartRoundParam.PIDs. %s", err.Error())
 	}
 

--- a/matchmake-referee/types/matchmake_referee_stats.go
+++ b/matchmake-referee/types/matchmake_referee_stats.go
@@ -62,95 +62,75 @@ func (mrs MatchmakeRefereeStats) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the MatchmakeRefereeStats from the given readable
 func (mrs *MatchmakeRefereeStats) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = mrs.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := mrs.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.Data. %s", err.Error())
 	}
 
-	err = mrs.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := mrs.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStats header. %s", err.Error())
 	}
 
-	err = mrs.UniqueID.ExtractFrom(readable)
-	if err != nil {
+	if err := mrs.UniqueID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.UniqueID. %s", err.Error())
 	}
 
-	err = mrs.Category.ExtractFrom(readable)
-	if err != nil {
+	if err := mrs.Category.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.Category. %s", err.Error())
 	}
 
-	err = mrs.PID.ExtractFrom(readable)
-	if err != nil {
+	if err := mrs.PID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.PID. %s", err.Error())
 	}
 
-	err = mrs.RecentDisconnection.ExtractFrom(readable)
-	if err != nil {
+	if err := mrs.RecentDisconnection.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.RecentDisconnection. %s", err.Error())
 	}
 
-	err = mrs.RecentViolation.ExtractFrom(readable)
-	if err != nil {
+	if err := mrs.RecentViolation.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.RecentViolation. %s", err.Error())
 	}
 
-	err = mrs.RecentMismatch.ExtractFrom(readable)
-	if err != nil {
+	if err := mrs.RecentMismatch.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.RecentMismatch. %s", err.Error())
 	}
 
-	err = mrs.RecentWin.ExtractFrom(readable)
-	if err != nil {
+	if err := mrs.RecentWin.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.RecentWin. %s", err.Error())
 	}
 
-	err = mrs.RecentLoss.ExtractFrom(readable)
-	if err != nil {
+	if err := mrs.RecentLoss.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.RecentLoss. %s", err.Error())
 	}
 
-	err = mrs.RecentDraw.ExtractFrom(readable)
-	if err != nil {
+	if err := mrs.RecentDraw.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.RecentDraw. %s", err.Error())
 	}
 
-	err = mrs.TotalDisconnect.ExtractFrom(readable)
-	if err != nil {
+	if err := mrs.TotalDisconnect.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.TotalDisconnect. %s", err.Error())
 	}
 
-	err = mrs.TotalViolation.ExtractFrom(readable)
-	if err != nil {
+	if err := mrs.TotalViolation.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.TotalViolation. %s", err.Error())
 	}
 
-	err = mrs.TotalMismatch.ExtractFrom(readable)
-	if err != nil {
+	if err := mrs.TotalMismatch.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.TotalMismatch. %s", err.Error())
 	}
 
-	err = mrs.TotalWin.ExtractFrom(readable)
-	if err != nil {
+	if err := mrs.TotalWin.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.TotalWin. %s", err.Error())
 	}
 
-	err = mrs.TotalLoss.ExtractFrom(readable)
-	if err != nil {
+	if err := mrs.TotalLoss.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.TotalLoss. %s", err.Error())
 	}
 
-	err = mrs.TotalDraw.ExtractFrom(readable)
-	if err != nil {
+	if err := mrs.TotalDraw.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.TotalDraw. %s", err.Error())
 	}
 
-	err = mrs.RatingValue.ExtractFrom(readable)
-	if err != nil {
+	if err := mrs.RatingValue.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStats.RatingValue. %s", err.Error())
 	}
 

--- a/matchmake-referee/types/matchmake_referee_stats_init_param.go
+++ b/matchmake-referee/types/matchmake_referee_stats_init_param.go
@@ -34,25 +34,19 @@ func (mrsip MatchmakeRefereeStatsInitParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the MatchmakeRefereeStatsInitParam from the given readable
 func (mrsip *MatchmakeRefereeStatsInitParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = mrsip.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := mrsip.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStatsInitParam.Data. %s", err.Error())
 	}
 
-	err = mrsip.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := mrsip.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStatsInitParam header. %s", err.Error())
 	}
 
-	err = mrsip.Category.ExtractFrom(readable)
-	if err != nil {
+	if err := mrsip.Category.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStatsInitParam.Category. %s", err.Error())
 	}
 
-	err = mrsip.InitialRatingValue.ExtractFrom(readable)
-	if err != nil {
+	if err := mrsip.InitialRatingValue.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStatsInitParam.InitialRatingValue. %s", err.Error())
 	}
 

--- a/matchmake-referee/types/matchmake_referee_stats_target.go
+++ b/matchmake-referee/types/matchmake_referee_stats_target.go
@@ -34,25 +34,19 @@ func (mrst MatchmakeRefereeStatsTarget) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the MatchmakeRefereeStatsTarget from the given readable
 func (mrst *MatchmakeRefereeStatsTarget) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = mrst.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := mrst.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStatsTarget.Data. %s", err.Error())
 	}
 
-	err = mrst.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := mrst.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStatsTarget header. %s", err.Error())
 	}
 
-	err = mrst.PID.ExtractFrom(readable)
-	if err != nil {
+	if err := mrst.PID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStatsTarget.PID. %s", err.Error())
 	}
 
-	err = mrst.Category.ExtractFrom(readable)
-	if err != nil {
+	if err := mrst.Category.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MatchmakeRefereeStatsTarget.Category. %s", err.Error())
 	}
 

--- a/messaging/types/binary_message.go
+++ b/messaging/types/binary_message.go
@@ -42,20 +42,15 @@ func (bm BinaryMessage) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the BinaryMessage from the given readable
 func (bm *BinaryMessage) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = bm.UserMessage.ExtractFrom(readable)
-	if err != nil {
+	if err := bm.UserMessage.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract BinaryMessage.UserMessage. %s", err.Error())
 	}
 
-	err = bm.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := bm.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract BinaryMessage header. %s", err.Error())
 	}
 
-	err = bm.BinaryBody.ExtractFrom(readable)
-	if err != nil {
+	if err := bm.BinaryBody.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract BinaryMessage.BinaryBody. %s", err.Error())
 	}
 

--- a/messaging/types/message_recipient.go
+++ b/messaging/types/message_recipient.go
@@ -49,33 +49,26 @@ func (mr *MessageRecipient) ExtractFrom(readable types.Readable) error {
 	stream := readable.(*nex.ByteStreamIn)
 	libraryVersion := stream.LibraryVersions.Messaging
 
-	var err error
-
-	err = mr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := mr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MessageRecipient header. %s", err.Error())
 	}
 
 	if !libraryVersion.GreaterOrEqual("4.0.0") {
-		err = mr.IDRecipient.ExtractFrom(readable)
-		if err != nil {
+		if err := mr.IDRecipient.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract MessageRecipient.IDRecipient. %s", err.Error())
 		}
 	}
 
-	err = mr.UIRecipientType.ExtractFrom(readable)
-	if err != nil {
+	if err := mr.UIRecipientType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract MessageRecipient.UIRecipientType. %s", err.Error())
 	}
 
 	if libraryVersion.GreaterOrEqual("4.0.0") {
-		err = mr.PrincipalID.ExtractFrom(readable)
-		if err != nil {
+		if err := mr.PrincipalID.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract MessageRecipient.PrincipalID. %s", err.Error())
 		}
 
-		err = mr.GatheringID.ExtractFrom(readable)
-		if err != nil {
+		if err := mr.GatheringID.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract MessageRecipient.GatheringID. %s", err.Error())
 		}
 	}

--- a/messaging/types/text_message.go
+++ b/messaging/types/text_message.go
@@ -42,20 +42,15 @@ func (tm TextMessage) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the TextMessage from the given readable
 func (tm *TextMessage) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = tm.UserMessage.ExtractFrom(readable)
-	if err != nil {
+	if err := tm.UserMessage.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract TextMessage.UserMessage. %s", err.Error())
 	}
 
-	err = tm.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := tm.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract TextMessage header. %s", err.Error())
 	}
 
-	err = tm.StrTextBody.ExtractFrom(readable)
-	if err != nil {
+	if err := tm.StrTextBody.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract TextMessage.StrTextBody. %s", err.Error())
 	}
 

--- a/messaging/types/user_message.go
+++ b/messaging/types/user_message.go
@@ -77,73 +77,58 @@ func (um *UserMessage) ExtractFrom(readable types.Readable) error {
 	stream := readable.(*nex.ByteStreamIn)
 	libraryVersion := stream.LibraryVersions.Messaging
 
-	var err error
-
-	err = um.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := um.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UserMessage.Data. %s", err.Error())
 	}
 
-	err = um.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := um.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UserMessage header. %s", err.Error())
 	}
 
-	err = um.UIID.ExtractFrom(readable)
-	if err != nil {
+	if err := um.UIID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UserMessage.UIID. %s", err.Error())
 	}
 
 	if !libraryVersion.GreaterOrEqual("4.0.0") {
-		err = um.IDRecipient.ExtractFrom(readable)
-		if err != nil {
+		if err := um.IDRecipient.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract UserMessage.IDRecipient. %s", err.Error())
 		}
 
-		err = um.UIRecipientType.ExtractFrom(readable)
-		if err != nil {
+		if err := um.UIRecipientType.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract UserMessage.UIRecipientType. %s", err.Error())
 		}
 	}
 
-	err = um.UIParentID.ExtractFrom(readable)
-	if err != nil {
+	if err := um.UIParentID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UserMessage.UIParentID. %s", err.Error())
 	}
 
-	err = um.PIDSender.ExtractFrom(readable)
-	if err != nil {
+	if err := um.PIDSender.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UserMessage.PIDSender. %s", err.Error())
 	}
 
-	err = um.Receptiontime.ExtractFrom(readable)
-	if err != nil {
+	if err := um.Receptiontime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UserMessage.Receptiontime. %s", err.Error())
 	}
 
-	err = um.UILifeTime.ExtractFrom(readable)
-	if err != nil {
+	if err := um.UILifeTime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UserMessage.UILifeTime. %s", err.Error())
 	}
 
-	err = um.UIFlags.ExtractFrom(readable)
-	if err != nil {
+	if err := um.UIFlags.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UserMessage.UIFlags. %s", err.Error())
 	}
 
-	err = um.StrSubject.ExtractFrom(readable)
-	if err != nil {
+	if err := um.StrSubject.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UserMessage.StrSubject. %s", err.Error())
 	}
 
-	err = um.StrSender.ExtractFrom(readable)
-	if err != nil {
+	if err := um.StrSender.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UserMessage.StrSender. %s", err.Error())
 	}
 
 	if libraryVersion.GreaterOrEqual("4.0.0") {
-		err = um.MessageRecipient.ExtractFrom(readable)
-		if err != nil {
+		if err := um.MessageRecipient.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract UserMessage.MessageRecipient. %s", err.Error())
 		}
 	}

--- a/nintendo-notifications/types/nintendo_notification_event.go
+++ b/nintendo-notifications/types/nintendo_notification_event.go
@@ -34,25 +34,19 @@ func (nne NintendoNotificationEvent) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the NintendoNotificationEvent from the given readable
 func (nne *NintendoNotificationEvent) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = nne.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := nne.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoNotificationEvent header. %s", err.Error())
 	}
 
-	err = nne.Type.ExtractFrom(readable)
-	if err != nil {
+	if err := nne.Type.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoNotificationEvent.Type. %s", err.Error())
 	}
 
-	err = nne.SenderPID.ExtractFrom(readable)
-	if err != nil {
+	if err := nne.SenderPID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoNotificationEvent.SenderPID. %s", err.Error())
 	}
 
-	err = nne.DataHolder.ExtractFrom(readable)
-	if err != nil {
+	if err := nne.DataHolder.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoNotificationEvent.DataHolder. %s", err.Error())
 	}
 

--- a/nintendo-notifications/types/nintendo_notification_event_general.go
+++ b/nintendo-notifications/types/nintendo_notification_event_general.go
@@ -48,35 +48,27 @@ func (nneg NintendoNotificationEventGeneral) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the NintendoNotificationEventGeneral from the given readable
 func (nneg *NintendoNotificationEventGeneral) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = nneg.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := nneg.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoNotificationEventGeneral.Data. %s", err.Error())
 	}
 
-	err = nneg.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := nneg.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoNotificationEventGeneral header. %s", err.Error())
 	}
 
-	err = nneg.U32Param.ExtractFrom(readable)
-	if err != nil {
+	if err := nneg.U32Param.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoNotificationEventGeneral.U32Param. %s", err.Error())
 	}
 
-	err = nneg.U64Param1.ExtractFrom(readable)
-	if err != nil {
+	if err := nneg.U64Param1.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoNotificationEventGeneral.U64Param1. %s", err.Error())
 	}
 
-	err = nneg.U64Param2.ExtractFrom(readable)
-	if err != nil {
+	if err := nneg.U64Param2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoNotificationEventGeneral.U64Param2. %s", err.Error())
 	}
 
-	err = nneg.StrParam.ExtractFrom(readable)
-	if err != nil {
+	if err := nneg.StrParam.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoNotificationEventGeneral.StrParam. %s", err.Error())
 	}
 

--- a/nintendo-notifications/types/nintendo_notification_event_profile.go
+++ b/nintendo-notifications/types/nintendo_notification_event_profile.go
@@ -40,40 +40,31 @@ func (nnep NintendoNotificationEventProfile) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the NintendoNotificationEventProfile from the given readable
 func (nnep *NintendoNotificationEventProfile) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = nnep.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := nnep.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoNotificationEventProfile.Data. %s", err.Error())
 	}
 
-	err = nnep.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := nnep.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoNotificationEventProfile header. %s", err.Error())
 	}
 
-	err = nnep.Region.ExtractFrom(readable)
-	if err != nil {
+	if err := nnep.Region.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoNotificationEventProfile.Region. %s", err.Error())
 	}
 
-	err = nnep.Country.ExtractFrom(readable)
-	if err != nil {
+	if err := nnep.Country.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoNotificationEventProfile.Country. %s", err.Error())
 	}
 
-	err = nnep.Area.ExtractFrom(readable)
-	if err != nil {
+	if err := nnep.Area.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoNotificationEventProfile.Area. %s", err.Error())
 	}
 
-	err = nnep.Language.ExtractFrom(readable)
-	if err != nil {
+	if err := nnep.Language.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoNotificationEventProfile.Language. %s", err.Error())
 	}
 
-	err = nnep.Platform.ExtractFrom(readable)
-	if err != nil {
+	if err := nnep.Platform.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoNotificationEventProfile.Platform. %s", err.Error())
 	}
 

--- a/notifications/types/notification_event.go
+++ b/notifications/types/notification_event.go
@@ -65,29 +65,23 @@ func (ne NotificationEvent) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the NotificationEvent from the given readable
 func (ne *NotificationEvent) ExtractFrom(readable types.Readable) error {
-	var err error
-
 	stream := readable.(*nex.ByteStreamIn)
 	libraryVersion := stream.LibraryVersions.Main
 
-	err = ne.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := ne.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NotificationEvent header. %s", err.Error())
 	}
 
-	err = ne.PIDSource.ExtractFrom(readable)
-	if err != nil {
+	if err := ne.PIDSource.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NotificationEvent.PIDSource. %s", err.Error())
 	}
 
-	err = ne.Type.ExtractFrom(readable)
-	if err != nil {
+	if err := ne.Type.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NotificationEvent.Type. %s", err.Error())
 	}
 
 	if libraryVersion.GreaterOrEqual("4.0.0") {
-		err = ne.Param1.ExtractFrom(readable)
-		if err != nil {
+		if err := ne.Param1.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract NotificationEvent.Param1. %s", err.Error())
 		}
 	} else {
@@ -100,8 +94,7 @@ func (ne *NotificationEvent) ExtractFrom(readable types.Readable) error {
 	}
 
 	if libraryVersion.GreaterOrEqual("4.0.0") {
-		err = ne.Param2.ExtractFrom(readable)
-		if err != nil {
+		if err := ne.Param2.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract NotificationEvent.Param2. %s", err.Error())
 		}
 	} else {
@@ -113,14 +106,12 @@ func (ne *NotificationEvent) ExtractFrom(readable types.Readable) error {
 		ne.Param2 = types.UInt64(param2)
 	}
 
-	err = ne.StrParam.ExtractFrom(readable)
-	if err != nil {
+	if err := ne.StrParam.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NotificationEvent.StrParam. %s", err.Error())
 	}
 
 	if libraryVersion.GreaterOrEqual("4.0.0") {
-		err = ne.Param3.ExtractFrom(readable)
-		if err != nil {
+		if err := ne.Param3.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract NotificationEvent.Param3. %s", err.Error())
 		}
 	} else if libraryVersion.GreaterOrEqual("3.4.0") {
@@ -133,8 +124,7 @@ func (ne *NotificationEvent) ExtractFrom(readable types.Readable) error {
 	}
 
 	if libraryVersion.GreaterOrEqual("4.0.0") && ne.StructureVersion >= 1 {
-		err = ne.MapParam.ExtractFrom(readable)
-		if err != nil {
+		if err := ne.MapParam.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract NotificationEvent.MapParam. %s", err.Error())
 		}
 	}

--- a/ranking/legacy/types/ranking_data.go
+++ b/ranking/legacy/types/ranking_data.go
@@ -59,38 +59,30 @@ func (rd *RankingData) ExtractFrom(readable types.Readable) error {
 	stream := readable.(*nex.ByteStreamIn)
 	libraryVersion := stream.LibraryVersions.Ranking
 
-	var err error
-
-	err = rd.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := rd.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingData header. %s", err.Error())
 	}
 
-	err = rd.PrincipalID.ExtractFrom(readable)
-	if err != nil {
+	if err := rd.PrincipalID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingData.PrincipalID. %s", err.Error())
 	}
 
-	err = rd.UniqueID.ExtractFrom(readable)
-	if err != nil {
+	if err := rd.UniqueID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingData.UniqueID. %s", err.Error())
 	}
 
-	err = rd.Order.ExtractFrom(readable)
-	if err != nil {
+	if err := rd.Order.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingData.Order. %s", err.Error())
 	}
 
 	if libraryVersion.GreaterOrEqual("2.0.0") {
-		err = rd.Category.ExtractFrom(readable)
-		if err != nil {
+		if err := rd.Category.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract RankingData.Category. %s", err.Error())
 		}
 	} else {
 		var category types.List[types.UInt16]
 
-		err = category.ExtractFrom(readable)
-		if err != nil {
+		if err := category.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract RankingData.Category. %s", err.Error())
 		}
 
@@ -101,23 +93,19 @@ func (rd *RankingData) ExtractFrom(readable types.Readable) error {
 		rd.Category = types.UInt32(category[0])
 	}
 
-	err = rd.Scores.ExtractFrom(readable)
-	if err != nil {
+	if err := rd.Scores.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingData.Scores. %s", err.Error())
 	}
 
-	err = rd.Unknown1.ExtractFrom(readable)
-	if err != nil {
+	if err := rd.Unknown1.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingData.Unknown1. %s", err.Error())
 	}
 
-	err = rd.Unknown2.ExtractFrom(readable)
-	if err != nil {
+	if err := rd.Unknown2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingData.Unknown2. %s", err.Error())
 	}
 
-	err = rd.CommonData.ExtractFrom(readable)
-	if err != nil {
+	if err := rd.CommonData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingData.CommonData. %s", err.Error())
 	}
 

--- a/ranking/legacy/types/ranking_order_param.go
+++ b/ranking/legacy/types/ranking_order_param.go
@@ -42,45 +42,35 @@ func (rop RankingOrderParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the RankingOrderParam from the given readable
 func (rop *RankingOrderParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = rop.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := rop.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingOrderParam header. %s", err.Error())
 	}
 
-	err = rop.ScoreIndex.ExtractFrom(readable)
-	if err != nil {
+	if err := rop.ScoreIndex.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingOrderParam.ScoreIndex. %s", err.Error())
 	}
 
-	err = rop.ScoreOrder.ExtractFrom(readable)
-	if err != nil {
+	if err := rop.ScoreOrder.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingOrderParam.ScoreOrder. %s", err.Error())
 	}
 
-	err = rop.RankCalculation.ExtractFrom(readable)
-	if err != nil {
+	if err := rop.RankCalculation.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingOrderParam.RankCalculation. %s", err.Error())
 	}
 
-	err = rop.Unknown1.ExtractFrom(readable)
-	if err != nil {
+	if err := rop.Unknown1.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingOrderParam.Unknown1. %s", err.Error())
 	}
 
-	err = rop.Unknown2.ExtractFrom(readable)
-	if err != nil {
+	if err := rop.Unknown2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingOrderParam.Unknown2. %s", err.Error())
 	}
 
-	err = rop.Unknown3.ExtractFrom(readable)
-	if err != nil {
+	if err := rop.Unknown3.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingOrderParam.Unknown3. %s", err.Error())
 	}
 
-	err = rop.Unknown4.ExtractFrom(readable)
-	if err != nil {
+	if err := rop.Unknown4.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingOrderParam.Unknown4. %s", err.Error())
 	}
 

--- a/ranking/legacy/types/ranking_score.go
+++ b/ranking/legacy/types/ranking_score.go
@@ -35,30 +35,23 @@ func (rs RankingScore) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the RankingScore from the given readable
 func (rs *RankingScore) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = rs.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := rs.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingScore header. %s", err.Error())
 	}
 
-	err = rs.Category.ExtractFrom(readable)
-	if err != nil {
+	if err := rs.Category.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingScore.Category. %s", err.Error())
 	}
 
-	err = rs.Score.ExtractFrom(readable)
-	if err != nil {
+	if err := rs.Score.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingScore.Score. %s", err.Error())
 	}
 
-	err = rs.Unknown1.ExtractFrom(readable)
-	if err != nil {
+	if err := rs.Unknown1.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingScore.Unknown1. %s", err.Error())
 	}
 
-	err = rs.Unknown2.ExtractFrom(readable)
-	if err != nil {
+	if err := rs.Unknown2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingScore.Unknown2. %s", err.Error())
 	}
 

--- a/ranking/legacy/types/ranking_score_with_limit.go
+++ b/ranking/legacy/types/ranking_score_with_limit.go
@@ -37,35 +37,27 @@ func (rswl RankingScoreWithLimit) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the RankingScoreWithLimit from the given readable
 func (rswl *RankingScoreWithLimit) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = rswl.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := rswl.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingScoreWithLimit header. %s", err.Error())
 	}
 
-	err = rswl.Category.ExtractFrom(readable)
-	if err != nil {
+	if err := rswl.Category.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingScoreWithLimit.Category. %s", err.Error())
 	}
 
-	err = rswl.Score.ExtractFrom(readable)
-	if err != nil {
+	if err := rswl.Score.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingScoreWithLimit.Score. %s", err.Error())
 	}
 
-	err = rswl.Unknown1.ExtractFrom(readable)
-	if err != nil {
+	if err := rswl.Unknown1.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingScoreWithLimit.Unknown1. %s", err.Error())
 	}
 
-	err = rswl.Unknown2.ExtractFrom(readable)
-	if err != nil {
+	if err := rswl.Unknown2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingScoreWithLimit.Unknown2. %s", err.Error())
 	}
 
-	err = rswl.Limit.ExtractFrom(readable)
-	if err != nil {
+	if err := rswl.Limit.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingScoreWithLimit.Limit. %s", err.Error())
 	}
 

--- a/ranking/mario-kart-8/types/competition_ranking_info.go
+++ b/ranking/mario-kart-8/types/competition_ranking_info.go
@@ -33,25 +33,19 @@ func (cri CompetitionRankingInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the CompetitionRankingInfo from the given readable
 func (cri *CompetitionRankingInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = cri.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := cri.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract CompetitionRankingInfo header. %s", err.Error())
 	}
 
-	err = cri.Unknown.ExtractFrom(readable)
-	if err != nil {
+	if err := cri.Unknown.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract CompetitionRankingInfo.Unknown. %s", err.Error())
 	}
 
-	err = cri.Unknown2.ExtractFrom(readable)
-	if err != nil {
+	if err := cri.Unknown2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract CompetitionRankingInfo.Unknown2. %s", err.Error())
 	}
 
-	err = cri.Unknown3.ExtractFrom(readable)
-	if err != nil {
+	if err := cri.Unknown3.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract CompetitionRankingInfo.Unknown3. %s", err.Error())
 	}
 

--- a/ranking/mario-kart-8/types/competition_ranking_info_get_param.go
+++ b/ranking/mario-kart-8/types/competition_ranking_info_get_param.go
@@ -31,20 +31,15 @@ func (crigp CompetitionRankingInfoGetParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the CompetitionRankingInfoGetParam from the given readable
 func (crigp *CompetitionRankingInfoGetParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = crigp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := crigp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract CompetitionRankingInfoGetParam header. %s", err.Error())
 	}
 
-	err = crigp.Unknown.ExtractFrom(readable)
-	if err != nil {
+	if err := crigp.Unknown.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract CompetitionRankingInfoGetParam.Unknown. %s", err.Error())
 	}
 
-	err = crigp.Result.ExtractFrom(readable)
-	if err != nil {
+	if err := crigp.Result.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract CompetitionRankingInfoGetParam.Result. %s", err.Error())
 	}
 

--- a/ranking/mario-kart-8/types/competition_ranking_upload_score_param.go
+++ b/ranking/mario-kart-8/types/competition_ranking_upload_score_param.go
@@ -43,50 +43,39 @@ func (crusp CompetitionRankingUploadScoreParam) WriteTo(writable types.Writable)
 
 // ExtractFrom extracts the CompetitionRankingUploadScoreParam from the given readable
 func (crusp *CompetitionRankingUploadScoreParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = crusp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := crusp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract CompetitionRankingUploadScoreParam header. %s", err.Error())
 	}
 
-	err = crusp.Unknown.ExtractFrom(readable)
-	if err != nil {
+	if err := crusp.Unknown.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract CompetitionRankingUploadScoreParam.Unknown. %s", err.Error())
 	}
 
-	err = crusp.Unknown2.ExtractFrom(readable)
-	if err != nil {
+	if err := crusp.Unknown2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract CompetitionRankingUploadScoreParam.Unknown2. %s", err.Error())
 	}
 
-	err = crusp.Unknown3.ExtractFrom(readable)
-	if err != nil {
+	if err := crusp.Unknown3.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract CompetitionRankingUploadScoreParam.Unknown3. %s", err.Error())
 	}
 
-	err = crusp.Unknown4.ExtractFrom(readable)
-	if err != nil {
+	if err := crusp.Unknown4.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract CompetitionRankingUploadScoreParam.Unknown4. %s", err.Error())
 	}
 
-	err = crusp.Unknown5.ExtractFrom(readable)
-	if err != nil {
+	if err := crusp.Unknown5.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract CompetitionRankingUploadScoreParam.Unknown5. %s", err.Error())
 	}
 
-	err = crusp.Unknown6.ExtractFrom(readable)
-	if err != nil {
+	if err := crusp.Unknown6.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract CompetitionRankingUploadScoreParam.Unknown6. %s", err.Error())
 	}
 
-	err = crusp.Unknown7.ExtractFrom(readable)
-	if err != nil {
+	if err := crusp.Unknown7.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract CompetitionRankingUploadScoreParam.Unknown7. %s", err.Error())
 	}
 
-	err = crusp.Metadata.ExtractFrom(readable)
-	if err != nil {
+	if err := crusp.Metadata.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract CompetitionRankingUploadScoreParam.Metadata. %s", err.Error())
 	}
 

--- a/ranking/types/ranking_cached_result.go
+++ b/ranking/types/ranking_cached_result.go
@@ -36,30 +36,23 @@ func (rcr RankingCachedResult) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the RankingCachedResult from the given readable
 func (rcr *RankingCachedResult) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = rcr.RankingResult.ExtractFrom(readable)
-	if err != nil {
+	if err := rcr.RankingResult.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingCachedResult.RankingResult. %s", err.Error())
 	}
 
-	err = rcr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := rcr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingCachedResult header. %s", err.Error())
 	}
 
-	err = rcr.CreatedTime.ExtractFrom(readable)
-	if err != nil {
+	if err := rcr.CreatedTime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingCachedResult.CreatedTime. %s", err.Error())
 	}
 
-	err = rcr.ExpiredTime.ExtractFrom(readable)
-	if err != nil {
+	if err := rcr.ExpiredTime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingCachedResult.ExpiredTime. %s", err.Error())
 	}
 
-	err = rcr.MaxLength.ExtractFrom(readable)
-	if err != nil {
+	if err := rcr.MaxLength.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingCachedResult.MaxLength. %s", err.Error())
 	}
 

--- a/ranking/types/ranking_change_attributes_param.go
+++ b/ranking/types/ranking_change_attributes_param.go
@@ -34,25 +34,19 @@ func (rcap RankingChangeAttributesParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the RankingChangeAttributesParam from the given readable
 func (rcap *RankingChangeAttributesParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = rcap.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := rcap.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingChangeAttributesParam header. %s", err.Error())
 	}
 
-	err = rcap.ModificationFlag.ExtractFrom(readable)
-	if err != nil {
+	if err := rcap.ModificationFlag.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingChangeAttributesParam.ModificationFlag. %s", err.Error())
 	}
 
-	err = rcap.Groups.ExtractFrom(readable)
-	if err != nil {
+	if err := rcap.Groups.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingChangeAttributesParam.Groups. %s", err.Error())
 	}
 
-	err = rcap.Param.ExtractFrom(readable)
-	if err != nil {
+	if err := rcap.Param.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingChangeAttributesParam.Param. %s", err.Error())
 	}
 

--- a/ranking/types/ranking_order_param.go
+++ b/ranking/types/ranking_order_param.go
@@ -40,40 +40,31 @@ func (rop RankingOrderParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the RankingOrderParam from the given readable
 func (rop *RankingOrderParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = rop.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := rop.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingOrderParam header. %s", err.Error())
 	}
 
-	err = rop.OrderCalculation.ExtractFrom(readable)
-	if err != nil {
+	if err := rop.OrderCalculation.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingOrderParam.OrderCalculation. %s", err.Error())
 	}
 
-	err = rop.GroupIndex.ExtractFrom(readable)
-	if err != nil {
+	if err := rop.GroupIndex.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingOrderParam.GroupIndex. %s", err.Error())
 	}
 
-	err = rop.GroupNum.ExtractFrom(readable)
-	if err != nil {
+	if err := rop.GroupNum.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingOrderParam.GroupNum. %s", err.Error())
 	}
 
-	err = rop.TimeScope.ExtractFrom(readable)
-	if err != nil {
+	if err := rop.TimeScope.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingOrderParam.TimeScope. %s", err.Error())
 	}
 
-	err = rop.Offset.ExtractFrom(readable)
-	if err != nil {
+	if err := rop.Offset.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingOrderParam.Offset. %s", err.Error())
 	}
 
-	err = rop.Length.ExtractFrom(readable)
-	if err != nil {
+	if err := rop.Length.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingOrderParam.Length. %s", err.Error())
 	}
 

--- a/ranking/types/ranking_rank_data.go
+++ b/ranking/types/ranking_rank_data.go
@@ -55,56 +55,44 @@ func (rrd *RankingRankData) ExtractFrom(readable types.Readable) error {
 	stream := readable.(*nex.ByteStreamIn)
 	libraryVersion := stream.LibraryVersions.Ranking
 
-	var err error
-
-	err = rrd.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := rrd.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingRankData header. %s", err.Error())
 	}
 
-	err = rrd.PrincipalID.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.PrincipalID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingRankData.PrincipalID. %s", err.Error())
 	}
 
-	err = rrd.UniqueID.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.UniqueID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingRankData.UniqueID. %s", err.Error())
 	}
 
-	err = rrd.Order.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.Order.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingRankData.Order. %s", err.Error())
 	}
 
-	err = rrd.Category.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.Category.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingRankData.Category. %s", err.Error())
 	}
 
-	err = rrd.Score.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.Score.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingRankData.Score. %s", err.Error())
 	}
 
-	err = rrd.Groups.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.Groups.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingRankData.Groups. %s", err.Error())
 	}
 
-	err = rrd.Param.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.Param.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingRankData.Param. %s", err.Error())
 	}
 
-	err = rrd.CommonData.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.CommonData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingRankData.CommonData. %s", err.Error())
 	}
 
 	if libraryVersion.GreaterOrEqual("3.6.0") {
-		err = rrd.UpdateTime.ExtractFrom(readable)
-		if err != nil {
+		if err := rrd.UpdateTime.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract RankingRankData.UpdateTime. %s", err.Error())
 		}
 	}

--- a/ranking/types/ranking_result.go
+++ b/ranking/types/ranking_result.go
@@ -33,25 +33,19 @@ func (rr RankingResult) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the RankingResult from the given readable
 func (rr *RankingResult) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = rr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := rr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingResult header. %s", err.Error())
 	}
 
-	err = rr.RankDataList.ExtractFrom(readable)
-	if err != nil {
+	if err := rr.RankDataList.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingResult.RankDataList. %s", err.Error())
 	}
 
-	err = rr.TotalCount.ExtractFrom(readable)
-	if err != nil {
+	if err := rr.TotalCount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingResult.TotalCount. %s", err.Error())
 	}
 
-	err = rr.SinceTime.ExtractFrom(readable)
-	if err != nil {
+	if err := rr.SinceTime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingResult.SinceTime. %s", err.Error())
 	}
 

--- a/ranking/types/ranking_score_data.go
+++ b/ranking/types/ranking_score_data.go
@@ -40,40 +40,31 @@ func (rsd RankingScoreData) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the RankingScoreData from the given readable
 func (rsd *RankingScoreData) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = rsd.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := rsd.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingScoreData header. %s", err.Error())
 	}
 
-	err = rsd.Category.ExtractFrom(readable)
-	if err != nil {
+	if err := rsd.Category.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingScoreData.Category. %s", err.Error())
 	}
 
-	err = rsd.Score.ExtractFrom(readable)
-	if err != nil {
+	if err := rsd.Score.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingScoreData.Score. %s", err.Error())
 	}
 
-	err = rsd.OrderBy.ExtractFrom(readable)
-	if err != nil {
+	if err := rsd.OrderBy.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingScoreData.OrderBy. %s", err.Error())
 	}
 
-	err = rsd.UpdateMode.ExtractFrom(readable)
-	if err != nil {
+	if err := rsd.UpdateMode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingScoreData.UpdateMode. %s", err.Error())
 	}
 
-	err = rsd.Groups.ExtractFrom(readable)
-	if err != nil {
+	if err := rsd.Groups.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingScoreData.Groups. %s", err.Error())
 	}
 
-	err = rsd.Param.ExtractFrom(readable)
-	if err != nil {
+	if err := rsd.Param.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingScoreData.Param. %s", err.Error())
 	}
 

--- a/ranking/types/ranking_stats.go
+++ b/ranking/types/ranking_stats.go
@@ -29,15 +29,11 @@ func (rs RankingStats) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the RankingStats from the given readable
 func (rs *RankingStats) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = rs.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := rs.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingStats header. %s", err.Error())
 	}
 
-	err = rs.StatsList.ExtractFrom(readable)
-	if err != nil {
+	if err := rs.StatsList.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingStats.StatsList. %s", err.Error())
 	}
 

--- a/ranking2/types/ranking2_category_setting.go
+++ b/ranking2/types/ranking2_category_setting.go
@@ -46,55 +46,43 @@ func (rcs Ranking2CategorySetting) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the Ranking2CategorySetting from the given readable
 func (rcs *Ranking2CategorySetting) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = rcs.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := rcs.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2CategorySetting header. %s", err.Error())
 	}
 
-	err = rcs.MinScore.ExtractFrom(readable)
-	if err != nil {
+	if err := rcs.MinScore.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2CategorySetting.MinScore. %s", err.Error())
 	}
 
-	err = rcs.MaxScore.ExtractFrom(readable)
-	if err != nil {
+	if err := rcs.MaxScore.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2CategorySetting.MaxScore. %s", err.Error())
 	}
 
-	err = rcs.LowestRank.ExtractFrom(readable)
-	if err != nil {
+	if err := rcs.LowestRank.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2CategorySetting.LowestRank. %s", err.Error())
 	}
 
-	err = rcs.ResetMonth.ExtractFrom(readable)
-	if err != nil {
+	if err := rcs.ResetMonth.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2CategorySetting.ResetMonth. %s", err.Error())
 	}
 
-	err = rcs.ResetDay.ExtractFrom(readable)
-	if err != nil {
+	if err := rcs.ResetDay.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2CategorySetting.ResetDay. %s", err.Error())
 	}
 
-	err = rcs.ResetHour.ExtractFrom(readable)
-	if err != nil {
+	if err := rcs.ResetHour.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2CategorySetting.ResetHour. %s", err.Error())
 	}
 
-	err = rcs.ResetMode.ExtractFrom(readable)
-	if err != nil {
+	if err := rcs.ResetMode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2CategorySetting.ResetMode. %s", err.Error())
 	}
 
-	err = rcs.MaxSeasonsToGoBack.ExtractFrom(readable)
-	if err != nil {
+	if err := rcs.MaxSeasonsToGoBack.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2CategorySetting.MaxSeasonsToGoBack. %s", err.Error())
 	}
 
-	err = rcs.ScoreOrder.ExtractFrom(readable)
-	if err != nil {
+	if err := rcs.ScoreOrder.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2CategorySetting.ScoreOrder. %s", err.Error())
 	}
 

--- a/ranking2/types/ranking2_chart_info.go
+++ b/ranking2/types/ranking2_chart_info.go
@@ -63,100 +63,79 @@ func (rci Ranking2ChartInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the Ranking2ChartInfo from the given readable
 func (rci *Ranking2ChartInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = rci.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := rci.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ChartInfo header. %s", err.Error())
 	}
 
-	err = rci.CreateTime.ExtractFrom(readable)
-	if err != nil {
+	if err := rci.CreateTime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ChartInfo.CreateTime. %s", err.Error())
 	}
 
-	err = rci.Index.ExtractFrom(readable)
-	if err != nil {
+	if err := rci.Index.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ChartInfo.Index. %s", err.Error())
 	}
 
-	err = rci.Category.ExtractFrom(readable)
-	if err != nil {
+	if err := rci.Category.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ChartInfo.Category. %s", err.Error())
 	}
 
-	err = rci.Season.ExtractFrom(readable)
-	if err != nil {
+	if err := rci.Season.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ChartInfo.Season. %s", err.Error())
 	}
 
-	err = rci.BinsSize.ExtractFrom(readable)
-	if err != nil {
+	if err := rci.BinsSize.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ChartInfo.BinsSize. %s", err.Error())
 	}
 
-	err = rci.SamplingRate.ExtractFrom(readable)
-	if err != nil {
+	if err := rci.SamplingRate.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ChartInfo.SamplingRate. %s", err.Error())
 	}
 
-	err = rci.ScoreOrder.ExtractFrom(readable)
-	if err != nil {
+	if err := rci.ScoreOrder.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ChartInfo.ScoreOrder. %s", err.Error())
 	}
 
-	err = rci.EstimateLength.ExtractFrom(readable)
-	if err != nil {
+	if err := rci.EstimateLength.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ChartInfo.EstimateLength. %s", err.Error())
 	}
 
-	err = rci.EstimateHighestScore.ExtractFrom(readable)
-	if err != nil {
+	if err := rci.EstimateHighestScore.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ChartInfo.EstimateHighestScore. %s", err.Error())
 	}
 
-	err = rci.EstimateLowestScore.ExtractFrom(readable)
-	if err != nil {
+	if err := rci.EstimateLowestScore.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ChartInfo.EstimateLowestScore. %s", err.Error())
 	}
 
-	err = rci.EstimateMedianScore.ExtractFrom(readable)
-	if err != nil {
+	if err := rci.EstimateMedianScore.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ChartInfo.EstimateMedianScore. %s", err.Error())
 	}
 
-	err = rci.EstimateAverageScore.ExtractFrom(readable)
-	if err != nil {
+	if err := rci.EstimateAverageScore.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ChartInfo.EstimateAverageScore. %s", err.Error())
 	}
 
-	err = rci.HighestBinsScore.ExtractFrom(readable)
-	if err != nil {
+	if err := rci.HighestBinsScore.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ChartInfo.HighestBinsScore. %s", err.Error())
 	}
 
-	err = rci.LowestBinsScore.ExtractFrom(readable)
-	if err != nil {
+	if err := rci.LowestBinsScore.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ChartInfo.LowestBinsScore. %s", err.Error())
 	}
 
-	err = rci.BinsWidth.ExtractFrom(readable)
-	if err != nil {
+	if err := rci.BinsWidth.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ChartInfo.BinsWidth. %s", err.Error())
 	}
 
-	err = rci.Attribute1.ExtractFrom(readable)
-	if err != nil {
+	if err := rci.Attribute1.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ChartInfo.Attribute1. %s", err.Error())
 	}
 
-	err = rci.Attribute2.ExtractFrom(readable)
-	if err != nil {
+	if err := rci.Attribute2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ChartInfo.Attribute2. %s", err.Error())
 	}
 
-	err = rci.Quantities.ExtractFrom(readable)
-	if err != nil {
+	if err := rci.Quantities.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ChartInfo.Quantities. %s", err.Error())
 	}
 

--- a/ranking2/types/ranking2_chart_info_input.go
+++ b/ranking2/types/ranking2_chart_info_input.go
@@ -31,20 +31,15 @@ func (rcii Ranking2ChartInfoInput) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the Ranking2ChartInfoInput from the given readable
 func (rcii *Ranking2ChartInfoInput) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = rcii.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := rcii.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ChartInfoInput header. %s", err.Error())
 	}
 
-	err = rcii.ChartIndex.ExtractFrom(readable)
-	if err != nil {
+	if err := rcii.ChartIndex.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ChartInfoInput.ChartIndex. %s", err.Error())
 	}
 
-	err = rcii.NumSeasonsToGoBack.ExtractFrom(readable)
-	if err != nil {
+	if err := rcii.NumSeasonsToGoBack.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ChartInfoInput.NumSeasonsToGoBack. %s", err.Error())
 	}
 

--- a/ranking2/types/ranking2_common_data.go
+++ b/ranking2/types/ranking2_common_data.go
@@ -33,25 +33,19 @@ func (rcd Ranking2CommonData) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the Ranking2CommonData from the given readable
 func (rcd *Ranking2CommonData) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = rcd.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := rcd.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2CommonData header. %s", err.Error())
 	}
 
-	err = rcd.UserName.ExtractFrom(readable)
-	if err != nil {
+	if err := rcd.UserName.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2CommonData.UserName. %s", err.Error())
 	}
 
-	err = rcd.Mii.ExtractFrom(readable)
-	if err != nil {
+	if err := rcd.Mii.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2CommonData.Mii. %s", err.Error())
 	}
 
-	err = rcd.BinaryData.ExtractFrom(readable)
-	if err != nil {
+	if err := rcd.BinaryData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2CommonData.BinaryData. %s", err.Error())
 	}
 

--- a/ranking2/types/ranking2_estimate_score_rank_input.go
+++ b/ranking2/types/ranking2_estimate_score_rank_input.go
@@ -33,25 +33,19 @@ func (resri Ranking2EstimateScoreRankInput) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the Ranking2EstimateScoreRankInput from the given readable
 func (resri *Ranking2EstimateScoreRankInput) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = resri.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := resri.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2EstimateScoreRankInput header. %s", err.Error())
 	}
 
-	err = resri.Category.ExtractFrom(readable)
-	if err != nil {
+	if err := resri.Category.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2EstimateScoreRankInput.Category. %s", err.Error())
 	}
 
-	err = resri.NumSeasonsToGoBack.ExtractFrom(readable)
-	if err != nil {
+	if err := resri.NumSeasonsToGoBack.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2EstimateScoreRankInput.NumSeasonsToGoBack. %s", err.Error())
 	}
 
-	err = resri.Score.ExtractFrom(readable)
-	if err != nil {
+	if err := resri.Score.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2EstimateScoreRankInput.Score. %s", err.Error())
 	}
 

--- a/ranking2/types/ranking2_estimate_score_rank_output.go
+++ b/ranking2/types/ranking2_estimate_score_rank_output.go
@@ -39,40 +39,31 @@ func (resro Ranking2EstimateScoreRankOutput) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the Ranking2EstimateScoreRankOutput from the given readable
 func (resro *Ranking2EstimateScoreRankOutput) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = resro.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := resro.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2EstimateScoreRankOutput header. %s", err.Error())
 	}
 
-	err = resro.Rank.ExtractFrom(readable)
-	if err != nil {
+	if err := resro.Rank.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2EstimateScoreRankOutput.Rank. %s", err.Error())
 	}
 
-	err = resro.Length.ExtractFrom(readable)
-	if err != nil {
+	if err := resro.Length.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2EstimateScoreRankOutput.Length. %s", err.Error())
 	}
 
-	err = resro.Score.ExtractFrom(readable)
-	if err != nil {
+	if err := resro.Score.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2EstimateScoreRankOutput.Score. %s", err.Error())
 	}
 
-	err = resro.Category.ExtractFrom(readable)
-	if err != nil {
+	if err := resro.Category.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2EstimateScoreRankOutput.Category. %s", err.Error())
 	}
 
-	err = resro.Season.ExtractFrom(readable)
-	if err != nil {
+	if err := resro.Season.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2EstimateScoreRankOutput.Season. %s", err.Error())
 	}
 
-	err = resro.SamplingRate.ExtractFrom(readable)
-	if err != nil {
+	if err := resro.SamplingRate.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2EstimateScoreRankOutput.SamplingRate. %s", err.Error())
 	}
 

--- a/ranking2/types/ranking2_get_by_list_param.go
+++ b/ranking2/types/ranking2_get_by_list_param.go
@@ -40,40 +40,31 @@ func (rgblp Ranking2GetByListParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the Ranking2GetByListParam from the given readable
 func (rgblp *Ranking2GetByListParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = rgblp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := rgblp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2GetByListParam header. %s", err.Error())
 	}
 
-	err = rgblp.Category.ExtractFrom(readable)
-	if err != nil {
+	if err := rgblp.Category.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2GetByListParam.Category. %s", err.Error())
 	}
 
-	err = rgblp.Offset.ExtractFrom(readable)
-	if err != nil {
+	if err := rgblp.Offset.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2GetByListParam.Offset. %s", err.Error())
 	}
 
-	err = rgblp.Length.ExtractFrom(readable)
-	if err != nil {
+	if err := rgblp.Length.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2GetByListParam.Length. %s", err.Error())
 	}
 
-	err = rgblp.SortFlags.ExtractFrom(readable)
-	if err != nil {
+	if err := rgblp.SortFlags.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2GetByListParam.SortFlags. %s", err.Error())
 	}
 
-	err = rgblp.OptionFlags.ExtractFrom(readable)
-	if err != nil {
+	if err := rgblp.OptionFlags.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2GetByListParam.OptionFlags. %s", err.Error())
 	}
 
-	err = rgblp.NumSeasonsToGoBack.ExtractFrom(readable)
-	if err != nil {
+	if err := rgblp.NumSeasonsToGoBack.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2GetByListParam.NumSeasonsToGoBack. %s", err.Error())
 	}
 

--- a/ranking2/types/ranking2_get_param.go
+++ b/ranking2/types/ranking2_get_param.go
@@ -46,55 +46,43 @@ func (rgp Ranking2GetParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the Ranking2GetParam from the given readable
 func (rgp *Ranking2GetParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = rgp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := rgp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2GetParam header. %s", err.Error())
 	}
 
-	err = rgp.NexUniqueID.ExtractFrom(readable)
-	if err != nil {
+	if err := rgp.NexUniqueID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2GetParam.NexUniqueID. %s", err.Error())
 	}
 
-	err = rgp.PrincipalID.ExtractFrom(readable)
-	if err != nil {
+	if err := rgp.PrincipalID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2GetParam.PrincipalID. %s", err.Error())
 	}
 
-	err = rgp.Category.ExtractFrom(readable)
-	if err != nil {
+	if err := rgp.Category.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2GetParam.Category. %s", err.Error())
 	}
 
-	err = rgp.Offset.ExtractFrom(readable)
-	if err != nil {
+	if err := rgp.Offset.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2GetParam.Offset. %s", err.Error())
 	}
 
-	err = rgp.Length.ExtractFrom(readable)
-	if err != nil {
+	if err := rgp.Length.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2GetParam.Length. %s", err.Error())
 	}
 
-	err = rgp.SortFlags.ExtractFrom(readable)
-	if err != nil {
+	if err := rgp.SortFlags.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2GetParam.SortFlags. %s", err.Error())
 	}
 
-	err = rgp.OptionFlags.ExtractFrom(readable)
-	if err != nil {
+	if err := rgp.OptionFlags.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2GetParam.OptionFlags. %s", err.Error())
 	}
 
-	err = rgp.Mode.ExtractFrom(readable)
-	if err != nil {
+	if err := rgp.Mode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2GetParam.Mode. %s", err.Error())
 	}
 
-	err = rgp.NumSeasonsToGoBack.ExtractFrom(readable)
-	if err != nil {
+	if err := rgp.NumSeasonsToGoBack.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2GetParam.NumSeasonsToGoBack. %s", err.Error())
 	}
 

--- a/ranking2/types/ranking2_info.go
+++ b/ranking2/types/ranking2_info.go
@@ -35,30 +35,23 @@ func (ri Ranking2Info) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the Ranking2Info from the given readable
 func (ri *Ranking2Info) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = ri.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := ri.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2Info header. %s", err.Error())
 	}
 
-	err = ri.RankDataList.ExtractFrom(readable)
-	if err != nil {
+	if err := ri.RankDataList.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2Info.RankDataList. %s", err.Error())
 	}
 
-	err = ri.LowestRank.ExtractFrom(readable)
-	if err != nil {
+	if err := ri.LowestRank.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2Info.LowestRank. %s", err.Error())
 	}
 
-	err = ri.NumRankedIn.ExtractFrom(readable)
-	if err != nil {
+	if err := ri.NumRankedIn.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2Info.NumRankedIn. %s", err.Error())
 	}
 
-	err = ri.Season.ExtractFrom(readable)
-	if err != nil {
+	if err := ri.Season.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2Info.Season. %s", err.Error())
 	}
 

--- a/ranking2/types/ranking2_rank_data.go
+++ b/ranking2/types/ranking2_rank_data.go
@@ -39,40 +39,31 @@ func (rrd Ranking2RankData) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the Ranking2RankData from the given readable
 func (rrd *Ranking2RankData) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = rrd.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := rrd.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2RankData header. %s", err.Error())
 	}
 
-	err = rrd.Misc.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.Misc.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2RankData.Misc. %s", err.Error())
 	}
 
-	err = rrd.NexUniqueID.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.NexUniqueID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2RankData.NexUniqueID. %s", err.Error())
 	}
 
-	err = rrd.PrincipalID.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.PrincipalID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2RankData.PrincipalID. %s", err.Error())
 	}
 
-	err = rrd.Rank.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.Rank.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2RankData.Rank. %s", err.Error())
 	}
 
-	err = rrd.Score.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.Score.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2RankData.Score. %s", err.Error())
 	}
 
-	err = rrd.CommonData.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.CommonData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2RankData.CommonData. %s", err.Error())
 	}
 

--- a/ranking2/types/ranking2_score_data.go
+++ b/ranking2/types/ranking2_score_data.go
@@ -33,25 +33,19 @@ func (rsd Ranking2ScoreData) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the Ranking2ScoreData from the given readable
 func (rsd *Ranking2ScoreData) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = rsd.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := rsd.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ScoreData header. %s", err.Error())
 	}
 
-	err = rsd.Misc.ExtractFrom(readable)
-	if err != nil {
+	if err := rsd.Misc.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ScoreData.Misc. %s", err.Error())
 	}
 
-	err = rsd.Category.ExtractFrom(readable)
-	if err != nil {
+	if err := rsd.Category.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ScoreData.Category. %s", err.Error())
 	}
 
-	err = rsd.Score.ExtractFrom(readable)
-	if err != nil {
+	if err := rsd.Score.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract Ranking2ScoreData.Score. %s", err.Error())
 	}
 

--- a/rating/types/rating_rank_data.go
+++ b/rating/types/rating_rank_data.go
@@ -47,60 +47,47 @@ func (rrd RatingRankData) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the RatingRankData from the given readable
 func (rrd *RatingRankData) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = rrd.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := rrd.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RatingRankData header. %s", err.Error())
 	}
 
-	err = rrd.PrincipalID.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.PrincipalID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RatingRankData.PrincipalID. %s", err.Error())
 	}
 
-	err = rrd.UniqueID.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.UniqueID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RatingRankData.UniqueID. %s", err.Error())
 	}
 
-	err = rrd.Order.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.Order.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RatingRankData.Order. %s", err.Error())
 	}
 
-	err = rrd.Category.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.Category.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RatingRankData.Category. %s", err.Error())
 	}
 
-	err = rrd.Score.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.Score.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RatingRankData.Score. %s", err.Error())
 	}
 
-	err = rrd.Unknown1.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.Unknown1.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RatingRankData.Unknown1. %s", err.Error())
 	}
 
-	err = rrd.Unknown2.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.Unknown2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RatingRankData.Unknown2. %s", err.Error())
 	}
 
-	err = rrd.Unknown3.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.Unknown3.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RatingRankData.Unknown3. %s", err.Error())
 	}
 
-	err = rrd.CommonData.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.CommonData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RatingRankData.CommonData. %s", err.Error())
 	}
 
-	err = rrd.UpdateTime.ExtractFrom(readable)
-	if err != nil {
+	if err := rrd.UpdateTime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RatingRankData.UpdateTime. %s", err.Error())
 	}
 

--- a/rating/types/rating_session_token.go
+++ b/rating/types/rating_session_token.go
@@ -31,20 +31,15 @@ func (rst RatingSessionToken) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the RatingSessionToken from the given readable
 func (rst *RatingSessionToken) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = rst.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := rst.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RatingSessionToken header. %s", err.Error())
 	}
 
-	err = rst.Unknown1.ExtractFrom(readable)
-	if err != nil {
+	if err := rst.Unknown1.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RatingSessionToken.Unknown1. %s", err.Error())
 	}
 
-	err = rst.Unknown2.ExtractFrom(readable)
-	if err != nil {
+	if err := rst.Unknown2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RatingSessionToken.Unknown2. %s", err.Error())
 	}
 

--- a/rating/types/rating_stats.go
+++ b/rating/types/rating_stats.go
@@ -39,40 +39,31 @@ func (rs RatingStats) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the RatingStats from the given readable
 func (rs *RatingStats) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = rs.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := rs.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RatingStats header. %s", err.Error())
 	}
 
-	err = rs.PrincipalID.ExtractFrom(readable)
-	if err != nil {
+	if err := rs.PrincipalID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RatingStats.PrincipalID. %s", err.Error())
 	}
 
-	err = rs.UniqueID.ExtractFrom(readable)
-	if err != nil {
+	if err := rs.UniqueID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RatingStats.UniqueID. %s", err.Error())
 	}
 
-	err = rs.Flags.ExtractFrom(readable)
-	if err != nil {
+	if err := rs.Flags.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RatingStats.Flags. %s", err.Error())
 	}
 
-	err = rs.Category.ExtractFrom(readable)
-	if err != nil {
+	if err := rs.Category.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RatingStats.Category. %s", err.Error())
 	}
 
-	err = rs.ReportData.ExtractFrom(readable)
-	if err != nil {
+	if err := rs.ReportData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RatingStats.ReportData. %s", err.Error())
 	}
 
-	err = rs.Values.ExtractFrom(readable)
-	if err != nil {
+	if err := rs.Values.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RatingStats.Values. %s", err.Error())
 	}
 

--- a/screening/types/screening_context_info.go
+++ b/screening/types/screening_context_info.go
@@ -31,20 +31,15 @@ func (sci ScreeningContextInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ScreeningContextInfo from the given readable
 func (sci *ScreeningContextInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sci.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sci.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ScreeningContextInfo header. %s", err.Error())
 	}
 
-	err = sci.Key.ExtractFrom(readable)
-	if err != nil {
+	if err := sci.Key.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ScreeningContextInfo.Key. %s", err.Error())
 	}
 
-	err = sci.Value.ExtractFrom(readable)
-	if err != nil {
+	if err := sci.Value.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ScreeningContextInfo.Value. %s", err.Error())
 	}
 

--- a/screening/types/screening_datastore_content_param.go
+++ b/screening/types/screening_datastore_content_param.go
@@ -37,35 +37,27 @@ func (sdscp ScreeningDataStoreContentParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ScreeningDataStoreContentParam from the given readable
 func (sdscp *ScreeningDataStoreContentParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sdscp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sdscp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ScreeningDataStoreContentParam header. %s", err.Error())
 	}
 
-	err = sdscp.DataID.ExtractFrom(readable)
-	if err != nil {
+	if err := sdscp.DataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ScreeningDataStoreContentParam.DataID. %s", err.Error())
 	}
 
-	err = sdscp.ContentDataID.ExtractFrom(readable)
-	if err != nil {
+	if err := sdscp.ContentDataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ScreeningDataStoreContentParam.ContentDataID. %s", err.Error())
 	}
 
-	err = sdscp.UGCType.ExtractFrom(readable)
-	if err != nil {
+	if err := sdscp.UGCType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ScreeningDataStoreContentParam.UGCType. %s", err.Error())
 	}
 
-	err = sdscp.Language.ExtractFrom(readable)
-	if err != nil {
+	if err := sdscp.Language.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ScreeningDataStoreContentParam.Language. %s", err.Error())
 	}
 
-	err = sdscp.SearchKey.ExtractFrom(readable)
-	if err != nil {
+	if err := sdscp.SearchKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ScreeningDataStoreContentParam.SearchKey. %s", err.Error())
 	}
 

--- a/screening/types/screening_ugc_violation_param.go
+++ b/screening/types/screening_ugc_violation_param.go
@@ -36,30 +36,23 @@ func (suvp ScreeningUGCViolationParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ScreeningUGCViolationParam from the given readable
 func (suvp *ScreeningUGCViolationParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = suvp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := suvp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ScreeningUGCViolationParam header. %s", err.Error())
 	}
 
-	err = suvp.Category.ExtractFrom(readable)
-	if err != nil {
+	if err := suvp.Category.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ScreeningUGCViolationParam.Category. %s", err.Error())
 	}
 
-	err = suvp.Reason.ExtractFrom(readable)
-	if err != nil {
+	if err := suvp.Reason.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ScreeningUGCViolationParam.Reason. %s", err.Error())
 	}
 
-	err = suvp.Context.ExtractFrom(readable)
-	if err != nil {
+	if err := suvp.Context.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ScreeningUGCViolationParam.Context. %s", err.Error())
 	}
 
-	err = suvp.ScreenshotDataID.ExtractFrom(readable)
-	if err != nil {
+	if err := suvp.ScreenshotDataID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ScreeningUGCViolationParam.ScreenshotDataID. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_account_right.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_account_right.go
@@ -33,25 +33,19 @@ func (siar ServiceItemAccountRight) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemAccountRight from the given readable
 func (siar *ServiceItemAccountRight) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siar.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siar.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAccountRight header. %s", err.Error())
 	}
 
-	err = siar.PID.ExtractFrom(readable)
-	if err != nil {
+	if err := siar.PID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAccountRight.PID. %s", err.Error())
 	}
 
-	err = siar.Limitation.ExtractFrom(readable)
-	if err != nil {
+	if err := siar.Limitation.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAccountRight.Limitation. %s", err.Error())
 	}
 
-	err = siar.RightBinaries.ExtractFrom(readable)
-	if err != nil {
+	if err := siar.RightBinaries.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAccountRight.RightBinaries. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_account_right_consumption.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_account_right_consumption.go
@@ -36,30 +36,23 @@ func (siarc ServiceItemAccountRightConsumption) WriteTo(writable types.Writable)
 
 // ExtractFrom extracts the ServiceItemAccountRightConsumption from the given readable
 func (siarc *ServiceItemAccountRightConsumption) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siarc.ServiceItemAccountRight.ExtractFrom(readable)
-	if err != nil {
+	if err := siarc.ServiceItemAccountRight.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAccountRightConsumption.ServiceItemAccountRight. %s", err.Error())
 	}
 
-	err = siarc.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siarc.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAccountRightConsumption header. %s", err.Error())
 	}
 
-	err = siarc.UsedCount.ExtractFrom(readable)
-	if err != nil {
+	if err := siarc.UsedCount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAccountRightConsumption.UsedCount. %s", err.Error())
 	}
 
-	err = siarc.ExpiredCount.ExtractFrom(readable)
-	if err != nil {
+	if err := siarc.ExpiredCount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAccountRightConsumption.ExpiredCount. %s", err.Error())
 	}
 
-	err = siarc.ExpiryCounts.ExtractFrom(readable)
-	if err != nil {
+	if err := siarc.ExpiryCounts.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAccountRightConsumption.ExpiryCounts. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_account_right_time.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_account_right_time.go
@@ -29,15 +29,11 @@ func (siart ServiceItemAccountRightTime) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemAccountRightTime from the given readable
 func (siart *ServiceItemAccountRightTime) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siart.ServiceItemAccountRight.ExtractFrom(readable)
-	if err != nil {
+	if err := siart.ServiceItemAccountRight.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAccountRightTime.ServiceItemAccountRight. %s", err.Error())
 	}
 
-	err = siart.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siart.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAccountRightTime header. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_acquire_service_item_by_account_param.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_acquire_service_item_by_account_param.go
@@ -45,55 +45,43 @@ func (siasibap ServiceItemAcquireServiceItemByAccountParam) WriteTo(writable typ
 
 // ExtractFrom extracts the ServiceItemAcquireServiceItemByAccountParam from the given readable
 func (siasibap *ServiceItemAcquireServiceItemByAccountParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siasibap.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siasibap.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAcquireServiceItemByAccountParam header. %s", err.Error())
 	}
 
-	err = siasibap.ReferenceIDForAcquisition.ExtractFrom(readable)
-	if err != nil {
+	if err := siasibap.ReferenceIDForAcquisition.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAcquireServiceItemByAccountParam.ReferenceIDForAcquisition. %s", err.Error())
 	}
 
-	err = siasibap.ReferenceIDForRightBinary.ExtractFrom(readable)
-	if err != nil {
+	if err := siasibap.ReferenceIDForRightBinary.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAcquireServiceItemByAccountParam.ReferenceIDForRightBinary. %s", err.Error())
 	}
 
-	err = siasibap.UseType.ExtractFrom(readable)
-	if err != nil {
+	if err := siasibap.UseType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAcquireServiceItemByAccountParam.UseType. %s", err.Error())
 	}
 
-	err = siasibap.LimitationType.ExtractFrom(readable)
-	if err != nil {
+	if err := siasibap.LimitationType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAcquireServiceItemByAccountParam.LimitationType. %s", err.Error())
 	}
 
-	err = siasibap.LimitationValue.ExtractFrom(readable)
-	if err != nil {
+	if err := siasibap.LimitationValue.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAcquireServiceItemByAccountParam.LimitationValue. %s", err.Error())
 	}
 
-	err = siasibap.RightBinary.ExtractFrom(readable)
-	if err != nil {
+	if err := siasibap.RightBinary.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAcquireServiceItemByAccountParam.RightBinary. %s", err.Error())
 	}
 
-	err = siasibap.LogMessage.ExtractFrom(readable)
-	if err != nil {
+	if err := siasibap.LogMessage.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAcquireServiceItemByAccountParam.LogMessage. %s", err.Error())
 	}
 
-	err = siasibap.UniqueID.ExtractFrom(readable)
-	if err != nil {
+	if err := siasibap.UniqueID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAcquireServiceItemByAccountParam.UniqueID. %s", err.Error())
 	}
 
-	err = siasibap.Platform.ExtractFrom(readable)
-	if err != nil {
+	if err := siasibap.Platform.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAcquireServiceItemByAccountParam.Platform. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_acquire_service_item_response.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_acquire_service_item_response.go
@@ -39,40 +39,31 @@ func (siasir ServiceItemAcquireServiceItemResponse) WriteTo(writable types.Writa
 
 // ExtractFrom extracts the ServiceItemAcquireServiceItemResponse from the given readable
 func (siasir *ServiceItemAcquireServiceItemResponse) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siasir.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siasir.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAcquireServiceItemResponse header. %s", err.Error())
 	}
 
-	err = siasir.LimitationType.ExtractFrom(readable)
-	if err != nil {
+	if err := siasir.LimitationType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAcquireServiceItemResponse.LimitationType. %s", err.Error())
 	}
 
-	err = siasir.AcquiredCount.ExtractFrom(readable)
-	if err != nil {
+	if err := siasir.AcquiredCount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAcquireServiceItemResponse.AcquiredCount. %s", err.Error())
 	}
 
-	err = siasir.UsedCount.ExtractFrom(readable)
-	if err != nil {
+	if err := siasir.UsedCount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAcquireServiceItemResponse.UsedCount. %s", err.Error())
 	}
 
-	err = siasir.ExpiryDate.ExtractFrom(readable)
-	if err != nil {
+	if err := siasir.ExpiryDate.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAcquireServiceItemResponse.ExpiryDate. %s", err.Error())
 	}
 
-	err = siasir.ExpiredCount.ExtractFrom(readable)
-	if err != nil {
+	if err := siasir.ExpiredCount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAcquireServiceItemResponse.ExpiredCount. %s", err.Error())
 	}
 
-	err = siasir.ExpiryCounts.ExtractFrom(readable)
-	if err != nil {
+	if err := siasir.ExpiryCounts.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAcquireServiceItemResponse.ExpiryCounts. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_amount.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_amount.go
@@ -33,25 +33,19 @@ func (sia ServiceItemAmount) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemAmount from the given readable
 func (sia *ServiceItemAmount) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sia.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sia.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAmount header. %s", err.Error())
 	}
 
-	err = sia.FormattedAmount.ExtractFrom(readable)
-	if err != nil {
+	if err := sia.FormattedAmount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAmount.FormattedAmount. %s", err.Error())
 	}
 
-	err = sia.Currency.ExtractFrom(readable)
-	if err != nil {
+	if err := sia.Currency.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAmount.Currency. %s", err.Error())
 	}
 
-	err = sia.RawValue.ExtractFrom(readable)
-	if err != nil {
+	if err := sia.RawValue.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAmount.RawValue. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_attribute.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_attribute.go
@@ -31,20 +31,15 @@ func (sia ServiceItemAttribute) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemAttribute from the given readable
 func (sia *ServiceItemAttribute) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sia.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sia.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAttribute header. %s", err.Error())
 	}
 
-	err = sia.Name.ExtractFrom(readable)
-	if err != nil {
+	if err := sia.Name.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAttribute.Name. %s", err.Error())
 	}
 
-	err = sia.Value.ExtractFrom(readable)
-	if err != nil {
+	if err := sia.Value.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAttribute.Value. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_catalog.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_catalog.go
@@ -37,35 +37,27 @@ func (sic ServiceItemCatalog) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemCatalog from the given readable
 func (sic *ServiceItemCatalog) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sic.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sic.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemCatalog header. %s", err.Error())
 	}
 
-	err = sic.TotalSize.ExtractFrom(readable)
-	if err != nil {
+	if err := sic.TotalSize.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemCatalog.TotalSize. %s", err.Error())
 	}
 
-	err = sic.Offset.ExtractFrom(readable)
-	if err != nil {
+	if err := sic.Offset.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemCatalog.Offset. %s", err.Error())
 	}
 
-	err = sic.ListItems.ExtractFrom(readable)
-	if err != nil {
+	if err := sic.ListItems.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemCatalog.ListItems. %s", err.Error())
 	}
 
-	err = sic.IsBalanceAvailable.ExtractFrom(readable)
-	if err != nil {
+	if err := sic.IsBalanceAvailable.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemCatalog.IsBalanceAvailable. %s", err.Error())
 	}
 
-	err = sic.Balance.ExtractFrom(readable)
-	if err != nil {
+	if err := sic.Balance.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemCatalog.Balance. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_eshop_response.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_eshop_response.go
@@ -33,25 +33,19 @@ func (siesr ServiceItemEShopResponse) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemEShopResponse from the given readable
 func (siesr *ServiceItemEShopResponse) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siesr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siesr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemEShopResponse header. %s", err.Error())
 	}
 
-	err = siesr.HTTPStatus.ExtractFrom(readable)
-	if err != nil {
+	if err := siesr.HTTPStatus.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemEShopResponse.HTTPStatus. %s", err.Error())
 	}
 
-	err = siesr.ErrorCode.ExtractFrom(readable)
-	if err != nil {
+	if err := siesr.ErrorCode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemEShopResponse.ErrorCode. %s", err.Error())
 	}
 
-	err = siesr.CorrelationID.ExtractFrom(readable)
-	if err != nil {
+	if err := siesr.CorrelationID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemEShopResponse.CorrelationID. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_get_balance_param.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_get_balance_param.go
@@ -36,26 +36,20 @@ func (sigbp ServiceItemGetBalanceParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemGetBalanceParam from the given readable
 func (sigbp *ServiceItemGetBalanceParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sigbp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sigbp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetBalanceParam header. %s", err.Error())
 	}
 
-	err = sigbp.Language.ExtractFrom(readable)
-	if err != nil {
+	if err := sigbp.Language.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetBalanceParam.Language. %s", err.Error())
 	}
 
-	err = sigbp.UniqueID.ExtractFrom(readable)
-	if err != nil {
+	if err := sigbp.UniqueID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetBalanceParam.UniqueID. %s", err.Error())
 	}
 
 	if sigbp.StructureVersion >= 1 {
-		err = sigbp.Platform.ExtractFrom(readable)
-		if err != nil {
+		if err := sigbp.Platform.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract ServiceItemGetBalanceParam.Platform. %s", err.Error())
 		}
 	}

--- a/service-item/team-kirby-clash-deluxe/types/service_item_get_balance_response.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_get_balance_response.go
@@ -32,20 +32,15 @@ func (sigbr ServiceItemGetBalanceResponse) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemGetBalanceResponse from the given readable
 func (sigbr *ServiceItemGetBalanceResponse) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sigbr.ServiceItemEShopResponse.ExtractFrom(readable)
-	if err != nil {
+	if err := sigbr.ServiceItemEShopResponse.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetBalanceResponse.ServiceItemEShopResponse. %s", err.Error())
 	}
 
-	err = sigbr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sigbr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetBalanceResponse header. %s", err.Error())
 	}
 
-	err = sigbr.NullableBalance.ExtractFrom(readable)
-	if err != nil {
+	if err := sigbr.NullableBalance.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetBalanceResponse.NullableBalance. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_get_law_message_param.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_get_law_message_param.go
@@ -36,26 +36,20 @@ func (siglmp ServiceItemGetLawMessageParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemGetLawMessageParam from the given readable
 func (siglmp *ServiceItemGetLawMessageParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siglmp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siglmp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetLawMessageParam header. %s", err.Error())
 	}
 
-	err = siglmp.Language.ExtractFrom(readable)
-	if err != nil {
+	if err := siglmp.Language.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetLawMessageParam.Language. %s", err.Error())
 	}
 
-	err = siglmp.UniqueID.ExtractFrom(readable)
-	if err != nil {
+	if err := siglmp.UniqueID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetLawMessageParam.UniqueID. %s", err.Error())
 	}
 
 	if siglmp.StructureVersion >= 1 {
-		err = siglmp.Platform.ExtractFrom(readable)
-		if err != nil {
+		if err := siglmp.Platform.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract ServiceItemGetLawMessageParam.Platform. %s", err.Error())
 		}
 	}

--- a/service-item/team-kirby-clash-deluxe/types/service_item_get_law_message_response.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_get_law_message_response.go
@@ -32,20 +32,15 @@ func (siglmr ServiceItemGetLawMessageResponse) WriteTo(writable types.Writable) 
 
 // ExtractFrom extracts the ServiceItemGetLawMessageResponse from the given readable
 func (siglmr *ServiceItemGetLawMessageResponse) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siglmr.ServiceItemEShopResponse.ExtractFrom(readable)
-	if err != nil {
+	if err := siglmr.ServiceItemEShopResponse.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetLawMessageResponse.ServiceItemEShopResponse. %s", err.Error())
 	}
 
-	err = siglmr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siglmr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetLawMessageResponse header. %s", err.Error())
 	}
 
-	err = siglmr.NullableLawMessage.ExtractFrom(readable)
-	if err != nil {
+	if err := siglmr.NullableLawMessage.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetLawMessageResponse.NullableLawMessage. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_get_notice_param.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_get_notice_param.go
@@ -29,15 +29,11 @@ func (signp ServiceItemGetNoticeParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemGetNoticeParam from the given readable
 func (signp *ServiceItemGetNoticeParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = signp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := signp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetNoticeParam header. %s", err.Error())
 	}
 
-	err = signp.ScheduleType.ExtractFrom(readable)
-	if err != nil {
+	if err := signp.ScheduleType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetNoticeParam.ScheduleType. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_get_prepurchase_info_param.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_get_prepurchase_info_param.go
@@ -37,35 +37,27 @@ func (sigpip ServiceItemGetPrepurchaseInfoParam) WriteTo(writable types.Writable
 
 // ExtractFrom extracts the ServiceItemGetPrepurchaseInfoParam from the given readable
 func (sigpip *ServiceItemGetPrepurchaseInfoParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sigpip.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sigpip.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPrepurchaseInfoParam header. %s", err.Error())
 	}
 
-	err = sigpip.ItemCode.ExtractFrom(readable)
-	if err != nil {
+	if err := sigpip.ItemCode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPrepurchaseInfoParam.ItemCode. %s", err.Error())
 	}
 
-	err = sigpip.ReferenceID.ExtractFrom(readable)
-	if err != nil {
+	if err := sigpip.ReferenceID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPrepurchaseInfoParam.ReferenceID. %s", err.Error())
 	}
 
-	err = sigpip.Limitation.ExtractFrom(readable)
-	if err != nil {
+	if err := sigpip.Limitation.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPrepurchaseInfoParam.Limitation. %s", err.Error())
 	}
 
-	err = sigpip.Language.ExtractFrom(readable)
-	if err != nil {
+	if err := sigpip.Language.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPrepurchaseInfoParam.Language. %s", err.Error())
 	}
 
-	err = sigpip.UniqueID.ExtractFrom(readable)
-	if err != nil {
+	if err := sigpip.UniqueID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPrepurchaseInfoParam.UniqueID. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_get_prepurchase_info_response.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_get_prepurchase_info_response.go
@@ -32,20 +32,15 @@ func (sigpir ServiceItemGetPrepurchaseInfoResponse) WriteTo(writable types.Writa
 
 // ExtractFrom extracts the ServiceItemGetPrepurchaseInfoResponse from the given readable
 func (sigpir *ServiceItemGetPrepurchaseInfoResponse) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sigpir.ServiceItemEShopResponse.ExtractFrom(readable)
-	if err != nil {
+	if err := sigpir.ServiceItemEShopResponse.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPrepurchaseInfoResponse.ServiceItemEShopResponse. %s", err.Error())
 	}
 
-	err = sigpir.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sigpir.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPrepurchaseInfoResponse header. %s", err.Error())
 	}
 
-	err = sigpir.NullablePrepurchaseInfo.ExtractFrom(readable)
-	if err != nil {
+	if err := sigpir.NullablePrepurchaseInfo.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPrepurchaseInfoResponse.NullablePrepurchaseInfo. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_get_purchase_history_param.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_get_purchase_history_param.go
@@ -37,35 +37,27 @@ func (sigphp ServiceItemGetPurchaseHistoryParam) WriteTo(writable types.Writable
 
 // ExtractFrom extracts the ServiceItemGetPurchaseHistoryParam from the given readable
 func (sigphp *ServiceItemGetPurchaseHistoryParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sigphp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sigphp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPurchaseHistoryParam header. %s", err.Error())
 	}
 
-	err = sigphp.Language.ExtractFrom(readable)
-	if err != nil {
+	if err := sigphp.Language.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPurchaseHistoryParam.Language. %s", err.Error())
 	}
 
-	err = sigphp.Offset.ExtractFrom(readable)
-	if err != nil {
+	if err := sigphp.Offset.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPurchaseHistoryParam.Offset. %s", err.Error())
 	}
 
-	err = sigphp.Size.ExtractFrom(readable)
-	if err != nil {
+	if err := sigphp.Size.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPurchaseHistoryParam.Size. %s", err.Error())
 	}
 
-	err = sigphp.UniqueID.ExtractFrom(readable)
-	if err != nil {
+	if err := sigphp.UniqueID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPurchaseHistoryParam.UniqueID. %s", err.Error())
 	}
 
-	err = sigphp.Platform.ExtractFrom(readable)
-	if err != nil {
+	if err := sigphp.Platform.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPurchaseHistoryParam.Platform. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_get_purchase_history_response.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_get_purchase_history_response.go
@@ -32,20 +32,15 @@ func (sigphr ServiceItemGetPurchaseHistoryResponse) WriteTo(writable types.Writa
 
 // ExtractFrom extracts the ServiceItemGetPurchaseHistoryResponse from the given readable
 func (sigphr *ServiceItemGetPurchaseHistoryResponse) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sigphr.ServiceItemEShopResponse.ExtractFrom(readable)
-	if err != nil {
+	if err := sigphr.ServiceItemEShopResponse.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPurchaseHistoryResponse.ServiceItemEShopResponse. %s", err.Error())
 	}
 
-	err = sigphr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sigphr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPurchaseHistoryResponse header. %s", err.Error())
 	}
 
-	err = sigphr.NullablePurchaseHistory.ExtractFrom(readable)
-	if err != nil {
+	if err := sigphr.NullablePurchaseHistory.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPurchaseHistoryResponse.NullablePurchaseHistory. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_get_service_item_right_param.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_get_service_item_right_param.go
@@ -40,36 +40,28 @@ func (sigsirp ServiceItemGetServiceItemRightParam) WriteTo(writable types.Writab
 
 // ExtractFrom extracts the ServiceItemGetServiceItemRightParam from the given readable
 func (sigsirp *ServiceItemGetServiceItemRightParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sigsirp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sigsirp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetServiceItemRightParam header. %s", err.Error())
 	}
 
-	err = sigsirp.ReferenceID.ExtractFrom(readable)
-	if err != nil {
+	if err := sigsirp.ReferenceID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetServiceItemRightParam.ReferenceID. %s", err.Error())
 	}
 
-	err = sigsirp.DeviceID.ExtractFrom(readable)
-	if err != nil {
+	if err := sigsirp.DeviceID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetServiceItemRightParam.DeviceID. %s", err.Error())
 	}
 
-	err = sigsirp.UniqueID.ExtractFrom(readable)
-	if err != nil {
+	if err := sigsirp.UniqueID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetServiceItemRightParam.UniqueID. %s", err.Error())
 	}
 
-	err = sigsirp.ItemGroup.ExtractFrom(readable)
-	if err != nil {
+	if err := sigsirp.ItemGroup.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetServiceItemRightParam.ItemGroup. %s", err.Error())
 	}
 
 	if sigsirp.StructureVersion >= 1 {
-		err = sigsirp.Platform.ExtractFrom(readable)
-		if err != nil {
+		if err := sigsirp.Platform.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract ServiceItemGetServiceItemRightParam.Platform. %s", err.Error())
 		}
 	}

--- a/service-item/team-kirby-clash-deluxe/types/service_item_get_service_item_right_response.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_get_service_item_right_response.go
@@ -32,20 +32,15 @@ func (sigsirr ServiceItemGetServiceItemRightResponse) WriteTo(writable types.Wri
 
 // ExtractFrom extracts the ServiceItemGetServiceItemRightResponse from the given readable
 func (sigsirr *ServiceItemGetServiceItemRightResponse) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sigsirr.ServiceItemEShopResponse.ExtractFrom(readable)
-	if err != nil {
+	if err := sigsirr.ServiceItemEShopResponse.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetServiceItemRightResponse.ServiceItemEShopResponse. %s", err.Error())
 	}
 
-	err = sigsirr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sigsirr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetServiceItemRightResponse header. %s", err.Error())
 	}
 
-	err = sigsirr.NullableRightInfos.ExtractFrom(readable)
-	if err != nil {
+	if err := sigsirr.NullableRightInfos.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetServiceItemRightResponse.NullableRightInfos. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_get_support_id_param.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_get_support_id_param.go
@@ -31,20 +31,15 @@ func (sigsidp ServiceItemGetSupportIDParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemGetSupportIDParam from the given readable
 func (sigsidp *ServiceItemGetSupportIDParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sigsidp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sigsidp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetSupportIDParam header. %s", err.Error())
 	}
 
-	err = sigsidp.UniqueID.ExtractFrom(readable)
-	if err != nil {
+	if err := sigsidp.UniqueID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetSupportIDParam.UniqueID. %s", err.Error())
 	}
 
-	err = sigsidp.Platform.ExtractFrom(readable)
-	if err != nil {
+	if err := sigsidp.Platform.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetSupportIDParam.Platform. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_http_get_param.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_http_get_param.go
@@ -29,15 +29,11 @@ func (sihttpgp ServiceItemHTTPGetParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemHTTPGetParam from the given readable
 func (sihttpgp *ServiceItemHTTPGetParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sihttpgp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sihttpgp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemHTTPGetParam header. %s", err.Error())
 	}
 
-	err = sihttpgp.URL.ExtractFrom(readable)
-	if err != nil {
+	if err := sihttpgp.URL.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemHTTPGetParam.URL. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_http_get_response.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_http_get_response.go
@@ -29,15 +29,11 @@ func (sihttpgr ServiceItemHTTPGetResponse) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemHTTPGetResponse from the given readable
 func (sihttpgr *ServiceItemHTTPGetResponse) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sihttpgr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sihttpgr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemHTTPGetResponse header. %s", err.Error())
 	}
 
-	err = sihttpgr.Response.ExtractFrom(readable)
-	if err != nil {
+	if err := sihttpgr.Response.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemHTTPGetResponse.Response. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_law_message.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_law_message.go
@@ -31,20 +31,15 @@ func (silm ServiceItemLawMessage) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemLawMessage from the given readable
 func (silm *ServiceItemLawMessage) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = silm.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := silm.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemLawMessage header. %s", err.Error())
 	}
 
-	err = silm.IsMessageRequired.ExtractFrom(readable)
-	if err != nil {
+	if err := silm.IsMessageRequired.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemLawMessage.IsMessageRequired. %s", err.Error())
 	}
 
-	err = silm.LawMessage.ExtractFrom(readable)
-	if err != nil {
+	if err := silm.LawMessage.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemLawMessage.LawMessage. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_limitation.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_limitation.go
@@ -31,20 +31,15 @@ func (sil ServiceItemLimitation) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemLimitation from the given readable
 func (sil *ServiceItemLimitation) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sil.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sil.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemLimitation header. %s", err.Error())
 	}
 
-	err = sil.LimitationType.ExtractFrom(readable)
-	if err != nil {
+	if err := sil.LimitationType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemLimitation.LimitationType. %s", err.Error())
 	}
 
-	err = sil.LimitationValue.ExtractFrom(readable)
-	if err != nil {
+	if err := sil.LimitationValue.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemLimitation.LimitationValue. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_list_item.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_list_item.go
@@ -39,40 +39,31 @@ func (sili ServiceItemListItem) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemListItem from the given readable
 func (sili *ServiceItemListItem) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sili.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sili.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListItem header. %s", err.Error())
 	}
 
-	err = sili.ItemCode.ExtractFrom(readable)
-	if err != nil {
+	if err := sili.ItemCode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListItem.ItemCode. %s", err.Error())
 	}
 
-	err = sili.RegularPrice.ExtractFrom(readable)
-	if err != nil {
+	if err := sili.RegularPrice.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListItem.RegularPrice. %s", err.Error())
 	}
 
-	err = sili.TaxExcluded.ExtractFrom(readable)
-	if err != nil {
+	if err := sili.TaxExcluded.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListItem.TaxExcluded. %s", err.Error())
 	}
 
-	err = sili.InitialPurchaseOnly.ExtractFrom(readable)
-	if err != nil {
+	if err := sili.InitialPurchaseOnly.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListItem.InitialPurchaseOnly. %s", err.Error())
 	}
 
-	err = sili.Limitation.ExtractFrom(readable)
-	if err != nil {
+	if err := sili.Limitation.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListItem.Limitation. %s", err.Error())
 	}
 
-	err = sili.Attributes.ExtractFrom(readable)
-	if err != nil {
+	if err := sili.Attributes.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListItem.Attributes. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_list_service_item_param.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_list_service_item_param.go
@@ -42,41 +42,32 @@ func (silsip ServiceItemListServiceItemParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemListServiceItemParam from the given readable
 func (silsip *ServiceItemListServiceItemParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = silsip.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := silsip.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListServiceItemParam header. %s", err.Error())
 	}
 
-	err = silsip.Language.ExtractFrom(readable)
-	if err != nil {
+	if err := silsip.Language.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListServiceItemParam.Language. %s", err.Error())
 	}
 
-	err = silsip.Offset.ExtractFrom(readable)
-	if err != nil {
+	if err := silsip.Offset.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListServiceItemParam.Offset. %s", err.Error())
 	}
 
-	err = silsip.Size.ExtractFrom(readable)
-	if err != nil {
+	if err := silsip.Size.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListServiceItemParam.Size. %s", err.Error())
 	}
 
-	err = silsip.IsBalanceAvailable.ExtractFrom(readable)
-	if err != nil {
+	if err := silsip.IsBalanceAvailable.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListServiceItemParam.IsBalanceAvailable. %s", err.Error())
 	}
 
-	err = silsip.UniqueID.ExtractFrom(readable)
-	if err != nil {
+	if err := silsip.UniqueID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListServiceItemParam.UniqueID. %s", err.Error())
 	}
 
 	if silsip.StructureVersion >= 1 {
-		err = silsip.Platform.ExtractFrom(readable)
-		if err != nil {
+		if err := silsip.Platform.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract ServiceItemListServiceItemParam.Platform. %s", err.Error())
 		}
 	}

--- a/service-item/team-kirby-clash-deluxe/types/service_item_list_service_item_response.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_list_service_item_response.go
@@ -32,20 +32,15 @@ func (silsir ServiceItemListServiceItemResponse) WriteTo(writable types.Writable
 
 // ExtractFrom extracts the ServiceItemListServiceItemResponse from the given readable
 func (silsir *ServiceItemListServiceItemResponse) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = silsir.ServiceItemEShopResponse.ExtractFrom(readable)
-	if err != nil {
+	if err := silsir.ServiceItemEShopResponse.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListServiceItemResponse.ServiceItemEShopResponse. %s", err.Error())
 	}
 
-	err = silsir.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := silsir.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListServiceItemResponse header. %s", err.Error())
 	}
 
-	err = silsir.NullableCatalog.ExtractFrom(readable)
-	if err != nil {
+	if err := silsir.NullableCatalog.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListServiceItemResponse.NullableCatalog. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_notice.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_notice.go
@@ -41,45 +41,35 @@ func (sin ServiceItemNotice) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemNotice from the given readable
 func (sin *ServiceItemNotice) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sin.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sin.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemNotice header. %s", err.Error())
 	}
 
-	err = sin.ScheduleID.ExtractFrom(readable)
-	if err != nil {
+	if err := sin.ScheduleID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemNotice.ScheduleID. %s", err.Error())
 	}
 
-	err = sin.ScheduleType.ExtractFrom(readable)
-	if err != nil {
+	if err := sin.ScheduleType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemNotice.ScheduleType. %s", err.Error())
 	}
 
-	err = sin.ParamInt.ExtractFrom(readable)
-	if err != nil {
+	if err := sin.ParamInt.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemNotice.ParamInt. %s", err.Error())
 	}
 
-	err = sin.ParamString.ExtractFrom(readable)
-	if err != nil {
+	if err := sin.ParamString.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemNotice.ParamString. %s", err.Error())
 	}
 
-	err = sin.ParamBinary.ExtractFrom(readable)
-	if err != nil {
+	if err := sin.ParamBinary.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemNotice.ParamBinary. %s", err.Error())
 	}
 
-	err = sin.TimeBegin.ExtractFrom(readable)
-	if err != nil {
+	if err := sin.TimeBegin.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemNotice.TimeBegin. %s", err.Error())
 	}
 
-	err = sin.TimeEnd.ExtractFrom(readable)
-	if err != nil {
+	if err := sin.TimeEnd.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemNotice.TimeEnd. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_post_right_binary_by_account_param.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_post_right_binary_by_account_param.go
@@ -39,40 +39,31 @@ func (siprbbap ServiceItemPostRightBinaryByAccountParam) WriteTo(writable types.
 
 // ExtractFrom extracts the ServiceItemPostRightBinaryByAccountParam from the given readable
 func (siprbbap *ServiceItemPostRightBinaryByAccountParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siprbbap.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siprbbap.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPostRightBinaryByAccountParam header. %s", err.Error())
 	}
 
-	err = siprbbap.ReferenceID.ExtractFrom(readable)
-	if err != nil {
+	if err := siprbbap.ReferenceID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPostRightBinaryByAccountParam.ReferenceID. %s", err.Error())
 	}
 
-	err = siprbbap.UseType.ExtractFrom(readable)
-	if err != nil {
+	if err := siprbbap.UseType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPostRightBinaryByAccountParam.UseType. %s", err.Error())
 	}
 
-	err = siprbbap.RightBinary.ExtractFrom(readable)
-	if err != nil {
+	if err := siprbbap.RightBinary.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPostRightBinaryByAccountParam.RightBinary. %s", err.Error())
 	}
 
-	err = siprbbap.LogMessage.ExtractFrom(readable)
-	if err != nil {
+	if err := siprbbap.LogMessage.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPostRightBinaryByAccountParam.LogMessage. %s", err.Error())
 	}
 
-	err = siprbbap.UniqueID.ExtractFrom(readable)
-	if err != nil {
+	if err := siprbbap.UniqueID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPostRightBinaryByAccountParam.UniqueID. %s", err.Error())
 	}
 
-	err = siprbbap.Platform.ExtractFrom(readable)
-	if err != nil {
+	if err := siprbbap.Platform.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPostRightBinaryByAccountParam.Platform. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_prepurchase_info.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_prepurchase_info.go
@@ -47,60 +47,47 @@ func (sipi ServiceItemPrepurchaseInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemPrepurchaseInfo from the given readable
 func (sipi *ServiceItemPrepurchaseInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sipi.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sipi.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseInfo header. %s", err.Error())
 	}
 
-	err = sipi.ItemCode.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.ItemCode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseInfo.ItemCode. %s", err.Error())
 	}
 
-	err = sipi.PriceID.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.PriceID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseInfo.PriceID. %s", err.Error())
 	}
 
-	err = sipi.RegularPrice.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.RegularPrice.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseInfo.RegularPrice. %s", err.Error())
 	}
 
-	err = sipi.IsTaxAvailable.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.IsTaxAvailable.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseInfo.IsTaxAvailable. %s", err.Error())
 	}
 
-	err = sipi.TaxAmount.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.TaxAmount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseInfo.TaxAmount. %s", err.Error())
 	}
 
-	err = sipi.TotalAmount.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.TotalAmount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseInfo.TotalAmount. %s", err.Error())
 	}
 
-	err = sipi.CurrentBalance.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.CurrentBalance.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseInfo.CurrentBalance. %s", err.Error())
 	}
 
-	err = sipi.PostBalance.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.PostBalance.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseInfo.PostBalance. %s", err.Error())
 	}
 
-	err = sipi.CurrentRightInfo.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.CurrentRightInfo.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseInfo.CurrentRightInfo. %s", err.Error())
 	}
 
-	err = sipi.PostRightInfo.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.PostRightInfo.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseInfo.PostRightInfo. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_prepurchase_right_info.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_prepurchase_right_info.go
@@ -39,40 +39,31 @@ func (sipri ServiceItemPrepurchaseRightInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemPrepurchaseRightInfo from the given readable
 func (sipri *ServiceItemPrepurchaseRightInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sipri.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sipri.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseRightInfo header. %s", err.Error())
 	}
 
-	err = sipri.LimitationType.ExtractFrom(readable)
-	if err != nil {
+	if err := sipri.LimitationType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseRightInfo.LimitationType. %s", err.Error())
 	}
 
-	err = sipri.AcquiredCount.ExtractFrom(readable)
-	if err != nil {
+	if err := sipri.AcquiredCount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseRightInfo.AcquiredCount. %s", err.Error())
 	}
 
-	err = sipri.UsedCount.ExtractFrom(readable)
-	if err != nil {
+	if err := sipri.UsedCount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseRightInfo.UsedCount. %s", err.Error())
 	}
 
-	err = sipri.ExpiryDate.ExtractFrom(readable)
-	if err != nil {
+	if err := sipri.ExpiryDate.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseRightInfo.ExpiryDate. %s", err.Error())
 	}
 
-	err = sipri.ExpiredCount.ExtractFrom(readable)
-	if err != nil {
+	if err := sipri.ExpiredCount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseRightInfo.ExpiredCount. %s", err.Error())
 	}
 
-	err = sipri.ExpiryCounts.ExtractFrom(readable)
-	if err != nil {
+	if err := sipri.ExpiryCounts.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseRightInfo.ExpiryCounts. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_purchase_history.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_purchase_history.go
@@ -33,25 +33,19 @@ func (siph ServiceItemPurchaseHistory) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemPurchaseHistory from the given readable
 func (siph *ServiceItemPurchaseHistory) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siph.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siph.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseHistory header. %s", err.Error())
 	}
 
-	err = siph.TotalSize.ExtractFrom(readable)
-	if err != nil {
+	if err := siph.TotalSize.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseHistory.TotalSize. %s", err.Error())
 	}
 
-	err = siph.Offset.ExtractFrom(readable)
-	if err != nil {
+	if err := siph.Offset.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseHistory.Offset. %s", err.Error())
 	}
 
-	err = siph.Transactions.ExtractFrom(readable)
-	if err != nil {
+	if err := siph.Transactions.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseHistory.Transactions. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_purchase_info.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_purchase_info.go
@@ -35,30 +35,23 @@ func (sipi ServiceItemPurchaseInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemPurchaseInfo from the given readable
 func (sipi *ServiceItemPurchaseInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sipi.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sipi.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseInfo header. %s", err.Error())
 	}
 
-	err = sipi.TransactionID.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.TransactionID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseInfo.TransactionID. %s", err.Error())
 	}
 
-	err = sipi.ExtTransactionID.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.ExtTransactionID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseInfo.ExtTransactionID. %s", err.Error())
 	}
 
-	err = sipi.ItemCode.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.ItemCode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseInfo.ItemCode. %s", err.Error())
 	}
 
-	err = sipi.PostBalance.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.PostBalance.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseInfo.PostBalance. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_purchase_service_item_param.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_purchase_service_item_param.go
@@ -48,56 +48,44 @@ func (sipsip ServiceItemPurchaseServiceItemParam) WriteTo(writable types.Writabl
 
 // ExtractFrom extracts the ServiceItemPurchaseServiceItemParam from the given readable
 func (sipsip *ServiceItemPurchaseServiceItemParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sipsip.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sipsip.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemParam header. %s", err.Error())
 	}
 
-	err = sipsip.ItemCode.ExtractFrom(readable)
-	if err != nil {
+	if err := sipsip.ItemCode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemParam.ItemCode. %s", err.Error())
 	}
 
-	err = sipsip.PriceID.ExtractFrom(readable)
-	if err != nil {
+	if err := sipsip.PriceID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemParam.PriceID. %s", err.Error())
 	}
 
-	err = sipsip.ReferenceID.ExtractFrom(readable)
-	if err != nil {
+	if err := sipsip.ReferenceID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemParam.ReferenceID. %s", err.Error())
 	}
 
-	err = sipsip.Balance.ExtractFrom(readable)
-	if err != nil {
+	if err := sipsip.Balance.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemParam.Balance. %s", err.Error())
 	}
 
-	err = sipsip.ItemName.ExtractFrom(readable)
-	if err != nil {
+	if err := sipsip.ItemName.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemParam.ItemName. %s", err.Error())
 	}
 
-	err = sipsip.EcServiceToken.ExtractFrom(readable)
-	if err != nil {
+	if err := sipsip.EcServiceToken.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemParam.EcServiceToken. %s", err.Error())
 	}
 
-	err = sipsip.Language.ExtractFrom(readable)
-	if err != nil {
+	if err := sipsip.Language.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemParam.Language. %s", err.Error())
 	}
 
-	err = sipsip.UniqueID.ExtractFrom(readable)
-	if err != nil {
+	if err := sipsip.UniqueID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemParam.UniqueID. %s", err.Error())
 	}
 
 	if sipsip.StructureVersion >= 1 {
-		err = sipsip.Platform.ExtractFrom(readable)
-		if err != nil {
+		if err := sipsip.Platform.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemParam.Platform. %s", err.Error())
 		}
 	}

--- a/service-item/team-kirby-clash-deluxe/types/service_item_purchase_service_item_response.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_purchase_service_item_response.go
@@ -32,20 +32,15 @@ func (sipsir ServiceItemPurchaseServiceItemResponse) WriteTo(writable types.Writ
 
 // ExtractFrom extracts the ServiceItemPurchaseServiceItemResponse from the given readable
 func (sipsir *ServiceItemPurchaseServiceItemResponse) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sipsir.ServiceItemEShopResponse.ExtractFrom(readable)
-	if err != nil {
+	if err := sipsir.ServiceItemEShopResponse.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemResponse.ServiceItemEShopResponse. %s", err.Error())
 	}
 
-	err = sipsir.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sipsir.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemResponse header. %s", err.Error())
 	}
 
-	err = sipsir.NullablePurchaseInfo.ExtractFrom(readable)
-	if err != nil {
+	if err := sipsir.NullablePurchaseInfo.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemResponse.NullablePurchaseInfo. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_right_binary.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_right_binary.go
@@ -31,20 +31,15 @@ func (sirb ServiceItemRightBinary) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemRightBinary from the given readable
 func (sirb *ServiceItemRightBinary) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sirb.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sirb.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRightBinary header. %s", err.Error())
 	}
 
-	err = sirb.UseType.ExtractFrom(readable)
-	if err != nil {
+	if err := sirb.UseType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRightBinary.UseType. %s", err.Error())
 	}
 
-	err = sirb.RightBinary.ExtractFrom(readable)
-	if err != nil {
+	if err := sirb.RightBinary.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRightBinary.RightBinary. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_right_consumption_info.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_right_consumption_info.go
@@ -32,20 +32,15 @@ func (sirci ServiceItemRightConsumptionInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemRightConsumptionInfo from the given readable
 func (sirci *ServiceItemRightConsumptionInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sirci.ServiceItemRightInfo.ExtractFrom(readable)
-	if err != nil {
+	if err := sirci.ServiceItemRightInfo.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRightConsumptionInfo.ServiceItemRightInfo. %s", err.Error())
 	}
 
-	err = sirci.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sirci.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRightConsumptionInfo header. %s", err.Error())
 	}
 
-	err = sirci.AccountRights.ExtractFrom(readable)
-	if err != nil {
+	if err := sirci.AccountRights.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRightConsumptionInfo.AccountRights. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_right_info.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_right_info.go
@@ -31,20 +31,15 @@ func (siri ServiceItemRightInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemRightInfo from the given readable
 func (siri *ServiceItemRightInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siri.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siri.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRightInfo header. %s", err.Error())
 	}
 
-	err = siri.ReferenceID.ExtractFrom(readable)
-	if err != nil {
+	if err := siri.ReferenceID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRightInfo.ReferenceID. %s", err.Error())
 	}
 
-	err = siri.ReferenceIDType.ExtractFrom(readable)
-	if err != nil {
+	if err := siri.ReferenceIDType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRightInfo.ReferenceIDType. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_right_infos.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_right_infos.go
@@ -37,35 +37,27 @@ func (siri ServiceItemRightInfos) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemRightInfos from the given readable
 func (siri *ServiceItemRightInfos) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siri.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siri.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRightInfos header. %s", err.Error())
 	}
 
-	err = siri.SupportID.ExtractFrom(readable)
-	if err != nil {
+	if err := siri.SupportID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRightInfos.SupportID. %s", err.Error())
 	}
 
-	err = siri.ConsumptionRightInfos.ExtractFrom(readable)
-	if err != nil {
+	if err := siri.ConsumptionRightInfos.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRightInfos.ConsumptionRightInfos. %s", err.Error())
 	}
 
-	err = siri.AdditionalTimeRightInfos.ExtractFrom(readable)
-	if err != nil {
+	if err := siri.AdditionalTimeRightInfos.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRightInfos.AdditionalTimeRightInfos. %s", err.Error())
 	}
 
-	err = siri.PermanentRightInfos.ExtractFrom(readable)
-	if err != nil {
+	if err := siri.PermanentRightInfos.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRightInfos.PermanentRightInfos. %s", err.Error())
 	}
 
-	err = siri.AlreadyPurchasedInitialOnlyItem.ExtractFrom(readable)
-	if err != nil {
+	if err := siri.AlreadyPurchasedInitialOnlyItem.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRightInfos.AlreadyPurchasedInitialOnlyItem. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_right_time_info.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_right_time_info.go
@@ -32,20 +32,15 @@ func (sirti ServiceItemRightTimeInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemRightTimeInfo from the given readable
 func (sirti *ServiceItemRightTimeInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sirti.ServiceItemRightInfo.ExtractFrom(readable)
-	if err != nil {
+	if err := sirti.ServiceItemRightInfo.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRightTimeInfo.ServiceItemRightInfo. %s", err.Error())
 	}
 
-	err = sirti.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sirti.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRightTimeInfo header. %s", err.Error())
 	}
 
-	err = sirti.AccountRights.ExtractFrom(readable)
-	if err != nil {
+	if err := sirti.AccountRights.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRightTimeInfo.AccountRights. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_transaction.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_transaction.go
@@ -45,55 +45,43 @@ func (sit ServiceItemTransaction) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemTransaction from the given readable
 func (sit *ServiceItemTransaction) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sit.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sit.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemTransaction header. %s", err.Error())
 	}
 
-	err = sit.TransactionID.ExtractFrom(readable)
-	if err != nil {
+	if err := sit.TransactionID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemTransaction.TransactionID. %s", err.Error())
 	}
 
-	err = sit.ExtTransactionID.ExtractFrom(readable)
-	if err != nil {
+	if err := sit.ExtTransactionID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemTransaction.ExtTransactionID. %s", err.Error())
 	}
 
-	err = sit.Time.ExtractFrom(readable)
-	if err != nil {
+	if err := sit.Time.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemTransaction.Time. %s", err.Error())
 	}
 
-	err = sit.TransactionType.ExtractFrom(readable)
-	if err != nil {
+	if err := sit.TransactionType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemTransaction.TransactionType. %s", err.Error())
 	}
 
-	err = sit.TransactionDescription.ExtractFrom(readable)
-	if err != nil {
+	if err := sit.TransactionDescription.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemTransaction.TransactionDescription. %s", err.Error())
 	}
 
-	err = sit.TransactionAmount.ExtractFrom(readable)
-	if err != nil {
+	if err := sit.TransactionAmount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemTransaction.TransactionAmount. %s", err.Error())
 	}
 
-	err = sit.ItemCode.ExtractFrom(readable)
-	if err != nil {
+	if err := sit.ItemCode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemTransaction.ItemCode. %s", err.Error())
 	}
 
-	err = sit.ReferenceID.ExtractFrom(readable)
-	if err != nil {
+	if err := sit.ReferenceID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemTransaction.ReferenceID. %s", err.Error())
 	}
 
-	err = sit.Limitation.ExtractFrom(readable)
-	if err != nil {
+	if err := sit.Limitation.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemTransaction.Limitation. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_use_service_item_by_account_param.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_use_service_item_by_account_param.go
@@ -43,50 +43,39 @@ func (siusibap ServiceItemUseServiceItemByAccountParam) WriteTo(writable types.W
 
 // ExtractFrom extracts the ServiceItemUseServiceItemByAccountParam from the given readable
 func (siusibap *ServiceItemUseServiceItemByAccountParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siusibap.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siusibap.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemUseServiceItemByAccountParam header. %s", err.Error())
 	}
 
-	err = siusibap.ReferenceIDForUse.ExtractFrom(readable)
-	if err != nil {
+	if err := siusibap.ReferenceIDForUse.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemUseServiceItemByAccountParam.ReferenceIDForUse. %s", err.Error())
 	}
 
-	err = siusibap.ReferenceIDForRightBinary.ExtractFrom(readable)
-	if err != nil {
+	if err := siusibap.ReferenceIDForRightBinary.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemUseServiceItemByAccountParam.ReferenceIDForRightBinary. %s", err.Error())
 	}
 
-	err = siusibap.UseType.ExtractFrom(readable)
-	if err != nil {
+	if err := siusibap.UseType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemUseServiceItemByAccountParam.UseType. %s", err.Error())
 	}
 
-	err = siusibap.UseNumber.ExtractFrom(readable)
-	if err != nil {
+	if err := siusibap.UseNumber.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemUseServiceItemByAccountParam.UseNumber. %s", err.Error())
 	}
 
-	err = siusibap.RightBinary.ExtractFrom(readable)
-	if err != nil {
+	if err := siusibap.RightBinary.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemUseServiceItemByAccountParam.RightBinary. %s", err.Error())
 	}
 
-	err = siusibap.LogMessage.ExtractFrom(readable)
-	if err != nil {
+	if err := siusibap.LogMessage.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemUseServiceItemByAccountParam.LogMessage. %s", err.Error())
 	}
 
-	err = siusibap.UniqueID.ExtractFrom(readable)
-	if err != nil {
+	if err := siusibap.UniqueID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemUseServiceItemByAccountParam.UniqueID. %s", err.Error())
 	}
 
-	err = siusibap.Platform.ExtractFrom(readable)
-	if err != nil {
+	if err := siusibap.Platform.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemUseServiceItemByAccountParam.Platform. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_use_service_item_response.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_use_service_item_response.go
@@ -32,20 +32,15 @@ func (siusir ServiceItemUseServiceItemResponse) WriteTo(writable types.Writable)
 
 // ExtractFrom extracts the ServiceItemUseServiceItemResponse from the given readable
 func (siusir *ServiceItemUseServiceItemResponse) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siusir.ServiceItemEShopResponse.ExtractFrom(readable)
-	if err != nil {
+	if err := siusir.ServiceItemEShopResponse.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemUseServiceItemResponse.ServiceItemEShopResponse. %s", err.Error())
 	}
 
-	err = siusir.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siusir.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemUseServiceItemResponse header. %s", err.Error())
 	}
 
-	err = siusir.NullableUsedInfo.ExtractFrom(readable)
-	if err != nil {
+	if err := siusir.NullableUsedInfo.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemUseServiceItemResponse.NullableUsedInfo. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_used_info.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_used_info.go
@@ -31,20 +31,15 @@ func (siui ServiceItemUsedInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemUsedInfo from the given readable
 func (siui *ServiceItemUsedInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siui.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siui.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemUsedInfo header. %s", err.Error())
 	}
 
-	err = siui.AcquiredCount.ExtractFrom(readable)
-	if err != nil {
+	if err := siui.AcquiredCount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemUsedInfo.AcquiredCount. %s", err.Error())
 	}
 
-	err = siui.UsedCount.ExtractFrom(readable)
-	if err != nil {
+	if err := siui.UsedCount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemUsedInfo.UsedCount. %s", err.Error())
 	}
 

--- a/service-item/team-kirby-clash-deluxe/types/service_item_user_info.go
+++ b/service-item/team-kirby-clash-deluxe/types/service_item_user_info.go
@@ -29,15 +29,11 @@ func (siui ServiceItemUserInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemUserInfo from the given readable
 func (siui *ServiceItemUserInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siui.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siui.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemUserInfo header. %s", err.Error())
 	}
 
-	err = siui.ApplicationBuffer.ExtractFrom(readable)
-	if err != nil {
+	if err := siui.ApplicationBuffer.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemUserInfo.ApplicationBuffer. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_account_right.go
+++ b/service-item/wii-sports-club/types/service_item_account_right.go
@@ -31,20 +31,15 @@ func (siar ServiceItemAccountRight) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemAccountRight from the given readable
 func (siar *ServiceItemAccountRight) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siar.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siar.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAccountRight header. %s", err.Error())
 	}
 
-	err = siar.PID.ExtractFrom(readable)
-	if err != nil {
+	if err := siar.PID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAccountRight.PID. %s", err.Error())
 	}
 
-	err = siar.Limitation.ExtractFrom(readable)
-	if err != nil {
+	if err := siar.Limitation.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAccountRight.Limitation. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_amount.go
+++ b/service-item/wii-sports-club/types/service_item_amount.go
@@ -33,25 +33,19 @@ func (sia ServiceItemAmount) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemAmount from the given readable
 func (sia *ServiceItemAmount) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sia.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sia.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAmount header. %s", err.Error())
 	}
 
-	err = sia.FormattedAmount.ExtractFrom(readable)
-	if err != nil {
+	if err := sia.FormattedAmount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAmount.FormattedAmount. %s", err.Error())
 	}
 
-	err = sia.Currency.ExtractFrom(readable)
-	if err != nil {
+	if err := sia.Currency.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAmount.Currency. %s", err.Error())
 	}
 
-	err = sia.RawValue.ExtractFrom(readable)
-	if err != nil {
+	if err := sia.RawValue.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAmount.RawValue. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_attribute.go
+++ b/service-item/wii-sports-club/types/service_item_attribute.go
@@ -31,20 +31,15 @@ func (sia ServiceItemAttribute) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemAttribute from the given readable
 func (sia *ServiceItemAttribute) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sia.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sia.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAttribute header. %s", err.Error())
 	}
 
-	err = sia.Name.ExtractFrom(readable)
-	if err != nil {
+	if err := sia.Name.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAttribute.Name. %s", err.Error())
 	}
 
-	err = sia.Value.ExtractFrom(readable)
-	if err != nil {
+	if err := sia.Value.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemAttribute.Value. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_catalog.go
+++ b/service-item/wii-sports-club/types/service_item_catalog.go
@@ -33,25 +33,19 @@ func (sic ServiceItemCatalog) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemCatalog from the given readable
 func (sic *ServiceItemCatalog) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sic.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sic.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemCatalog header. %s", err.Error())
 	}
 
-	err = sic.TotalSize.ExtractFrom(readable)
-	if err != nil {
+	if err := sic.TotalSize.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemCatalog.TotalSize. %s", err.Error())
 	}
 
-	err = sic.Offset.ExtractFrom(readable)
-	if err != nil {
+	if err := sic.Offset.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemCatalog.Offset. %s", err.Error())
 	}
 
-	err = sic.ListItems.ExtractFrom(readable)
-	if err != nil {
+	if err := sic.ListItems.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemCatalog.ListItems. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_end_challenge_param.go
+++ b/service-item/wii-sports-club/types/service_item_end_challenge_param.go
@@ -31,20 +31,15 @@ func (siecp ServiceItemEndChallengeParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemEndChallengeParam from the given readable
 func (siecp *ServiceItemEndChallengeParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siecp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siecp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemEndChallengeParam header. %s", err.Error())
 	}
 
-	err = siecp.ChallengeScheduleID.ExtractFrom(readable)
-	if err != nil {
+	if err := siecp.ChallengeScheduleID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemEndChallengeParam.ChallengeScheduleID. %s", err.Error())
 	}
 
-	err = siecp.UserInfo.ExtractFrom(readable)
-	if err != nil {
+	if err := siecp.UserInfo.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemEndChallengeParam.UserInfo. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_eshop_response.go
+++ b/service-item/wii-sports-club/types/service_item_eshop_response.go
@@ -33,25 +33,19 @@ func (siesr ServiceItemEShopResponse) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemEShopResponse from the given readable
 func (siesr *ServiceItemEShopResponse) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siesr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siesr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemEShopResponse header. %s", err.Error())
 	}
 
-	err = siesr.HTTPStatus.ExtractFrom(readable)
-	if err != nil {
+	if err := siesr.HTTPStatus.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemEShopResponse.HTTPStatus. %s", err.Error())
 	}
 
-	err = siesr.ErrorCode.ExtractFrom(readable)
-	if err != nil {
+	if err := siesr.ErrorCode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemEShopResponse.ErrorCode. %s", err.Error())
 	}
 
-	err = siesr.CorrelationID.ExtractFrom(readable)
-	if err != nil {
+	if err := siesr.CorrelationID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemEShopResponse.CorrelationID. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_event.go
+++ b/service-item/wii-sports-club/types/service_item_event.go
@@ -43,50 +43,39 @@ func (sie ServiceItemEvent) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemEvent from the given readable
 func (sie *ServiceItemEvent) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sie.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sie.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemEvent header. %s", err.Error())
 	}
 
-	err = sie.EventID.ExtractFrom(readable)
-	if err != nil {
+	if err := sie.EventID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemEvent.EventID. %s", err.Error())
 	}
 
-	err = sie.ParamInt.ExtractFrom(readable)
-	if err != nil {
+	if err := sie.ParamInt.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemEvent.ParamInt. %s", err.Error())
 	}
 
-	err = sie.ParamString.ExtractFrom(readable)
-	if err != nil {
+	if err := sie.ParamString.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemEvent.ParamString. %s", err.Error())
 	}
 
-	err = sie.ParamBinary.ExtractFrom(readable)
-	if err != nil {
+	if err := sie.ParamBinary.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemEvent.ParamBinary. %s", err.Error())
 	}
 
-	err = sie.PresentTicketType.ExtractFrom(readable)
-	if err != nil {
+	if err := sie.PresentTicketType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemEvent.PresentTicketType. %s", err.Error())
 	}
 
-	err = sie.PresentTicketNum.ExtractFrom(readable)
-	if err != nil {
+	if err := sie.PresentTicketNum.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemEvent.PresentTicketNum. %s", err.Error())
 	}
 
-	err = sie.TimeBegin.ExtractFrom(readable)
-	if err != nil {
+	if err := sie.TimeBegin.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemEvent.TimeBegin. %s", err.Error())
 	}
 
-	err = sie.TimeEnd.ExtractFrom(readable)
-	if err != nil {
+	if err := sie.TimeEnd.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemEvent.TimeEnd. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_get_balance_param.go
+++ b/service-item/wii-sports-club/types/service_item_get_balance_param.go
@@ -31,20 +31,15 @@ func (sigbp ServiceItemGetBalanceParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemGetBalanceParam from the given readable
 func (sigbp *ServiceItemGetBalanceParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sigbp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sigbp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetBalanceParam header. %s", err.Error())
 	}
 
-	err = sigbp.Language.ExtractFrom(readable)
-	if err != nil {
+	if err := sigbp.Language.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetBalanceParam.Language. %s", err.Error())
 	}
 
-	err = sigbp.TitleID.ExtractFrom(readable)
-	if err != nil {
+	if err := sigbp.TitleID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetBalanceParam.TitleID. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_get_balance_response.go
+++ b/service-item/wii-sports-club/types/service_item_get_balance_response.go
@@ -32,20 +32,15 @@ func (sigbr ServiceItemGetBalanceResponse) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemGetBalanceResponse from the given readable
 func (sigbr *ServiceItemGetBalanceResponse) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sigbr.ServiceItemEShopResponse.ExtractFrom(readable)
-	if err != nil {
+	if err := sigbr.ServiceItemEShopResponse.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetBalanceResponse.ServiceItemEShopResponse. %s", err.Error())
 	}
 
-	err = sigbr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sigbr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetBalanceResponse header. %s", err.Error())
 	}
 
-	err = sigbr.NullableBalance.ExtractFrom(readable)
-	if err != nil {
+	if err := sigbr.NullableBalance.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetBalanceResponse.NullableBalance. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_get_notice_param.go
+++ b/service-item/wii-sports-club/types/service_item_get_notice_param.go
@@ -29,15 +29,11 @@ func (signp ServiceItemGetNoticeParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemGetNoticeParam from the given readable
 func (signp *ServiceItemGetNoticeParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = signp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := signp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetNoticeParam header. %s", err.Error())
 	}
 
-	err = signp.NoticeType.ExtractFrom(readable)
-	if err != nil {
+	if err := signp.NoticeType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetNoticeParam.NoticeType. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_get_prepurchase_info_param.go
+++ b/service-item/wii-sports-club/types/service_item_get_prepurchase_info_param.go
@@ -33,25 +33,19 @@ func (sigpip ServiceItemGetPrepurchaseInfoParam) WriteTo(writable types.Writable
 
 // ExtractFrom extracts the ServiceItemGetPrepurchaseInfoParam from the given readable
 func (sigpip *ServiceItemGetPrepurchaseInfoParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sigpip.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sigpip.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPrepurchaseInfoParam header. %s", err.Error())
 	}
 
-	err = sigpip.ItemCode.ExtractFrom(readable)
-	if err != nil {
+	if err := sigpip.ItemCode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPrepurchaseInfoParam.ItemCode. %s", err.Error())
 	}
 
-	err = sigpip.Language.ExtractFrom(readable)
-	if err != nil {
+	if err := sigpip.Language.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPrepurchaseInfoParam.Language. %s", err.Error())
 	}
 
-	err = sigpip.TitleID.ExtractFrom(readable)
-	if err != nil {
+	if err := sigpip.TitleID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPrepurchaseInfoParam.TitleID. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_get_prepurchase_info_response.go
+++ b/service-item/wii-sports-club/types/service_item_get_prepurchase_info_response.go
@@ -32,20 +32,15 @@ func (sigpir ServiceItemGetPrepurchaseInfoResponse) WriteTo(writable types.Writa
 
 // ExtractFrom extracts the ServiceItemGetPrepurchaseInfoResponse from the given readable
 func (sigpir *ServiceItemGetPrepurchaseInfoResponse) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sigpir.ServiceItemEShopResponse.ExtractFrom(readable)
-	if err != nil {
+	if err := sigpir.ServiceItemEShopResponse.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPrepurchaseInfoResponse.ServiceItemEShopResponse. %s", err.Error())
 	}
 
-	err = sigpir.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sigpir.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPrepurchaseInfoResponse header. %s", err.Error())
 	}
 
-	err = sigpir.NullablePrepurchaseInfo.ExtractFrom(readable)
-	if err != nil {
+	if err := sigpir.NullablePrepurchaseInfo.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPrepurchaseInfoResponse.NullablePrepurchaseInfo. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_get_purchase_history_param.go
+++ b/service-item/wii-sports-club/types/service_item_get_purchase_history_param.go
@@ -35,30 +35,23 @@ func (sigphp ServiceItemGetPurchaseHistoryParam) WriteTo(writable types.Writable
 
 // ExtractFrom extracts the ServiceItemGetPurchaseHistoryParam from the given readable
 func (sigphp *ServiceItemGetPurchaseHistoryParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sigphp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sigphp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPurchaseHistoryParam header. %s", err.Error())
 	}
 
-	err = sigphp.Language.ExtractFrom(readable)
-	if err != nil {
+	if err := sigphp.Language.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPurchaseHistoryParam.Language. %s", err.Error())
 	}
 
-	err = sigphp.Offset.ExtractFrom(readable)
-	if err != nil {
+	if err := sigphp.Offset.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPurchaseHistoryParam.Offset. %s", err.Error())
 	}
 
-	err = sigphp.Size.ExtractFrom(readable)
-	if err != nil {
+	if err := sigphp.Size.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPurchaseHistoryParam.Size. %s", err.Error())
 	}
 
-	err = sigphp.TitleID.ExtractFrom(readable)
-	if err != nil {
+	if err := sigphp.TitleID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPurchaseHistoryParam.TitleID. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_get_purchase_history_response.go
+++ b/service-item/wii-sports-club/types/service_item_get_purchase_history_response.go
@@ -32,20 +32,15 @@ func (sigphr ServiceItemGetPurchaseHistoryResponse) WriteTo(writable types.Writa
 
 // ExtractFrom extracts the ServiceItemGetPurchaseHistoryResponse from the given readable
 func (sigphr *ServiceItemGetPurchaseHistoryResponse) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sigphr.ServiceItemEShopResponse.ExtractFrom(readable)
-	if err != nil {
+	if err := sigphr.ServiceItemEShopResponse.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPurchaseHistoryResponse.ServiceItemEShopResponse. %s", err.Error())
 	}
 
-	err = sigphr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sigphr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPurchaseHistoryResponse header. %s", err.Error())
 	}
 
-	err = sigphr.NullablePurchaseHistory.ExtractFrom(readable)
-	if err != nil {
+	if err := sigphr.NullablePurchaseHistory.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetPurchaseHistoryResponse.NullablePurchaseHistory. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_get_service_item_right_param.go
+++ b/service-item/wii-sports-club/types/service_item_get_service_item_right_param.go
@@ -31,20 +31,15 @@ func (sigsirp ServiceItemGetServiceItemRightParam) WriteTo(writable types.Writab
 
 // ExtractFrom extracts the ServiceItemGetServiceItemRightParam from the given readable
 func (sigsirp *ServiceItemGetServiceItemRightParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sigsirp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sigsirp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetServiceItemRightParam header. %s", err.Error())
 	}
 
-	err = sigsirp.ReferenceID.ExtractFrom(readable)
-	if err != nil {
+	if err := sigsirp.ReferenceID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetServiceItemRightParam.ReferenceID. %s", err.Error())
 	}
 
-	err = sigsirp.TitleID.ExtractFrom(readable)
-	if err != nil {
+	if err := sigsirp.TitleID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetServiceItemRightParam.TitleID. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_get_service_item_right_response.go
+++ b/service-item/wii-sports-club/types/service_item_get_service_item_right_response.go
@@ -32,20 +32,15 @@ func (sigsirr ServiceItemGetServiceItemRightResponse) WriteTo(writable types.Wri
 
 // ExtractFrom extracts the ServiceItemGetServiceItemRightResponse from the given readable
 func (sigsirr *ServiceItemGetServiceItemRightResponse) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sigsirr.ServiceItemEShopResponse.ExtractFrom(readable)
-	if err != nil {
+	if err := sigsirr.ServiceItemEShopResponse.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetServiceItemRightResponse.ServiceItemEShopResponse. %s", err.Error())
 	}
 
-	err = sigsirr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sigsirr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetServiceItemRightResponse header. %s", err.Error())
 	}
 
-	err = sigsirr.NullableRightInfos.ExtractFrom(readable)
-	if err != nil {
+	if err := sigsirr.NullableRightInfos.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemGetServiceItemRightResponse.NullableRightInfos. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_http_get_param.go
+++ b/service-item/wii-sports-club/types/service_item_http_get_param.go
@@ -29,15 +29,11 @@ func (sihttpgp ServiceItemHTTPGetParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemHTTPGetParam from the given readable
 func (sihttpgp *ServiceItemHTTPGetParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sihttpgp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sihttpgp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemHTTPGetParam header. %s", err.Error())
 	}
 
-	err = sihttpgp.URL.ExtractFrom(readable)
-	if err != nil {
+	if err := sihttpgp.URL.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemHTTPGetParam.URL. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_http_get_response.go
+++ b/service-item/wii-sports-club/types/service_item_http_get_response.go
@@ -29,15 +29,11 @@ func (sihttpgr ServiceItemHTTPGetResponse) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemHTTPGetResponse from the given readable
 func (sihttpgr *ServiceItemHTTPGetResponse) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sihttpgr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sihttpgr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemHTTPGetResponse header. %s", err.Error())
 	}
 
-	err = sihttpgr.Response.ExtractFrom(readable)
-	if err != nil {
+	if err := sihttpgr.Response.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemHTTPGetResponse.Response. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_limitation.go
+++ b/service-item/wii-sports-club/types/service_item_limitation.go
@@ -31,20 +31,15 @@ func (sil ServiceItemLimitation) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemLimitation from the given readable
 func (sil *ServiceItemLimitation) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sil.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sil.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemLimitation header. %s", err.Error())
 	}
 
-	err = sil.LimitationType.ExtractFrom(readable)
-	if err != nil {
+	if err := sil.LimitationType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemLimitation.LimitationType. %s", err.Error())
 	}
 
-	err = sil.LimitationValue.ExtractFrom(readable)
-	if err != nil {
+	if err := sil.LimitationValue.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemLimitation.LimitationValue. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_list_item.go
+++ b/service-item/wii-sports-club/types/service_item_list_item.go
@@ -39,40 +39,31 @@ func (sili ServiceItemListItem) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemListItem from the given readable
 func (sili *ServiceItemListItem) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sili.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sili.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListItem header. %s", err.Error())
 	}
 
-	err = sili.ItemCode.ExtractFrom(readable)
-	if err != nil {
+	if err := sili.ItemCode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListItem.ItemCode. %s", err.Error())
 	}
 
-	err = sili.RegularPrice.ExtractFrom(readable)
-	if err != nil {
+	if err := sili.RegularPrice.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListItem.RegularPrice. %s", err.Error())
 	}
 
-	err = sili.TaxExcluded.ExtractFrom(readable)
-	if err != nil {
+	if err := sili.TaxExcluded.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListItem.TaxExcluded. %s", err.Error())
 	}
 
-	err = sili.InitialPurchaseOnly.ExtractFrom(readable)
-	if err != nil {
+	if err := sili.InitialPurchaseOnly.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListItem.InitialPurchaseOnly. %s", err.Error())
 	}
 
-	err = sili.Limitation.ExtractFrom(readable)
-	if err != nil {
+	if err := sili.Limitation.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListItem.Limitation. %s", err.Error())
 	}
 
-	err = sili.Attributes.ExtractFrom(readable)
-	if err != nil {
+	if err := sili.Attributes.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListItem.Attributes. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_list_service_item_param.go
+++ b/service-item/wii-sports-club/types/service_item_list_service_item_param.go
@@ -35,30 +35,23 @@ func (silsip ServiceItemListServiceItemParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemListServiceItemParam from the given readable
 func (silsip *ServiceItemListServiceItemParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = silsip.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := silsip.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListServiceItemParam header. %s", err.Error())
 	}
 
-	err = silsip.Language.ExtractFrom(readable)
-	if err != nil {
+	if err := silsip.Language.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListServiceItemParam.Language. %s", err.Error())
 	}
 
-	err = silsip.Offset.ExtractFrom(readable)
-	if err != nil {
+	if err := silsip.Offset.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListServiceItemParam.Offset. %s", err.Error())
 	}
 
-	err = silsip.Size.ExtractFrom(readable)
-	if err != nil {
+	if err := silsip.Size.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListServiceItemParam.Size. %s", err.Error())
 	}
 
-	err = silsip.TitleID.ExtractFrom(readable)
-	if err != nil {
+	if err := silsip.TitleID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListServiceItemParam.TitleID. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_list_service_item_response.go
+++ b/service-item/wii-sports-club/types/service_item_list_service_item_response.go
@@ -32,20 +32,15 @@ func (silsir ServiceItemListServiceItemResponse) WriteTo(writable types.Writable
 
 // ExtractFrom extracts the ServiceItemListServiceItemResponse from the given readable
 func (silsir *ServiceItemListServiceItemResponse) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = silsir.ServiceItemEShopResponse.ExtractFrom(readable)
-	if err != nil {
+	if err := silsir.ServiceItemEShopResponse.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListServiceItemResponse.ServiceItemEShopResponse. %s", err.Error())
 	}
 
-	err = silsir.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := silsir.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListServiceItemResponse header. %s", err.Error())
 	}
 
-	err = silsir.NullableCatalog.ExtractFrom(readable)
-	if err != nil {
+	if err := silsir.NullableCatalog.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemListServiceItemResponse.NullableCatalog. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_notice.go
+++ b/service-item/wii-sports-club/types/service_item_notice.go
@@ -41,45 +41,35 @@ func (sin ServiceItemNotice) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemNotice from the given readable
 func (sin *ServiceItemNotice) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sin.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sin.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemNotice header. %s", err.Error())
 	}
 
-	err = sin.ScheduleID.ExtractFrom(readable)
-	if err != nil {
+	if err := sin.ScheduleID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemNotice.ScheduleID. %s", err.Error())
 	}
 
-	err = sin.ScheduleType.ExtractFrom(readable)
-	if err != nil {
+	if err := sin.ScheduleType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemNotice.ScheduleType. %s", err.Error())
 	}
 
-	err = sin.ParamInt.ExtractFrom(readable)
-	if err != nil {
+	if err := sin.ParamInt.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemNotice.ParamInt. %s", err.Error())
 	}
 
-	err = sin.ParamString.ExtractFrom(readable)
-	if err != nil {
+	if err := sin.ParamString.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemNotice.ParamString. %s", err.Error())
 	}
 
-	err = sin.ParamBinary.ExtractFrom(readable)
-	if err != nil {
+	if err := sin.ParamBinary.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemNotice.ParamBinary. %s", err.Error())
 	}
 
-	err = sin.TimeBegin.ExtractFrom(readable)
-	if err != nil {
+	if err := sin.TimeBegin.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemNotice.TimeBegin. %s", err.Error())
 	}
 
-	err = sin.TimeEnd.ExtractFrom(readable)
-	if err != nil {
+	if err := sin.TimeEnd.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemNotice.TimeEnd. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_prepurchase_info.go
+++ b/service-item/wii-sports-club/types/service_item_prepurchase_info.go
@@ -43,50 +43,39 @@ func (sipi ServiceItemPrepurchaseInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemPrepurchaseInfo from the given readable
 func (sipi *ServiceItemPrepurchaseInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sipi.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sipi.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseInfo header. %s", err.Error())
 	}
 
-	err = sipi.ItemCode.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.ItemCode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseInfo.ItemCode. %s", err.Error())
 	}
 
-	err = sipi.PriceID.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.PriceID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseInfo.PriceID. %s", err.Error())
 	}
 
-	err = sipi.RegularPrice.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.RegularPrice.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseInfo.RegularPrice. %s", err.Error())
 	}
 
-	err = sipi.IsTaxAvailable.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.IsTaxAvailable.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseInfo.IsTaxAvailable. %s", err.Error())
 	}
 
-	err = sipi.TaxAmount.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.TaxAmount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseInfo.TaxAmount. %s", err.Error())
 	}
 
-	err = sipi.TotalAmount.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.TotalAmount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseInfo.TotalAmount. %s", err.Error())
 	}
 
-	err = sipi.CurrentBalance.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.CurrentBalance.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseInfo.CurrentBalance. %s", err.Error())
 	}
 
-	err = sipi.PostBalance.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.PostBalance.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPrepurchaseInfo.PostBalance. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_purchace_info.go
+++ b/service-item/wii-sports-club/types/service_item_purchace_info.go
@@ -35,30 +35,23 @@ func (sipi ServiceItemPurchaceInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemPurchaceInfo from the given readable
 func (sipi *ServiceItemPurchaceInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sipi.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sipi.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaceInfo header. %s", err.Error())
 	}
 
-	err = sipi.TransactionID.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.TransactionID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaceInfo.TransactionID. %s", err.Error())
 	}
 
-	err = sipi.ExtTransactionID.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.ExtTransactionID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaceInfo.ExtTransactionID. %s", err.Error())
 	}
 
-	err = sipi.ItemCode.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.ItemCode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaceInfo.ItemCode. %s", err.Error())
 	}
 
-	err = sipi.PostBalance.ExtractFrom(readable)
-	if err != nil {
+	if err := sipi.PostBalance.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaceInfo.PostBalance. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_purchase_history.go
+++ b/service-item/wii-sports-club/types/service_item_purchase_history.go
@@ -33,25 +33,19 @@ func (siph ServiceItemPurchaseHistory) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemPurchaseHistory from the given readable
 func (siph *ServiceItemPurchaseHistory) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siph.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siph.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseHistory header. %s", err.Error())
 	}
 
-	err = siph.TotalSize.ExtractFrom(readable)
-	if err != nil {
+	if err := siph.TotalSize.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseHistory.TotalSize. %s", err.Error())
 	}
 
-	err = siph.Offset.ExtractFrom(readable)
-	if err != nil {
+	if err := siph.Offset.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseHistory.Offset. %s", err.Error())
 	}
 
-	err = siph.Transactions.ExtractFrom(readable)
-	if err != nil {
+	if err := siph.Transactions.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseHistory.Transactions. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_purchase_service_item_param.go
+++ b/service-item/wii-sports-club/types/service_item_purchase_service_item_param.go
@@ -43,50 +43,39 @@ func (sipsip ServiceItemPurchaseServiceItemParam) WriteTo(writable types.Writabl
 
 // ExtractFrom extracts the ServiceItemPurchaseServiceItemParam from the given readable
 func (sipsip *ServiceItemPurchaseServiceItemParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sipsip.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sipsip.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemParam header. %s", err.Error())
 	}
 
-	err = sipsip.ItemCode.ExtractFrom(readable)
-	if err != nil {
+	if err := sipsip.ItemCode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemParam.ItemCode. %s", err.Error())
 	}
 
-	err = sipsip.PriceID.ExtractFrom(readable)
-	if err != nil {
+	if err := sipsip.PriceID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemParam.PriceID. %s", err.Error())
 	}
 
-	err = sipsip.ReferenceID.ExtractFrom(readable)
-	if err != nil {
+	if err := sipsip.ReferenceID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemParam.ReferenceID. %s", err.Error())
 	}
 
-	err = sipsip.Balance.ExtractFrom(readable)
-	if err != nil {
+	if err := sipsip.Balance.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemParam.Balance. %s", err.Error())
 	}
 
-	err = sipsip.ItemName.ExtractFrom(readable)
-	if err != nil {
+	if err := sipsip.ItemName.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemParam.ItemName. %s", err.Error())
 	}
 
-	err = sipsip.EcServiceToken.ExtractFrom(readable)
-	if err != nil {
+	if err := sipsip.EcServiceToken.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemParam.EcServiceToken. %s", err.Error())
 	}
 
-	err = sipsip.Language.ExtractFrom(readable)
-	if err != nil {
+	if err := sipsip.Language.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemParam.Language. %s", err.Error())
 	}
 
-	err = sipsip.TitleID.ExtractFrom(readable)
-	if err != nil {
+	if err := sipsip.TitleID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemParam.TitleID. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_purchase_service_item_response.go
+++ b/service-item/wii-sports-club/types/service_item_purchase_service_item_response.go
@@ -32,20 +32,15 @@ func (sipsir ServiceItemPurchaseServiceItemResponse) WriteTo(writable types.Writ
 
 // ExtractFrom extracts the ServiceItemPurchaseServiceItemResponse from the given readable
 func (sipsir *ServiceItemPurchaseServiceItemResponse) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sipsir.ServiceItemEShopResponse.ExtractFrom(readable)
-	if err != nil {
+	if err := sipsir.ServiceItemEShopResponse.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemResponse.ServiceItemEShopResponse. %s", err.Error())
 	}
 
-	err = sipsir.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sipsir.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemResponse header. %s", err.Error())
 	}
 
-	err = sipsir.NullablePurchaceInfo.ExtractFrom(readable)
-	if err != nil {
+	if err := sipsir.NullablePurchaceInfo.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemPurchaseServiceItemResponse.NullablePurchaceInfo. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_request_ticket_restoration_param.go
+++ b/service-item/wii-sports-club/types/service_item_request_ticket_restoration_param.go
@@ -31,20 +31,15 @@ func (sirtrp ServiceItemRequestTicketRestorationParam) WriteTo(writable types.Wr
 
 // ExtractFrom extracts the ServiceItemRequestTicketRestorationParam from the given readable
 func (sirtrp *ServiceItemRequestTicketRestorationParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sirtrp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sirtrp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRequestTicketRestorationParam header. %s", err.Error())
 	}
 
-	err = sirtrp.TicketType.ExtractFrom(readable)
-	if err != nil {
+	if err := sirtrp.TicketType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRequestTicketRestorationParam.TicketType. %s", err.Error())
 	}
 
-	err = sirtrp.NumTicket.ExtractFrom(readable)
-	if err != nil {
+	if err := sirtrp.NumTicket.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRequestTicketRestorationParam.NumTicket. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_right_info.go
+++ b/service-item/wii-sports-club/types/service_item_right_info.go
@@ -31,20 +31,15 @@ func (siri ServiceItemRightInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemRightInfo from the given readable
 func (siri *ServiceItemRightInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siri.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siri.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRightInfo header. %s", err.Error())
 	}
 
-	err = siri.ReferenceID.ExtractFrom(readable)
-	if err != nil {
+	if err := siri.ReferenceID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRightInfo.ReferenceID. %s", err.Error())
 	}
 
-	err = siri.AccountRights.ExtractFrom(readable)
-	if err != nil {
+	if err := siri.AccountRights.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRightInfo.AccountRights. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_right_infos.go
+++ b/service-item/wii-sports-club/types/service_item_right_infos.go
@@ -29,15 +29,11 @@ func (siri ServiceItemRightInfos) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemRightInfos from the given readable
 func (siri *ServiceItemRightInfos) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siri.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siri.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRightInfos header. %s", err.Error())
 	}
 
-	err = siri.RightInfos.ExtractFrom(readable)
-	if err != nil {
+	if err := siri.RightInfos.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemRightInfos.RightInfos. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_start_challenge_param.go
+++ b/service-item/wii-sports-club/types/service_item_start_challenge_param.go
@@ -33,25 +33,19 @@ func (siscp ServiceItemStartChallengeParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemStartChallengeParam from the given readable
 func (siscp *ServiceItemStartChallengeParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siscp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siscp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemStartChallengeParam header. %s", err.Error())
 	}
 
-	err = siscp.ChallengeScheduleID.ExtractFrom(readable)
-	if err != nil {
+	if err := siscp.ChallengeScheduleID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemStartChallengeParam.ChallengeScheduleID. %s", err.Error())
 	}
 
-	err = siscp.TicketType.ExtractFrom(readable)
-	if err != nil {
+	if err := siscp.TicketType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemStartChallengeParam.TicketType. %s", err.Error())
 	}
 
-	err = siscp.NumTicket.ExtractFrom(readable)
-	if err != nil {
+	if err := siscp.NumTicket.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemStartChallengeParam.NumTicket. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_ticket_info.go
+++ b/service-item/wii-sports-club/types/service_item_ticket_info.go
@@ -31,20 +31,15 @@ func (siti ServiceItemTicketInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemTicketInfo from the given readable
 func (siti *ServiceItemTicketInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siti.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siti.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemTicketInfo header. %s", err.Error())
 	}
 
-	err = siti.TicketType.ExtractFrom(readable)
-	if err != nil {
+	if err := siti.TicketType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemTicketInfo.TicketType. %s", err.Error())
 	}
 
-	err = siti.NumTotal.ExtractFrom(readable)
-	if err != nil {
+	if err := siti.NumTotal.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemTicketInfo.NumTotal. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_transaction.go
+++ b/service-item/wii-sports-club/types/service_item_transaction.go
@@ -45,55 +45,43 @@ func (sit ServiceItemTransaction) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemTransaction from the given readable
 func (sit *ServiceItemTransaction) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sit.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sit.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemTransaction header. %s", err.Error())
 	}
 
-	err = sit.TransactionID.ExtractFrom(readable)
-	if err != nil {
+	if err := sit.TransactionID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemTransaction.TransactionID. %s", err.Error())
 	}
 
-	err = sit.ExtTransactionID.ExtractFrom(readable)
-	if err != nil {
+	if err := sit.ExtTransactionID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemTransaction.ExtTransactionID. %s", err.Error())
 	}
 
-	err = sit.Time.ExtractFrom(readable)
-	if err != nil {
+	if err := sit.Time.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemTransaction.Time. %s", err.Error())
 	}
 
-	err = sit.TransactionType.ExtractFrom(readable)
-	if err != nil {
+	if err := sit.TransactionType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemTransaction.TransactionType. %s", err.Error())
 	}
 
-	err = sit.TransactionDescription.ExtractFrom(readable)
-	if err != nil {
+	if err := sit.TransactionDescription.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemTransaction.TransactionDescription. %s", err.Error())
 	}
 
-	err = sit.TransactionAmount.ExtractFrom(readable)
-	if err != nil {
+	if err := sit.TransactionAmount.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemTransaction.TransactionAmount. %s", err.Error())
 	}
 
-	err = sit.ItemCode.ExtractFrom(readable)
-	if err != nil {
+	if err := sit.ItemCode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemTransaction.ItemCode. %s", err.Error())
 	}
 
-	err = sit.ReferenceID.ExtractFrom(readable)
-	if err != nil {
+	if err := sit.ReferenceID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemTransaction.ReferenceID. %s", err.Error())
 	}
 
-	err = sit.Limitation.ExtractFrom(readable)
-	if err != nil {
+	if err := sit.Limitation.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemTransaction.Limitation. %s", err.Error())
 	}
 

--- a/service-item/wii-sports-club/types/service_item_user_info.go
+++ b/service-item/wii-sports-club/types/service_item_user_info.go
@@ -31,20 +31,15 @@ func (siui ServiceItemUserInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ServiceItemUserInfo from the given readable
 func (siui *ServiceItemUserInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = siui.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := siui.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemUserInfo header. %s", err.Error())
 	}
 
-	err = siui.NumTotalEntryTicket.ExtractFrom(readable)
-	if err != nil {
+	if err := siui.NumTotalEntryTicket.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemUserInfo.NumTotalEntryTicket. %s", err.Error())
 	}
 
-	err = siui.ApplicationBuffer.ExtractFrom(readable)
-	if err != nil {
+	if err := siui.ApplicationBuffer.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ServiceItemUserInfo.ApplicationBuffer. %s", err.Error())
 	}
 

--- a/shop/nintendo-badge-arcade/types/shop_post_play_log_param.go
+++ b/shop/nintendo-badge-arcade/types/shop_post_play_log_param.go
@@ -33,25 +33,19 @@ func (spplp ShopPostPlayLogParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ShopPostPlayLogParam from the given readable
 func (spplp *ShopPostPlayLogParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = spplp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := spplp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ShopPostPlayLogParam header. %s", err.Error())
 	}
 
-	err = spplp.Unknown1.ExtractFrom(readable)
-	if err != nil {
+	if err := spplp.Unknown1.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ShopPostPlayLogParam.Unknown1. %s", err.Error())
 	}
 
-	err = spplp.Timestamp.ExtractFrom(readable)
-	if err != nil {
+	if err := spplp.Timestamp.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ShopPostPlayLogParam.Timestamp. %s", err.Error())
 	}
 
-	err = spplp.Unknown2.ExtractFrom(readable)
-	if err != nil {
+	if err := spplp.Unknown2.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ShopPostPlayLogParam.Unknown2. %s", err.Error())
 	}
 

--- a/shop/types/shop_item.go
+++ b/shop/types/shop_item.go
@@ -35,30 +35,23 @@ func (si ShopItem) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ShopItem from the given readable
 func (si *ShopItem) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = si.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := si.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ShopItem header. %s", err.Error())
 	}
 
-	err = si.ItemID.ExtractFrom(readable)
-	if err != nil {
+	if err := si.ItemID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ShopItem.ItemID. %s", err.Error())
 	}
 
-	err = si.ReferenceID.ExtractFrom(readable)
-	if err != nil {
+	if err := si.ReferenceID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ShopItem.ReferenceID. %s", err.Error())
 	}
 
-	err = si.ServiceName.ExtractFrom(readable)
-	if err != nil {
+	if err := si.ServiceName.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ShopItem.ServiceName. %s", err.Error())
 	}
 
-	err = si.ItemCode.ExtractFrom(readable)
-	if err != nil {
+	if err := si.ItemCode.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ShopItem.ItemCode. %s", err.Error())
 	}
 

--- a/shop/types/shop_item_rights.go
+++ b/shop/types/shop_item_rights.go
@@ -33,25 +33,19 @@ func (sir ShopItemRights) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ShopItemRights from the given readable
 func (sir *ShopItemRights) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sir.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sir.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ShopItemRights header. %s", err.Error())
 	}
 
-	err = sir.ReferenceID.ExtractFrom(readable)
-	if err != nil {
+	if err := sir.ReferenceID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ShopItemRights.ReferenceID. %s", err.Error())
 	}
 
-	err = sir.ItemType.ExtractFrom(readable)
-	if err != nil {
+	if err := sir.ItemType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ShopItemRights.ItemType. %s", err.Error())
 	}
 
-	err = sir.Attribute.ExtractFrom(readable)
-	if err != nil {
+	if err := sir.Attribute.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ShopItemRights.Attribute. %s", err.Error())
 	}
 

--- a/subscriber/types/subscriber_content.go
+++ b/subscriber/types/subscriber_content.go
@@ -39,40 +39,31 @@ func (sc SubscriberContent) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the SubscriberContent from the given readable
 func (sc *SubscriberContent) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sc.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sc.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriberContent header. %s", err.Error())
 	}
 
-	err = sc.ContentID.ExtractFrom(readable)
-	if err != nil {
+	if err := sc.ContentID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriberContent.ContentID. %s", err.Error())
 	}
 
-	err = sc.Message.ExtractFrom(readable)
-	if err != nil {
+	if err := sc.Message.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriberContent.Message. %s", err.Error())
 	}
 
-	err = sc.Binary.ExtractFrom(readable)
-	if err != nil {
+	if err := sc.Binary.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriberContent.Binary. %s", err.Error())
 	}
 
-	err = sc.PID.ExtractFrom(readable)
-	if err != nil {
+	if err := sc.PID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriberContent.PID. %s", err.Error())
 	}
 
-	err = sc.Topics.ExtractFrom(readable)
-	if err != nil {
+	if err := sc.Topics.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriberContent.Topics. %s", err.Error())
 	}
 
-	err = sc.PostTime.ExtractFrom(readable)
-	if err != nil {
+	if err := sc.PostTime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriberContent.PostTime. %s", err.Error())
 	}
 

--- a/subscriber/types/subscriber_get_content_param.go
+++ b/subscriber/types/subscriber_get_content_param.go
@@ -35,30 +35,23 @@ func (sgcp SubscriberGetContentParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the SubscriberGetContentParam from the given readable
 func (sgcp *SubscriberGetContentParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sgcp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sgcp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriberGetContentParam header. %s", err.Error())
 	}
 
-	err = sgcp.Topic.ExtractFrom(readable)
-	if err != nil {
+	if err := sgcp.Topic.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriberGetContentParam.Topic. %s", err.Error())
 	}
 
-	err = sgcp.Size.ExtractFrom(readable)
-	if err != nil {
+	if err := sgcp.Size.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriberGetContentParam.Size. %s", err.Error())
 	}
 
-	err = sgcp.Offset.ExtractFrom(readable)
-	if err != nil {
+	if err := sgcp.Offset.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriberGetContentParam.Offset. %s", err.Error())
 	}
 
-	err = sgcp.MinimumContentID.ExtractFrom(readable)
-	if err != nil {
+	if err := sgcp.MinimumContentID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriberGetContentParam.MinimumContentID. %s", err.Error())
 	}
 

--- a/subscriber/types/subscriber_post_content_param.go
+++ b/subscriber/types/subscriber_post_content_param.go
@@ -33,25 +33,19 @@ func (spcp SubscriberPostContentParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the SubscriberPostContentParam from the given readable
 func (spcp *SubscriberPostContentParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = spcp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := spcp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriberPostContentParam header. %s", err.Error())
 	}
 
-	err = spcp.Topic.ExtractFrom(readable)
-	if err != nil {
+	if err := spcp.Topic.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriberPostContentParam.Topic. %s", err.Error())
 	}
 
-	err = spcp.Message.ExtractFrom(readable)
-	if err != nil {
+	if err := spcp.Message.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriberPostContentParam.Message. %s", err.Error())
 	}
 
-	err = spcp.Binary.ExtractFrom(readable)
-	if err != nil {
+	if err := spcp.Binary.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriberPostContentParam.Binary. %s", err.Error())
 	}
 

--- a/subscriber/types/subscriber_user_status_info.go
+++ b/subscriber/types/subscriber_user_status_info.go
@@ -31,20 +31,15 @@ func (susi SubscriberUserStatusInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the SubscriberUserStatusInfo from the given readable
 func (susi *SubscriberUserStatusInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = susi.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := susi.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriberUserStatusInfo header. %s", err.Error())
 	}
 
-	err = susi.PID.ExtractFrom(readable)
-	if err != nil {
+	if err := susi.PID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriberUserStatusInfo.PID. %s", err.Error())
 	}
 
-	err = susi.Values.ExtractFrom(readable)
-	if err != nil {
+	if err := susi.Values.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriberUserStatusInfo.Values. %s", err.Error())
 	}
 

--- a/subscriber/types/subscriber_user_status_param.go
+++ b/subscriber/types/subscriber_user_status_param.go
@@ -29,15 +29,11 @@ func (u SubscriberUserStatusParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the SubscriberUserStatusParam from the given readable
 func (u *SubscriberUserStatusParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = u.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := u.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriberUserStatusParam header. %s", err.Error())
 	}
 
-	err = u.Value.ExtractFrom(readable)
-	if err != nil {
+	if err := u.Value.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriberUserStatusParam.Value. %s", err.Error())
 	}
 

--- a/subscription/types/active_player_subscription_data.go
+++ b/subscription/types/active_player_subscription_data.go
@@ -42,20 +42,15 @@ func (apsd ActivePlayerSubscriptionData) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ActivePlayerSubscriptionData from the given readable
 func (apsd *ActivePlayerSubscriptionData) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = apsd.SubscriptionData.ExtractFrom(readable)
-	if err != nil {
+	if err := apsd.SubscriptionData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ActivePlayerSubscriptionData.SubscriptionData. %s", err.Error())
 	}
 
-	err = apsd.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := apsd.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ActivePlayerSubscriptionData header. %s", err.Error())
 	}
 
-	err = apsd.Unknown.ExtractFrom(readable)
-	if err != nil {
+	if err := apsd.Unknown.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ActivePlayerSubscriptionData.Unknown. %s", err.Error())
 	}
 

--- a/subscription/types/subscription_data.go
+++ b/subscription/types/subscription_data.go
@@ -44,25 +44,19 @@ func (sd SubscriptionData) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the SubscriptionData from the given readable
 func (sd *SubscriptionData) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = sd.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := sd.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriptionData.Data. %s", err.Error())
 	}
 
-	err = sd.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := sd.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriptionData header. %s", err.Error())
 	}
 
-	err = sd.PrincipalID.ExtractFrom(readable)
-	if err != nil {
+	if err := sd.PrincipalID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriptionData.PrincipalID. %s", err.Error())
 	}
 
-	err = sd.Unknown.ExtractFrom(readable)
-	if err != nil {
+	if err := sd.Unknown.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract SubscriptionData.Unknown. %s", err.Error())
 	}
 

--- a/ticket-granting/types/authentication_info.go
+++ b/ticket-granting/types/authentication_info.go
@@ -59,36 +59,28 @@ func (ai *AuthenticationInfo) ExtractFrom(readable types.Readable) error {
 	stream := readable.(*nex.ByteStreamIn)
 	libraryVersion := stream.LibraryVersions.Main
 
-	var err error
-
-	err = ai.Data.ExtractFrom(readable)
-	if err != nil {
+	if err := ai.Data.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AuthenticationInfo.Data. %s", err.Error())
 	}
 
-	err = ai.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := ai.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AuthenticationInfo header. %s", err.Error())
 	}
 
-	err = ai.Token.ExtractFrom(readable)
-	if err != nil {
+	if err := ai.Token.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AuthenticationInfo.Token. %s", err.Error())
 	}
 
-	err = ai.NGSVersion.ExtractFrom(readable)
-	if err != nil {
+	if err := ai.NGSVersion.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract AuthenticationInfo.NGSVersion. %s", err.Error())
 	}
 
 	if libraryVersion.GreaterOrEqual("3.0.0") {
-		err = ai.TokenType.ExtractFrom(readable)
-		if err != nil {
+		if err := ai.TokenType.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract AuthenticationInfo.TokenType. %s", err.Error())
 		}
 
-		err = ai.ServerVersion.ExtractFrom(readable)
-		if err != nil {
+		if err := ai.ServerVersion.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract AuthenticationInfo.ServerVersion. %s", err.Error())
 		}
 	}

--- a/ticket-granting/types/nintendo_login_data.go
+++ b/ticket-granting/types/nintendo_login_data.go
@@ -39,15 +39,11 @@ func (nld NintendoLoginData) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the NintendoLoginData from the given readable
 func (nld *NintendoLoginData) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = nld.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := nld.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoLoginData header. %s", err.Error())
 	}
 
-	err = nld.Token.ExtractFrom(readable)
-	if err != nil {
+	if err := nld.Token.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract NintendoLoginData.Token. %s", err.Error())
 	}
 

--- a/ticket-granting/types/validate_and_request_ticket_param.go
+++ b/ticket-granting/types/validate_and_request_ticket_param.go
@@ -49,40 +49,31 @@ func (vartp ValidateAndRequestTicketParam) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ValidateAndRequestTicketParam from the given readable
 func (vartp *ValidateAndRequestTicketParam) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = vartp.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := vartp.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ValidateAndRequestTicketParam header. %s", err.Error())
 	}
 
-	err = vartp.PlatformType.ExtractFrom(readable)
-	if err != nil {
+	if err := vartp.PlatformType.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ValidateAndRequestTicketParam.PlatformType. %s", err.Error())
 	}
 
-	err = vartp.Username.ExtractFrom(readable)
-	if err != nil {
+	if err := vartp.Username.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ValidateAndRequestTicketParam.Username. %s", err.Error())
 	}
 
-	err = vartp.ExtraData.ExtractFrom(readable)
-	if err != nil {
+	if err := vartp.ExtraData.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ValidateAndRequestTicketParam.ExtraData. %s", err.Error())
 	}
 
-	err = vartp.IgnoreAPIVersionCheck.ExtractFrom(readable)
-	if err != nil {
+	if err := vartp.IgnoreAPIVersionCheck.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ValidateAndRequestTicketParam.IgnoreAPIVersionCheck. %s", err.Error())
 	}
 
-	err = vartp.APIVersionGeneral.ExtractFrom(readable)
-	if err != nil {
+	if err := vartp.APIVersionGeneral.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ValidateAndRequestTicketParam.APIVersionGeneral. %s", err.Error())
 	}
 
-	err = vartp.APIVersionCustom.ExtractFrom(readable)
-	if err != nil {
+	if err := vartp.APIVersionCustom.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ValidateAndRequestTicketParam.APIVersionCustom. %s", err.Error())
 	}
 
@@ -93,8 +84,7 @@ func (vartp *ValidateAndRequestTicketParam) ExtractFrom(readable types.Readable)
 	// * or not a game has crossplay at this stage, this is
 	// * the best we can do
 	if readable.Remaining() != 0 {
-		err = vartp.PlatformTypeForPlatformPID.ExtractFrom(readable)
-		if err != nil {
+		if err := vartp.PlatformTypeForPlatformPID.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract ValidateAndRequestTicketParam.PlatformTypeForPlatformPID. %s", err.Error())
 		}
 	}

--- a/ticket-granting/types/validate_and_request_ticket_result.go
+++ b/ticket-granting/types/validate_and_request_ticket_result.go
@@ -47,40 +47,31 @@ func (vartr ValidateAndRequestTicketResult) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the ValidateAndRequestTicketResult from the given readable
 func (vartr *ValidateAndRequestTicketResult) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = vartr.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := vartr.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ValidateAndRequestTicketResult header. %s", err.Error())
 	}
 
-	err = vartr.SourcePID.ExtractFrom(readable)
-	if err != nil {
+	if err := vartr.SourcePID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ValidateAndRequestTicketResult.PlatformType. %s", err.Error())
 	}
 
-	err = vartr.BufResponse.ExtractFrom(readable)
-	if err != nil {
+	if err := vartr.BufResponse.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ValidateAndRequestTicketResult.Username. %s", err.Error())
 	}
 
-	err = vartr.ServiceNodeURL.ExtractFrom(readable)
-	if err != nil {
+	if err := vartr.ServiceNodeURL.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ValidateAndRequestTicketResult.ExtraData. %s", err.Error())
 	}
 
-	err = vartr.CurrentUTCTime.ExtractFrom(readable)
-	if err != nil {
+	if err := vartr.CurrentUTCTime.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ValidateAndRequestTicketResult.IgnoreAPIVersionCheck. %s", err.Error())
 	}
 
-	err = vartr.ReturnMsg.ExtractFrom(readable)
-	if err != nil {
+	if err := vartr.ReturnMsg.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ValidateAndRequestTicketResult.APIVersionGeneral. %s", err.Error())
 	}
 
-	err = vartr.SourceKey.ExtractFrom(readable)
-	if err != nil {
+	if err := vartr.SourceKey.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract ValidateAndRequestTicketResult.APIVersionCustom. %s", err.Error())
 	}
 
@@ -91,8 +82,7 @@ func (vartr *ValidateAndRequestTicketResult) ExtractFrom(readable types.Readable
 	// * or not a game has crossplay at this stage, this is
 	// * the best we can do
 	if readable.Remaining() != 0 {
-		err = vartr.PlatformPID.ExtractFrom(readable)
-		if err != nil {
+		if err := vartr.PlatformPID.ExtractFrom(readable); err != nil {
 			return fmt.Errorf("Failed to extract ValidateAndRequestTicketResult.PlatformTypeForPlatformPID. %s", err.Error())
 		}
 	}

--- a/utility/types/unique_id_info.go
+++ b/utility/types/unique_id_info.go
@@ -31,20 +31,15 @@ func (uidi UniqueIDInfo) WriteTo(writable types.Writable) {
 
 // ExtractFrom extracts the UniqueIDInfo from the given readable
 func (uidi *UniqueIDInfo) ExtractFrom(readable types.Readable) error {
-	var err error
-
-	err = uidi.ExtractHeaderFrom(readable)
-	if err != nil {
+	if err := uidi.ExtractHeaderFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UniqueIDInfo header. %s", err.Error())
 	}
 
-	err = uidi.NEXUniqueID.ExtractFrom(readable)
-	if err != nil {
+	if err := uidi.NEXUniqueID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UniqueIDInfo.NEXUniqueID. %s", err.Error())
 	}
 
-	err = uidi.NEXUniqueIDPassword.ExtractFrom(readable)
-	if err != nil {
+	if err := uidi.NEXUniqueIDPassword.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract UniqueIDInfo.NEXUniqueIDPassword. %s", err.Error())
 	}
 


### PR DESCRIPTION
Resolves #XXX

### Changes:

- Moves to `if-ok` style syntax when decoding protocol class types

Only partially resolves https://github.com/PretendoNetwork/nex-protocols-go/issues/103, more work needs to be done later for the other tasks

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.