### PR TITLE
Update `DataStoreMetaInfo.FilterPropertiesByResultOption` to use `ResultFlag` correctly

### DIFF
--- a/datastore/types/datastore_meta_info.go
+++ b/datastore/types/datastore_meta_info.go
@@ -316,7 +316,7 @@ func (dsmi DataStoreMetaInfo) FormatToString(indentationLevel int) string {
 }
 
 // FilterPropertiesByResultOption zeroes out certain struct properties based on the input flags
-func (dsmi *DataStoreMetaInfo) FilterPropertiesByResultOption(resultOption types.UInt8) {
+func (dsmi *DataStoreMetaInfo) FilterPropertiesByResultOption(resultOption constants.ResultFlag) {
 	// * This is kind of backwards
 	// *
 	// * This method assumes all struct data exists
@@ -326,18 +326,23 @@ func (dsmi *DataStoreMetaInfo) FilterPropertiesByResultOption(resultOption types
 	// * flags being used to conditionally ADD properties,
 	// * it's used to conditionally REMOVE them
 
-	if resultOption&0x1 == 0 {
+	if resultOption&constants.ResultFlagTags == 0 {
 		dsmi.Tags = types.NewList[types.String]()
 
 	}
 
-	if resultOption&0x2 == 0 {
+	if resultOption&constants.ResultFlagRatings == 0 {
 		dsmi.Ratings = types.NewList[DataStoreRatingInfoWithSlot]()
 
 	}
 
-	if resultOption&0x4 == 0 {
+	if resultOption&constants.ResultFlagMetaBinary == 0 {
 		dsmi.MetaBinary = types.NewQBuffer(nil)
+	}
+
+	if resultOption&constants.ResultFlagPermittedIDs == 0 {
+		dsmi.Permission = NewDataStorePermission()
+		dsmi.DelPermission = NewDataStorePermission()
 	}
 }
 


### PR DESCRIPTION
Resolves #XXX

### Changes:

Title. I'm updating the common protocols to use the latest changes, and found this missed change. There may be other PRs like this too for other protocols

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.