### PR TITLE
Add String() method to all enums/flags types

### DIFF
--- a/datastore/constants/comparison_flag.go
+++ b/datastore/constants/comparison_flag.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // ComparisonFlag indicates the flags set on comparisonFlag of DataStoreChangeMetaCompareParam.
 // These flags tell the server what values to use when comparing
@@ -41,6 +45,42 @@ func (cf ComparisonFlag) HasFlags(flags ...ComparisonFlag) bool {
 	}
 
 	return true
+}
+
+// String returns a human-readable representation of the ComparisonFlag bitmask.
+// Multiple flags are joined with "|", e.g. "Name|Period|Tags".
+// Returns "None" if no flags are set, or "All" if all flags are set.
+func (cf ComparisonFlag) String() string {
+	if cf == ComparisonFlagNone {
+		return "None"
+	}
+	if cf == ComparisonFlagAll {
+		return "All"
+	}
+
+	flags := []struct {
+		flag ComparisonFlag
+		name string
+	}{
+		{ComparisonFlagName, "Name"},
+		{ComparisonFlagAccessPermission, "AccessPermission"},
+		{ComparisonFlagUpdatePermission, "UpdatePermission"},
+		{ComparisonFlagPeriod, "Period"},
+		{ComparisonFlagMetaBinary, "MetaBinary"},
+		{ComparisonFlagTags, "Tags"},
+		{ComparisonFlagDataType, "DataType"},
+		{ComparisonFlagReferredCount, "ReferredCount"},
+		{ComparisonFlagStatus, "Status"},
+	}
+
+	var parts []string
+	for _, f := range flags {
+		if cf&f.flag != 0 {
+			parts = append(parts, f.name)
+		}
+	}
+
+	return strings.Join(parts, "|")
 }
 
 const (

--- a/datastore/constants/data_flag.go
+++ b/datastore/constants/data_flag.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // DataFlag sets different configuration flags for uploaded objects.
 // Stored in the objects DataStoreMetaInfo.flag field
@@ -40,6 +44,37 @@ func (df DataFlag) HasFlags(flags ...DataFlag) bool {
 	}
 
 	return true
+}
+
+// String returns a human-readable representation of the DataFlag bitmask.
+// Multiple flags are joined with "|", e.g. "NeedReview|NeedCompletion".
+// Returns "None" if no flags are set.
+func (df DataFlag) String() string {
+	if df == DataFlagNone {
+		return "None"
+	}
+
+	flags := []struct {
+		flag DataFlag
+		name string
+	}{
+		{DataFlagNeedReview, "NeedReview"},
+		{DataFlagPeriodFromLastReferred, "PeriodFromLastReferred"},
+		{DataFlagUseReadLock, "UseReadLock"},
+		{DataFlagUseNotificationOnPost, "UseNotificationOnPost"},
+		{DataFlagUseNotificationOnUpdate, "UseNotificationOnUpdate"},
+		{DataFlagNotUseFileServer, "NotUseFileServer"},
+		{DataFlagNeedCompletion, "NeedCompletion"},
+	}
+
+	var parts []string
+	for _, f := range flags {
+		if df&f.flag != 0 {
+			parts = append(parts, f.name)
+		}
+	}
+
+	return strings.Join(parts, "|")
 }
 
 const (

--- a/datastore/constants/data_status.go
+++ b/datastore/constants/data_status.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // DataStatus indicates the availablity status of an object.
 // If an object has a status other than DataStatusNone, it is
@@ -22,6 +26,20 @@ func (ds *DataStatus) ExtractFrom(readable types.Readable) error {
 
 	*ds = DataStatus(value)
 	return nil
+}
+
+// String returns a human-readable representation of the DataStatus.
+func (ds DataStatus) String() string {
+	switch ds {
+	case DataStatusNone:
+		return "None"
+	case DataStatusPending:
+		return "Pending"
+	case DataStatusRejected:
+		return "Rejected"
+	default:
+		return fmt.Sprintf("DataStatus(%d)", int(ds))
+	}
 }
 
 const (

--- a/datastore/constants/modification_flag.go
+++ b/datastore/constants/modification_flag.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // ModificationFlag indicates what fields of an object have been modified
 type ModificationFlag uint16
@@ -39,6 +43,40 @@ func (mf ModificationFlag) HasFlags(flags ...ModificationFlag) bool {
 	}
 
 	return true
+}
+
+// String returns a human-readable representation of the ModificationFlag bitmask.
+// Multiple flags are joined with "|", e.g. "Name|Period|Tags".
+// Returns "None" if no flags are set.
+func (mf ModificationFlag) String() string {
+	if mf == ModificationFlagNone {
+		return "None"
+	}
+
+	flags := []struct {
+		flag ModificationFlag
+		name string
+	}{
+		{ModificationFlagName, "Name"},
+		{ModificationFlagAccessPermission, "AccessPermission"},
+		{ModificationFlagUpdatePermission, "UpdatePermission"},
+		{ModificationFlagPeriod, "Period"},
+		{ModificationFlagMetaBinary, "MetaBinary"},
+		{ModificationFlagTags, "Tags"},
+		{ModificationFlagUpdatedTime, "UpdatedTime"},
+		{ModificationFlagDataType, "DataType"},
+		{ModificationFlagReferredCount, "ReferredCount"},
+		{ModificationFlagStatus, "Status"},
+	}
+
+	var parts []string
+	for _, f := range flags {
+		if mf&f.flag != 0 {
+			parts = append(parts, f.name)
+		}
+	}
+
+	return strings.Join(parts, "|")
 }
 
 const (

--- a/datastore/constants/permission.go
+++ b/datastore/constants/permission.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // Permission defines what users can perform access and update
 // operations for an object. Access and update operations are
@@ -21,6 +25,24 @@ func (p *Permission) ExtractFrom(readable types.Readable) error {
 
 	*p = Permission(value)
 	return nil
+}
+
+// String returns a human-readable representation of the Permission.
+func (p Permission) String() string {
+	switch p {
+	case PermissionPublic:
+		return "Public"
+	case PermissionFriend:
+		return "Friend"
+	case PermissionSpecified:
+		return "Specified"
+	case PermissionPrivate:
+		return "Private"
+	case PermissionSpecifiedFriend:
+		return "SpecifiedFriend"
+	default:
+		return fmt.Sprintf("Permission(%d)", int(p))
+	}
 }
 
 const (

--- a/datastore/constants/rating_flag.go
+++ b/datastore/constants/rating_flag.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // RatingFlag indicates how the server should handle
 // user ratings for object rating slots
@@ -40,6 +44,33 @@ func (rf RatingFlag) HasFlags(flags ...RatingFlag) bool {
 	}
 
 	return true
+}
+
+// String returns a human-readable representation of the RatingFlag bitmask.
+// Multiple flags are joined with "|", e.g. "Modifiable|DisableSelfRating".
+// Returns "None" if no flags are set.
+func (rf RatingFlag) String() string {
+	if rf == 0 {
+		return "None"
+	}
+
+	flags := []struct {
+		flag RatingFlag
+		name string
+	}{
+		{RatingFlagModifiable, "Modifiable"},
+		{RatingFlagRoundMinus, "RoundMinus"},
+		{RatingFlagDisableSelfRating, "DisableSelfRating"},
+	}
+
+	var parts []string
+	for _, f := range flags {
+		if rf&f.flag != 0 {
+			parts = append(parts, f.name)
+		}
+	}
+
+	return strings.Join(parts, "|")
 }
 
 const (

--- a/datastore/constants/rating_internal_flag.go
+++ b/datastore/constants/rating_internal_flag.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // RatingInternalFlag indicates whether or not a minimum or
 // maximum rating value should be set
@@ -40,6 +44,32 @@ func (rif RatingInternalFlag) HasFlags(flags ...RatingInternalFlag) bool {
 	}
 
 	return true
+}
+
+// String returns a human-readable representation of the RatingInternalFlag bitmask.
+// Multiple flags are joined with "|", e.g. "UseRangeMin|UseRangeMax".
+// Returns "None" if no flags are set.
+func (rif RatingInternalFlag) String() string {
+	if rif == 0 {
+		return "None"
+	}
+
+	flags := []struct {
+		flag RatingInternalFlag
+		name string
+	}{
+		{RatingInternalFlagUseRangeMin, "UseRangeMin"},
+		{RatingInternalFlagUseRangeMax, "UseRangeMax"},
+	}
+
+	var parts []string
+	for _, f := range flags {
+		if rif&f.flag != 0 {
+			parts = append(parts, f.name)
+		}
+	}
+
+	return strings.Join(parts, "|")
 }
 
 const (

--- a/datastore/constants/rating_lock_period.go
+++ b/datastore/constants/rating_lock_period.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // RatingLockPeriodDay tells the rating slot locks what day
 // the lock should expire.
@@ -25,6 +29,30 @@ func (rlpd *RatingLockPeriodDay) ExtractFrom(readable types.Readable) error {
 
 	*rlpd = RatingLockPeriodDay(value)
 	return nil
+}
+
+// String returns a human-readable representation of the RatingLockPeriodDay.
+func (rlpd RatingLockPeriodDay) String() string {
+	switch rlpd {
+	case RatingLockPeriodDay1:
+		return "Day1"
+	case RatingLockPeriodSun:
+		return "Sun"
+	case RatingLockPeriodSat:
+		return "Sat"
+	case RatingLockPeriodFri:
+		return "Fri"
+	case RatingLockPeriodThu:
+		return "Thu"
+	case RatingLockPeriodWed:
+		return "Wed"
+	case RatingLockPeriodTue:
+		return "Tue"
+	case RatingLockPeriodMon:
+		return "Mon"
+	default:
+		return fmt.Sprintf("RatingLockPeriodDay(%d)", int(rlpd))
+	}
 }
 
 const (

--- a/datastore/constants/rating_lock_type.go
+++ b/datastore/constants/rating_lock_type.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // RatingLockType indicates the type of lock applied to object ratings.
 // Locks are applied per-user, not per-object. If a user tries to rate
@@ -21,6 +25,22 @@ func (rlt *RatingLockType) ExtractFrom(readable types.Readable) error {
 
 	*rlt = RatingLockType(value)
 	return nil
+}
+
+// String returns a human-readable representation of the RatingLockType.
+func (rlt RatingLockType) String() string {
+	switch rlt {
+	case RatingLockNone:
+		return "None"
+	case RatingLockInterval:
+		return "Interval"
+	case RatingLockPeriod:
+		return "Period"
+	case RatingLockPermanent:
+		return "Permanent"
+	default:
+		return fmt.Sprintf("RatingLockType(%d)", int(rlt))
+	}
 }
 
 const (

--- a/datastore/constants/result_flag.go
+++ b/datastore/constants/result_flag.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // ResultFlag tells the server what fields to populate in responses
 // to object searches
@@ -40,6 +44,34 @@ func (rf ResultFlag) HasFlags(flags ...ResultFlag) bool {
 	}
 
 	return true
+}
+
+// String returns a human-readable representation of the ResultFlag bitmask.
+// Multiple flags are joined with "|", e.g. "Tags|Ratings|MetaBinary".
+// Returns "None" if no flags are set.
+func (rf ResultFlag) String() string {
+	if rf == 0 {
+		return "None"
+	}
+
+	flags := []struct {
+		flag ResultFlag
+		name string
+	}{
+		{ResultFlagTags, "Tags"},
+		{ResultFlagRatings, "Ratings"},
+		{ResultFlagMetaBinary, "MetaBinary"},
+		{ResultFlagPermittedIDs, "PermittedIDs"},
+	}
+
+	var parts []string
+	for _, f := range flags {
+		if rf&f.flag != 0 {
+			parts = append(parts, f.name)
+		}
+	}
+
+	return strings.Join(parts, "|")
 }
 
 const (

--- a/datastore/constants/search_result_total_count_type.go
+++ b/datastore/constants/search_result_total_count_type.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // SearchResultTotalCountType indicates how the client should interpret the
 // DataStoreSearchResult.totalCount value when counting search results
@@ -20,6 +24,22 @@ func (srtct *SearchResultTotalCountType) ExtractFrom(readable types.Readable) er
 
 	*srtct = SearchResultTotalCountType(value)
 	return nil
+}
+
+// String returns a human-readable representation of the SearchResultTotalCountType.
+func (srct SearchResultTotalCountType) String() string {
+	switch srct {
+	case SearchResultTotalExact:
+		return "Exact"
+	case SearchResultTotalMinimum:
+		return "Minimum"
+	case SearchResultTotalEstimate:
+		return "Estimate"
+	case SearchResultTotalDisabled:
+		return "Disabled"
+	default:
+		return fmt.Sprintf("SearchResultTotalCountType(%d)", int(srct))
+	}
 }
 
 const (

--- a/datastore/constants/search_sort_column.go
+++ b/datastore/constants/search_sort_column.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // SearchSortColumn tells the server which database column to use as the input
 // for the ordering of returned object searches
@@ -20,6 +24,92 @@ func (ssc *SearchSortColumn) ExtractFrom(readable types.Readable) error {
 
 	*ssc = SearchSortColumn(value)
 	return nil
+}
+
+// String returns a human-readable representation of the SearchSortColumn.
+func (ssc SearchSortColumn) String() string {
+	switch ssc {
+	case SearchSortColumnDataID:
+		return "DataID"
+	case SearchSortColumnSize:
+		return "Size"
+	case SearchSortColumnNameAlphabetical:
+		return "NameAlphabetical"
+	case SearchSortColumnDataType:
+		return "DataType"
+	case SearchSortColumnReferredCount:
+		return "ReferredCount"
+	case SearchSortColumnCreatedTime:
+		return "CreatedTime"
+	case SearchSortColumnUpdatedTime:
+		return "UpdatedTime"
+	case SearchSortColumnRating0:
+		return "Rating0"
+	case SearchSortColumnRating1:
+		return "Rating1"
+	case SearchSortColumnRating2:
+		return "Rating2"
+	case SearchSortColumnRating3:
+		return "Rating3"
+	case SearchSortColumnRating4:
+		return "Rating4"
+	case SearchSortColumnRating5:
+		return "Rating5"
+	case SearchSortColumnRating6:
+		return "Rating6"
+	case SearchSortColumnRating7:
+		return "Rating7"
+	case SearchSortColumnRating8:
+		return "Rating8"
+	case SearchSortColumnRating9:
+		return "Rating9"
+	case SearchSortColumnRating10:
+		return "Rating10"
+	case SearchSortColumnRating11:
+		return "Rating11"
+	case SearchSortColumnRating12:
+		return "Rating12"
+	case SearchSortColumnRating13:
+		return "Rating13"
+	case SearchSortColumnRating14:
+		return "Rating14"
+	case SearchSortColumnRating15:
+		return "Rating15"
+	case SearchSortColumnRatingAverage0:
+		return "RatingAverage0"
+	case SearchSortColumnRatingAverage1:
+		return "RatingAverage1"
+	case SearchSortColumnRatingAverage2:
+		return "RatingAverage2"
+	case SearchSortColumnRatingAverage3:
+		return "RatingAverage3"
+	case SearchSortColumnRatingAverage4:
+		return "RatingAverage4"
+	case SearchSortColumnRatingAverage5:
+		return "RatingAverage5"
+	case SearchSortColumnRatingAverage6:
+		return "RatingAverage6"
+	case SearchSortColumnRatingAverage7:
+		return "RatingAverage7"
+	case SearchSortColumnRatingAverage8:
+		return "RatingAverage8"
+	case SearchSortColumnRatingAverage9:
+		return "RatingAverage9"
+	case SearchSortColumnRatingAverage10:
+		return "RatingAverage10"
+	case SearchSortColumnRatingAverage11:
+		return "RatingAverage11"
+	case SearchSortColumnRatingAverage12:
+		return "RatingAverage12"
+	case SearchSortColumnRatingAverage13:
+		return "RatingAverage13"
+	case SearchSortColumnRatingAverage14:
+		return "RatingAverage14"
+	case SearchSortColumnRatingAverage15:
+		return "RatingAverage15"
+	default:
+		return fmt.Sprintf("SearchSortColumn(%d)", int(ssc))
+	}
 }
 
 const (

--- a/datastore/constants/search_sort_order.go
+++ b/datastore/constants/search_sort_order.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // SearchSortOrder tells the server in what direction to order search results
 type SearchSortOrder uint8
@@ -19,6 +23,18 @@ func (sso *SearchSortOrder) ExtractFrom(readable types.Readable) error {
 
 	*sso = SearchSortOrder(value)
 	return nil
+}
+
+// String returns a human-readable representation of the SearchSortOrder.
+func (sso SearchSortOrder) String() string {
+	switch sso {
+	case SearchSortOrderAsc:
+		return "Asc"
+	case SearchSortOrderDesc:
+		return "Desc"
+	default:
+		return fmt.Sprintf("SearchSortOrder(%d)", int(sso))
+	}
 }
 
 const (

--- a/datastore/constants/search_target.go
+++ b/datastore/constants/search_target.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // SearchTarget represents the type of user who owns an object.
 // Not to be confused with DataStoreSearchParam.searchTarget,
@@ -24,6 +28,20 @@ func (st *SearchTarget) ExtractFrom(readable types.Readable) error {
 	return nil
 }
 
+// String returns a human-readable representation of the SearchTarget.
+func (st SearchTarget) String() string {
+	switch st {
+	case SearchTargetAnybody:
+		return "Anybody"
+	case SearchTargetFriend:
+		return "Friend"
+	case SearchTargetAnybodyExcludeSpecified:
+		return "AnybodyExcludeSpecified"
+	default:
+		return fmt.Sprintf("SearchTarget(%d)", int(st))
+	}
+}
+
 const (
 	// SearchTargetAnybody selects objects owned by anyone
 	SearchTargetAnybody SearchTarget = iota
@@ -32,6 +50,6 @@ const (
 	SearchTargetFriend
 
 	// SearchTargetAnybodyExcludeSpecified selects objects owned by anyone
-	// EXCEPT those set in DataStoreSearchParam.ownerIds
+	// EXCEPT those specified in the search paramaters
 	SearchTargetAnybodyExcludeSpecified
 )

--- a/datastore/constants/search_type.go
+++ b/datastore/constants/search_type.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // SearchType represents the type of user who can access an object.
 // This is stored in DataStoreSearchParam.searchTarget.
@@ -21,6 +25,42 @@ func (st *SearchType) ExtractFrom(readable types.Readable) error {
 
 	*st = SearchType(value)
 	return nil
+}
+
+// String returns a human-readable representation of the SearchType.
+func (st SearchType) String() string {
+	switch st {
+	case SearchTypePublic:
+		return "Public"
+	case SearchTypeSendFriend:
+		return "SendFriend"
+	case SearchTypeSendSpecified:
+		return "SendSpecified"
+	case SearchTypeSendSpecifiedFriend:
+		return "SendSpecifiedFriend"
+	case SearchTypeSend:
+		return "Send"
+	case SearchTypeFriend:
+		return "Friend"
+	case SearchTypeReceivedSpecified:
+		return "ReceivedSpecified"
+	case SearchTypeReceived:
+		return "Received"
+	case SearchTypePrivate:
+		return "Private"
+	case SearchTypeOwn:
+		return "Own"
+	case SearchTypePublicExcludeOwnAndFriends:
+		return "PublicExcludeOwnAndFriends"
+	case SearchTypeOwnPending:
+		return "OwnPending"
+	case SearchTypeOwnRejected:
+		return "OwnRejected"
+	case SearchTypeOwnAll:
+		return "OwnAll"
+	default:
+		return fmt.Sprintf("SearchType(%d)", int(st))
+	}
 }
 
 const (

--- a/datastore/types/datastore_rating_init_param.go
+++ b/datastore/types/datastore_rating_init_param.go
@@ -177,7 +177,11 @@ func (dsrip DataStoreRatingInitParam) FormatToString(indentationLevel int) strin
 	b.WriteString(fmt.Sprintf("%sRangeMin: %s,\n", indentationValues, dsrip.RangeMin))
 	b.WriteString(fmt.Sprintf("%sRangeMax: %s,\n", indentationValues, dsrip.RangeMax))
 	b.WriteString(fmt.Sprintf("%sPeriodHour: %s,\n", indentationValues, dsrip.PeriodHour))
-	b.WriteString(fmt.Sprintf("%sPeriodDuration: %s,\n", indentationValues, dsrip.PeriodDuration))
+	if dsrip.LockType == constants.RatingLockPeriod {
+		b.WriteString(fmt.Sprintf("%sPeriodDuration: %s\n", indentationValues, dsrip.PeriodDuration))
+	} else {
+		b.WriteString(fmt.Sprintf("%sPeriodDuration: %s\n", indentationValues, types.Int16(dsrip.PeriodDuration)))
+	}
 	b.WriteString(fmt.Sprintf("%s}", indentationEnd))
 
 	return b.String()

--- a/friends-3ds/constants/mii_character_set.go
+++ b/friends-3ds/constants/mii_character_set.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // MiiCharacterSet defines the character set (font/language) used by a Mii
 type MiiCharacterSet uint8
@@ -19,6 +23,22 @@ func (mcs *MiiCharacterSet) ExtractFrom(readable types.Readable) error {
 
 	*mcs = MiiCharacterSet(value)
 	return nil
+}
+
+// String returns a human-readable representation of the MiiCharacterSet.
+func (mcs MiiCharacterSet) String() string {
+	switch mcs {
+	case MiiCharacterSetJUE:
+		return "JUE"
+	case MiiCharacterSetCHN:
+		return "CHN"
+	case MiiCharacterSetKOR:
+		return "KOR"
+	case MiiCharacterSetTWN:
+		return "TWN"
+	default:
+		return fmt.Sprintf("MiiCharacterSet(%d)", int(mcs))
+	}
 }
 
 const (

--- a/friends-3ds/constants/presence_changed_flag.go
+++ b/friends-3ds/constants/presence_changed_flag.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // PresenceChangedFlag indicates what fields of a users NintendoPresenceV2 have been changed
 type PresenceChangedFlag uint32
@@ -39,6 +43,39 @@ func (pcf PresenceChangedFlag) HasFlags(flags ...PresenceChangedFlag) bool {
 	}
 
 	return true
+}
+
+// String returns a human-readable representation of the PresenceChangedFlag bitmask.
+// Multiple flags are joined with "|", e.g. "GameKey|GatheringID".
+// Returns "None" if no flags are set.
+func (pcf PresenceChangedFlag) String() string {
+	if pcf == PresenceChangedFlagNone {
+		return "None"
+	}
+
+	flags := []struct {
+		flag PresenceChangedFlag
+		name string
+	}{
+		{PresenceChangedFlagGameKey, "GameKey"},
+		{PresenceChangedFlagGameModeDescription, "GameModeDescription"},
+		{PresenceChangedFlagJoinAvailabilityFlag, "JoinAvailabilityFlag"},
+		{PresenceChangedFlagMatchmakeSystemType, "MatchmakeSystemType"},
+		{PresenceChangedFlagJoinGameID, "JoinGameID"},
+		{PresenceChangedFlagJoinGameMode, "JoinGameMode"},
+		{PresenceChangedFlagOwnerPID, "OwnerPID"},
+		{PresenceChangedFlagGatheringID, "GatheringID"},
+		{PresenceChangedFlagApplicationData, "ApplicationData"},
+	}
+
+	var parts []string
+	for _, f := range flags {
+		if pcf&f.flag != 0 {
+			parts = append(parts, f.name)
+		}
+	}
+
+	return strings.Join(parts, "|")
 }
 
 const (

--- a/friends-3ds/constants/relationship_type.go
+++ b/friends-3ds/constants/relationship_type.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // RelationshipType defines the status of a 3DS friend relationship
 type RelationshipType uint8
@@ -19,6 +23,20 @@ func (rt *RelationshipType) ExtractFrom(readable types.Readable) error {
 
 	*rt = RelationshipType(value)
 	return nil
+}
+
+// String returns a human-readable representation of the RelationshipType.
+func (rt RelationshipType) String() string {
+	switch rt {
+	case RelationshipTypeIncomplete:
+		return "Incomplete"
+	case RelationshipTypeComplete:
+		return "Complete"
+	case RelationshipTypeInvalid:
+		return "Invalid"
+	default:
+		return fmt.Sprintf("RelationshipType(%d)", int(rt))
+	}
 }
 
 const (

--- a/friends-wiiu/constants/presence_changed_flag.go
+++ b/friends-wiiu/constants/presence_changed_flag.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // PresenceChangedFlag indicates what fields of a users NintendoPresenceV2 have been changed
 type PresenceChangedFlag uint32
@@ -39,6 +43,39 @@ func (pcf PresenceChangedFlag) HasFlags(flags ...PresenceChangedFlag) bool {
 	}
 
 	return true
+}
+
+// String returns a human-readable representation of the PresenceChangedFlag bitmask.
+// Multiple flags are joined with "|", e.g. "GameKey|GatheringID".
+// Returns "None" if no flags are set.
+func (pcf PresenceChangedFlag) String() string {
+	if pcf == PresenceChangedFlagNone {
+		return "None"
+	}
+
+	flags := []struct {
+		flag PresenceChangedFlag
+		name string
+	}{
+		{PresenceChangedFlagGameKey, "GameKey"},
+		{PresenceChangedFlagGameModeDescription, "GameModeDescription"},
+		{PresenceChangedFlagJoinAvailabilityFlag, "JoinAvailabilityFlag"},
+		{PresenceChangedFlagMatchmakeSystemType, "MatchmakeSystemType"},
+		{PresenceChangedFlagGameServerID, "GameServerID"},
+		{PresenceChangedFlagJoinGameMode, "JoinGameMode"},
+		{PresenceChangedFlagOwnerPID, "OwnerPID"},
+		{PresenceChangedFlagGatheringID, "GatheringID"},
+		{PresenceChangedFlagApplicationData, "ApplicationData"},
+	}
+
+	var parts []string
+	for _, f := range flags {
+		if pcf&f.flag != 0 {
+			parts = append(parts, f.name)
+		}
+	}
+
+	return strings.Join(parts, "|")
 }
 
 const (

--- a/match-making/constants/auto_matchmake_option.go
+++ b/match-making/constants/auto_matchmake_option.go
@@ -1,6 +1,8 @@
 package constants
 
 import (
+	"fmt"
+
 	"github.com/PretendoNetwork/nex-go/v2/types"
 )
 
@@ -21,6 +23,20 @@ func (amo *AutoMatchmakeOption) ExtractFrom(readable types.Readable) error {
 
 	*amo = AutoMatchmakeOption(value)
 	return nil
+}
+
+// String returns a human-readable representation of the AutoMatchmakeOption.
+func (amo AutoMatchmakeOption) String() string {
+	switch amo {
+	case AutoMatchmakeOptionNone:
+		return "None"
+	case AutoMatchmakeOptionRecordLastGIDForParticipationCheck:
+		return "RecordLastGIDForParticipationCheck"
+	case AutoMatchmakeOptionUniqueGatheringByCodeword:
+		return "UniqueGatheringByCodeword"
+	default:
+		return fmt.Sprintf("AutoMatchmakeOption(%d)", int(amo))
+	}
 }
 
 const (

--- a/match-making/constants/find_matchmake_session_result_option.go
+++ b/match-making/constants/find_matchmake_session_result_option.go
@@ -1,43 +1,73 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // FindMatchmakeSessionResultOption indicates how to populate the
 // responses from FindMatchmakeSessionByParticipant
 type FindMatchmakeSessionResultOption uint32
 
 // WriteTo writes the FindMatchmakeSessionResultOption to the given writable
-func (fmsr FindMatchmakeSessionResultOption) WriteTo(writable types.Writable) {
-	writable.WriteUInt32LE(uint32(fmsr))
+func (fmsro FindMatchmakeSessionResultOption) WriteTo(writable types.Writable) {
+	writable.WriteUInt32LE(uint32(fmsro))
 }
 
 // ExtractFrom extracts the FindMatchmakeSessionResultOption value from the given readable
-func (fmsr *FindMatchmakeSessionResultOption) ExtractFrom(readable types.Readable) error {
+func (fmsro *FindMatchmakeSessionResultOption) ExtractFrom(readable types.Readable) error {
 	value, err := readable.ReadUInt32LE()
 	if err != nil {
 		return err
 	}
 
-	*fmsr = FindMatchmakeSessionResultOption(value)
+	*fmsro = FindMatchmakeSessionResultOption(value)
 	return nil
 }
 
-func (fmsr FindMatchmakeSessionResultOption) HasFlag(flag FindMatchmakeSessionResultOption) bool {
-	return fmsr&flag == flag
+func (fmsro FindMatchmakeSessionResultOption) HasFlag(flag FindMatchmakeSessionResultOption) bool {
+	return fmsro&flag == flag
 }
 
-func (fmsr FindMatchmakeSessionResultOption) HasFlags(flags ...FindMatchmakeSessionResultOption) bool {
+func (fmsro FindMatchmakeSessionResultOption) HasFlags(flags ...FindMatchmakeSessionResultOption) bool {
 	if len(flags) == 0 {
 		return false
 	}
 
 	for _, flag := range flags {
-		if fmsr&flag != flag {
+		if fmsro&flag != flag {
 			return false
 		}
 	}
 
 	return true
+}
+
+// String returns a human-readable representation of the FindMatchmakeSessionResultOption bitmask.
+// Multiple flags are joined with "|", e.g. "ApplicationBuffer|MatchmakeParam".
+// Returns "None" if no flags are set.
+func (fmsro FindMatchmakeSessionResultOption) String() string {
+	if fmsro == FindMatchmakeSessionResultOptionNone {
+		return "None"
+	}
+
+	flags := []struct {
+		flag FindMatchmakeSessionResultOption
+		name string
+	}{
+		{FindMatchmakeSessionResultOptionApplicationBuffer, "ApplicationBuffer"},
+		{FindMatchmakeSessionResultOptionMatchmakeParam, "MatchmakeParam"},
+	}
+
+	var parts []string
+	for _, f := range flags {
+		if fmsro&f.flag != 0 {
+			parts = append(parts, f.name)
+		}
+	}
+
+	return strings.Join(parts, "|")
 }
 
 const (

--- a/match-making/constants/gathering_flags.go
+++ b/match-making/constants/gathering_flags.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // GatheringFlags indicates the flags set on a gathering
 type GatheringFlags uint16
@@ -37,6 +41,37 @@ func (gf GatheringFlags) HasFlags(flags ...GatheringFlags) bool {
 	}
 
 	return true
+}
+
+// String returns a human-readable representation of the GatheringFlags bitmask.
+// Multiple flags are joined with "|", e.g. "PersistentGathering|MigrateOwner".
+// Returns "None" if no flags are set.
+func (gf GatheringFlags) String() string {
+	if gf == GatheringFlagNone {
+		return "None"
+	}
+
+	flags := []struct {
+		flag GatheringFlags
+		name string
+	}{
+		{GatheringFlagPersistentGathering, "PersistentGathering"},
+		{GatheringFlagMigrateOwner, "MigrateOwner"},
+		{GatheringFlagNoPersistentParticipation, "NoPersistentParticipation"},
+		{GatheringFlagAllowNoParticipant, "AllowNoParticipant"},
+		{GatheringFlagChangeOwnerByOtherHost, "ChangeOwnerByOtherHost"},
+		{GatheringFlagNotifyParticipationEventsToAllParticipants, "NotifyParticipationEventsToAllParticipants"},
+		{GatheringFlagNotifyParticipationEventsToAllParticipantsReproducibly, "NotifyParticipationEventsToAllParticipantsReproducibly"},
+	}
+
+	var parts []string
+	for _, f := range flags {
+		if gf&f.flag != 0 {
+			parts = append(parts, f.name)
+		}
+	}
+
+	return strings.Join(parts, "|")
 }
 
 const (

--- a/match-making/constants/gathering_state.go
+++ b/match-making/constants/gathering_state.go
@@ -1,6 +1,8 @@
 package constants
 
 import (
+	"fmt"
+
 	"github.com/PretendoNetwork/nex-go/v2/types"
 )
 
@@ -26,6 +28,20 @@ func (gs *GatheringState) ExtractFrom(readable types.Readable) error {
 
 	*gs = GatheringState(value)
 	return nil
+}
+
+// String returns a human-readable representation of the GatheringState.
+func (gs GatheringState) String() string {
+	switch gs {
+	case GatheringStateLocked:
+		return "Locked"
+	case GatheringStateStarted:
+		return "Started"
+	case GatheringStateFinished:
+		return "Finished"
+	default:
+		return fmt.Sprintf("GatheringState(%d)", int(gs))
+	}
 }
 
 const (

--- a/match-making/constants/join_matchmake_session_behavior.go
+++ b/match-making/constants/join_matchmake_session_behavior.go
@@ -1,6 +1,8 @@
 package constants
 
 import (
+	"fmt"
+
 	"github.com/PretendoNetwork/nex-go/v2/types"
 )
 
@@ -21,6 +23,18 @@ func (jmsb *JoinMatchmakeSessionBehavior) ExtractFrom(readable types.Readable) e
 
 	*jmsb = JoinMatchmakeSessionBehavior(value)
 	return nil
+}
+
+// String returns a human-readable representation of the JoinMatchmakeSessionBehavior.
+func (jmsb JoinMatchmakeSessionBehavior) String() string {
+	switch jmsb {
+	case JoinMatchmakeSessionBehaviorJoinMyself:
+		return "JoinMyself"
+	case JoinMatchmakeSessionBehaviorImAlreadyJoined:
+		return "ImAlreadyJoined"
+	default:
+		return fmt.Sprintf("JoinMatchmakeSessionBehavior(%d)", int(jmsb))
+	}
 }
 
 const (

--- a/match-making/constants/matchmake_geo_ip_result.go
+++ b/match-making/constants/matchmake_geo_ip_result.go
@@ -1,6 +1,8 @@
 package constants
 
 import (
+	"fmt"
+
 	"github.com/PretendoNetwork/nex-go/v2/types"
 )
 
@@ -8,19 +10,35 @@ import (
 type MatchmakeGeoIPResult uint32
 
 // WriteTo writes the MatchmakeGeoIPResult to the given writable
-func (mgipr MatchmakeGeoIPResult) WriteTo(writable types.Writable) {
-	writable.WriteUInt32LE(uint32(mgipr))
+func (mgir MatchmakeGeoIPResult) WriteTo(writable types.Writable) {
+	writable.WriteUInt32LE(uint32(mgir))
 }
 
 // ExtractFrom extracts the MatchmakeGeoIPResult value from the given readable
-func (mgipr *MatchmakeGeoIPResult) ExtractFrom(readable types.Readable) error {
+func (mgir *MatchmakeGeoIPResult) ExtractFrom(readable types.Readable) error {
 	value, err := readable.ReadUInt32LE()
 	if err != nil {
 		return err
 	}
 
-	*mgipr = MatchmakeGeoIPResult(value)
+	*mgir = MatchmakeGeoIPResult(value)
 	return nil
+}
+
+// String returns a human-readable representation of the MatchmakeGeoIPResult.
+func (mgir MatchmakeGeoIPResult) String() string {
+	switch mgir {
+	case MatchmakeGeoIPResultInvalid:
+		return "Invalid"
+	case MatchmakeGeoIPResultFound:
+		return "Found"
+	case MatchmakeGeoIPResultNotFound:
+		return "NotFound"
+	case MatchmakeGeoIPResultUnused:
+		return "Unused"
+	default:
+		return fmt.Sprintf("MatchmakeGeoIPResult(%d)", int(mgir))
+	}
 }
 
 const (

--- a/match-making/constants/matchmake_option.go
+++ b/match-making/constants/matchmake_option.go
@@ -1,6 +1,8 @@
 package constants
 
 import (
+	"fmt"
+
 	"github.com/PretendoNetwork/nex-go/v2/types"
 )
 
@@ -21,6 +23,20 @@ func (mo *MatchmakeOption) ExtractFrom(readable types.Readable) error {
 
 	*mo = MatchmakeOption(value)
 	return nil
+}
+
+// String returns a human-readable representation of the MatchmakeOption.
+func (mo MatchmakeOption) String() string {
+	switch mo {
+	case MatchmakeOptionNone:
+		return "None"
+	case MatchmakeOptionRecordLastGIDForParticipationCheck:
+		return "RecordLastGIDForParticipationCheck"
+	case MatchmakeOptionReserved1:
+		return "Reserved1"
+	default:
+		return fmt.Sprintf("MatchmakeOption(%d)", int(mo))
+	}
 }
 
 const (

--- a/match-making/constants/matchmake_selection_method.go
+++ b/match-making/constants/matchmake_selection_method.go
@@ -1,6 +1,8 @@
 package constants
 
 import (
+	"fmt"
+
 	"github.com/PretendoNetwork/nex-go/v2/types"
 )
 
@@ -21,6 +23,26 @@ func (msm *MatchmakeSelectionMethod) ExtractFrom(readable types.Readable) error 
 
 	*msm = MatchmakeSelectionMethod(value)
 	return nil
+}
+
+// String returns a human-readable representation of the MatchmakeSelectionMethod.
+func (msm MatchmakeSelectionMethod) String() string {
+	switch msm {
+	case MatchmakeSelectionMethodRandom:
+		return "Random"
+	case MatchmakeSelectionMethodNearestNeighbor:
+		return "NearestNeighbor"
+	case MatchmakeSelectionMethodBroadenRange:
+		return "BroadenRange"
+	case MatchmakeSelectionMethodProgressScore:
+		return "ProgressScore"
+	case MatchmakeSelectionMethodBroadenRangeWithProgressScore:
+		return "BroadenRangeWithProgressScore"
+	case MatchmakeSelectionMethodScoreBased:
+		return "ScoreBased"
+	default:
+		return fmt.Sprintf("MatchmakeSelectionMethod(%d)", int(msm))
+	}
 }
 
 const (

--- a/match-making/constants/matchmake_session_modification_flag.go
+++ b/match-making/constants/matchmake_session_modification_flag.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // MatchmakeSessionModificationFlag indicates the flags set on a gathering
 type MatchmakeSessionModificationFlag uint32
@@ -37,6 +41,45 @@ func (msmf MatchmakeSessionModificationFlag) HasFlags(flags ...MatchmakeSessionM
 	}
 
 	return true
+}
+
+// String returns a human-readable representation of the MatchmakeSessionModificationFlag bitmask.
+// Multiple flags are joined with "|", e.g. "Attributes|ApplicationBuffer|GameMode".
+// Returns "None" if no flags are set.
+func (msmf MatchmakeSessionModificationFlag) String() string {
+	if msmf == MatchmakeSessionModificationFlagNone {
+		return "None"
+	}
+
+	flags := []struct {
+		flag MatchmakeSessionModificationFlag
+		name string
+	}{
+		{MatchmakeSessionModificationFlagAttributes, "Attributes"},
+		{MatchmakeSessionModificationFlagOpenParticipation, "OpenParticipation"},
+		{MatchmakeSessionModificationFlagApplicationBuffer, "ApplicationBuffer"},
+		{MatchmakeSessionModificationFlagProgressScore, "ProgressScore"},
+		{MatchmakeSessionModificationFlagOption0, "Option0"},
+		{MatchmakeSessionModificationFlagMatchmakeParam, "MatchmakeParam"},
+		{MatchmakeSessionModificationFlagMatchmakeParamOverride, "MatchmakeParamOverride"},
+		{MatchmakeSessionModificationFlagStartedTime, "StartedTime"},
+		{MatchmakeSessionModificationFlagUserPassword, "UserPassword"},
+		{MatchmakeSessionModificationFlagGameMode, "GameMode"},
+		{MatchmakeSessionModificationFlagDescription, "Description"},
+		{MatchmakeSessionModificationFlagMinParticipants, "MinParticipants"},
+		{MatchmakeSessionModificationFlagMaxParticipants, "MaxParticipants"},
+		{MatchmakeSessionModificationFlagMatchmakeSystemType, "MatchmakeSystemType"},
+		{MatchmakeSessionModificationFlagCodeword, "Codeword"},
+	}
+
+	var parts []string
+	for _, f := range flags {
+		if msmf&f.flag != 0 {
+			parts = append(parts, f.name)
+		}
+	}
+
+	return strings.Join(parts, "|")
 }
 
 const (

--- a/match-making/constants/matchmake_session_option0.go
+++ b/match-making/constants/matchmake_session_option0.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // MatchmakeSessionOption0 has an unknown use.
 // Seems related to whether or not the delay the response for "Auto"
@@ -39,6 +43,20 @@ func (mso MatchmakeSessionOption0) HasFlags(flags ...MatchmakeSessionOption0) bo
 	}
 
 	return true
+}
+
+// String returns a human-readable representation of the MatchmakeSessionOption0.
+func (mso MatchmakeSessionOption0) String() string {
+	switch mso {
+	case MatchmakeSessionOption0None:
+		return "None"
+	case MatchmakeSessionOption0ForceAutomatchDelay:
+		return "ForceAutomatchDelay"
+	case MatchmakeSessionOption0ForceAutomatchNoDelay:
+		return "ForceAutomatchNoDelay"
+	default:
+		return fmt.Sprintf("MatchmakeSessionOption0(%d)", int(mso))
+	}
 }
 
 const (

--- a/match-making/constants/matchmake_system_type.go
+++ b/match-making/constants/matchmake_system_type.go
@@ -1,6 +1,8 @@
 package constants
 
 import (
+	"fmt"
+
 	"github.com/PretendoNetwork/nex-go/v2/types"
 )
 
@@ -21,6 +23,26 @@ func (mst *MatchmakeSystemType) ExtractFrom(readable types.Readable) error {
 
 	*mst = MatchmakeSystemType(value)
 	return nil
+}
+
+// String returns a human-readable representation of the MatchmakeSystemType.
+func (mst MatchmakeSystemType) String() string {
+	switch mst {
+	case MatchmakeSystemTypeInvalid:
+		return "Invalid"
+	case MatchmakeSystemTypeAnybody:
+		return "Anybody"
+	case MatchmakeSystemTypeFriends:
+		return "Friends"
+	case MatchmakeSystemTypeFriendsInvite:
+		return "FriendsInvite"
+	case MatchmakeSystemTypeInvite:
+		return "Invite"
+	case MatchmakeSystemTypePersistentGathering:
+		return "PersistentGathering"
+	default:
+		return fmt.Sprintf("MatchmakeSystemType(%d)", int(mst))
+	}
 }
 
 const (

--- a/match-making/constants/matchmake_system_type_string.go
+++ b/match-making/constants/matchmake_system_type_string.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // MatchmakeSystemTypeString represents MatchmakeSystemType values but as strings.
 // Used for MatchmakeSessionSearchCriteria, where the value is encoded as a string
@@ -24,6 +28,28 @@ func (msts *MatchmakeSystemTypeString) ExtractFrom(readable types.Readable) erro
 	}
 	*msts = MatchmakeSystemTypeString(s)
 	return nil
+}
+
+// String returns a human-readable representation of the MatchmakeSystemTypeString.
+func (msts MatchmakeSystemTypeString) String() string {
+	switch msts {
+	case MatchmakeSystemTypeStringMissing:
+		return "Missing"
+	case MatchmakeSystemTypeStringInvalid:
+		return "Invalid"
+	case MatchmakeSystemTypeStringAnybody:
+		return "Anybody"
+	case MatchmakeSystemTypeStringFriends:
+		return "Friends"
+	case MatchmakeSystemTypeStringFriendsInvite:
+		return "FriendsInvite"
+	case MatchmakeSystemTypeStringInvite:
+		return "Invite"
+	case MatchmakeSystemTypeStringPersistentGathering:
+		return "PersistentGathering"
+	default:
+		return fmt.Sprintf("MatchmakeSystemTypeString(%s)", string(msts))
+	}
 }
 
 const (

--- a/match-making/constants/participation_policy.go
+++ b/match-making/constants/participation_policy.go
@@ -1,6 +1,8 @@
 package constants
 
 import (
+	"fmt"
+
 	"github.com/PretendoNetwork/nex-go/v2/types"
 )
 
@@ -24,6 +26,26 @@ func (pp *ParticipationPolicy) ExtractFrom(readable types.Readable) error {
 
 	*pp = ParticipationPolicy(value)
 	return nil
+}
+
+// String returns a human-readable representation of the ParticipationPolicy.
+func (pp ParticipationPolicy) String() string {
+	switch pp {
+	case ParticipationPolicyPasswordProtected:
+		return "PasswordProtected"
+	case ParticipationPolicyOpenParticipation:
+		return "OpenParticipation"
+	case ParticipationPolicyAnybody:
+		return "Anybody"
+	case ParticipationPolicyInviteOnly:
+		return "InviteOnly"
+	case ParticipationPolicyCommunity:
+		return "Community"
+	case ParticipationPolicyFriendsOnly:
+		return "FriendsOnly"
+	default:
+		return fmt.Sprintf("ParticipationPolicy(%d)", int(pp))
+	}
 }
 
 const (

--- a/match-making/constants/persistent_gathering_type.go
+++ b/match-making/constants/persistent_gathering_type.go
@@ -1,6 +1,8 @@
 package constants
 
 import (
+	"fmt"
+
 	"github.com/PretendoNetwork/nex-go/v2/types"
 )
 
@@ -21,6 +23,20 @@ func (pgt *PersistentGatheringType) ExtractFrom(readable types.Readable) error {
 
 	*pgt = PersistentGatheringType(value)
 	return nil
+}
+
+// String returns a human-readable representation of the PersistentGatheringType.
+func (pgt PersistentGatheringType) String() string {
+	switch pgt {
+	case PersistentGatheringTypeOpen:
+		return "Open"
+	case PersistentGatheringTypePasswordLocked:
+		return "PasswordLocked"
+	case PersistentGatheringTypeOfficial:
+		return "Official"
+	default:
+		return fmt.Sprintf("PersistentGatheringType(%d)", int(pgt))
+	}
 }
 
 const (

--- a/match-making/constants/policy_argument.go
+++ b/match-making/constants/policy_argument.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // PolicyArgument is not an official type. It exists to be the
 // base type of other policy argument types and to be used as
@@ -21,4 +25,10 @@ func (pa *PolicyArgument) ExtractFrom(readable types.Readable) error {
 
 	*pa = PolicyArgument(value)
 	return nil
+}
+
+// String returns a human-readable representation of PolicyArgument.
+// This cannot differentiate between types of PolicyArguments
+func (pa PolicyArgument) String() string {
+	return fmt.Sprintf("PolicyArgument(%d)", int(pa))
 }

--- a/match-making/constants/policy_argument.go
+++ b/match-making/constants/policy_argument.go
@@ -32,3 +32,25 @@ func (pa *PolicyArgument) ExtractFrom(readable types.Readable) error {
 func (pa PolicyArgument) String() string {
 	return fmt.Sprintf("PolicyArgument(%d)", int(pa))
 }
+
+// StringAnybodyParticipationPolicyArgument returns a human-readable representation of the AnybodyParticipationPolicyArgument.
+func (pa PolicyArgument) StringAnybodyParticipationPolicyArgument() string {
+	appa := AnybodyParticipationPolicyArgument(pa)
+	switch appa {
+	case AnybodyParticipationPolicyArgumentWithoutClose:
+		return "WithoutClose"
+	case AnybodyParticipationPolicyArgumentCloseOnOwnerMigration:
+		return "CloseOnOwnerMigration"
+	default:
+		return fmt.Sprintf("AnybodyParticipationPolicyArgument(%d)", int(appa))
+	}
+}
+
+// StringFriendsOnlyParticipationPolicyArgument returns a human-readable representation of the FriendsOnlyParticipationPolicyArgument.
+func (pa PolicyArgument) StringFriendsOnlyParticipationPolicyArgument() string {
+	foppa := FriendsOnlyParticipationPolicyArgument(pa)
+	switch foppa {
+	default:
+		return fmt.Sprintf("FriendsOnlyParticipationPolicyArgument(%d)", int(foppa))
+	}
+}

--- a/match-making/types/gathering.go
+++ b/match-making/types/gathering.go
@@ -208,7 +208,14 @@ func (g Gathering) FormatToString(indentationLevel int) string {
 	b.WriteString(fmt.Sprintf("%sMinimumParticipants: %s,\n", indentationValues, g.MinimumParticipants))
 	b.WriteString(fmt.Sprintf("%sMaximumParticipants: %s,\n", indentationValues, g.MaximumParticipants))
 	b.WriteString(fmt.Sprintf("%sParticipationPolicy: %s,\n", indentationValues, g.ParticipationPolicy))
-	b.WriteString(fmt.Sprintf("%sPolicyArgument: %s,\n", indentationValues, g.PolicyArgument))
+	switch g.ParticipationPolicy {
+	case constants.ParticipationPolicyAnybody:
+		b.WriteString(fmt.Sprintf("%sPolicyArgument: %s,\n", indentationValues, g.PolicyArgument.StringAnybodyParticipationPolicyArgument()))
+	case constants.ParticipationPolicyFriendsOnly:
+		b.WriteString(fmt.Sprintf("%sPolicyArgument: %s,\n", indentationValues, g.PolicyArgument.StringFriendsOnlyParticipationPolicyArgument()))
+	default:
+		b.WriteString(fmt.Sprintf("%sPolicyArgument: %s,\n", indentationValues, g.PolicyArgument))
+	}
 	b.WriteString(fmt.Sprintf("%sFlags: %s,\n", indentationValues, g.Flags))
 	b.WriteString(fmt.Sprintf("%sState: %s,\n", indentationValues, g.State))
 	b.WriteString(fmt.Sprintf("%sDescription: %s,\n", indentationValues, g.Description))

--- a/messaging/constants/message_flag.go
+++ b/messaging/constants/message_flag.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // MessageFlag determines how the message is delivered to the recipient.
 type MessageFlag uint32
@@ -39,6 +43,18 @@ func (mf MessageFlag) HasFlags(flags ...MessageFlag) bool {
 	}
 
 	return true
+}
+
+// String returns a human-readable representation of the MessageFlag.
+func (mf MessageFlag) String() string {
+	switch mf {
+	case MessageFlagPersistentMessage:
+		return "PersistentMessage"
+	case MessageFlagInstantMessage:
+		return "InstantMessage"
+	default:
+		return fmt.Sprintf("MessageFlag(%d)", int(mf))
+	}
 }
 
 const (

--- a/messaging/constants/recipient_type.go
+++ b/messaging/constants/recipient_type.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // RecipientType determines what to target when sending messages.
 type RecipientType uint32
@@ -19,6 +23,18 @@ func (rt *RecipientType) ExtractFrom(readable types.Readable) error {
 
 	*rt = RecipientType(value)
 	return nil
+}
+
+// String returns a human-readable representation of the RecipientType.
+func (rt RecipientType) String() string {
+	switch rt {
+	case RecipientTypePrincipalID:
+		return "PrincipalID"
+	case RecipientTypeGatheringID:
+		return "GatheringID"
+	default:
+		return fmt.Sprintf("RecipientType(%d)", int(rt))
+	}
 }
 
 const (

--- a/nintendo-notifications/constants/notification_type.go
+++ b/nintendo-notifications/constants/notification_type.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // NotificationType represents the type of notification being sent.
 //
@@ -21,6 +25,64 @@ func (nt *NotificationType) ExtractFrom(readable types.Readable) error {
 
 	*nt = NotificationType(value)
 	return nil
+}
+
+// String returns a human-readable representation of the NotificationType.
+func (nt NotificationType) String() string {
+	switch nt {
+	case NotificationTypeFriendPresenceUpdated3DS:
+		return "FriendPresenceUpdated3DS"
+	case NotificationTypeFriendFavoriteGameUpdated3DS:
+		return "FriendFavoriteGameUpdated3DS"
+	case NotificationTypeFriendCommentUpdated3DS:
+		return "FriendCommentUpdated3DS"
+	case NotificationTypeFriendMiiChanged3DS:
+		return "FriendMiiChanged3DS"
+	case NotificationTypeFriendProfileUpdated3DS:
+		return "FriendProfileUpdated3DS"
+	case NotificationTypeFriendshipCompleted3DS:
+		return "FriendshipCompleted3DS"
+	case NotificationTypeFriendshipRemoved3DS:
+		return "FriendshipRemoved3DS"
+	case NotificationTypeFriendSentInvitation3DS:
+		return "FriendSentInvitation3DS"
+	case NotificationTypeFriendOffline:
+		return "FriendOffline"
+	case NotificationTypeFriendMiiChangedWiiU:
+		return "FriendMiiChangedWiiU"
+	case NotificationTypeUnknown1MiiRelatedWiiU:
+		return "Unknown1MiiRelatedWiiU"
+	case NotificationTypeFriendPreferencesChangedWiiU:
+		return "FriendPreferencesChangedWiiU"
+	case NotificationTypeFriendStartedTitleWiiU:
+		return "FriendStartedTitleWiiU"
+	case NotificationTypeUnknown2FriendRequestRelatedWiiU:
+		return "Unknown2FriendRequestRelatedWiiU"
+	case NotificationTypeFriendshipCanceledWiiU:
+		return "FriendshipCanceledWiiU"
+	case NotificationTypeFriendRequestReceivedWiiU:
+		return "FriendRequestReceivedWiiU"
+	case NotificationTypeUnknown3FriendRequestRelatedWiiU:
+		return "Unknown3FriendRequestRelatedWiiU"
+	case NotificationTypeUnknown4BlacklistRelatedWiiU:
+		return "Unknown4BlacklistRelatedWiiU"
+	case NotificationTypeFriendRequestAcceptedWiiU:
+		return "FriendRequestAcceptedWiiU"
+	case NotificationTypeUnknown5BlacklistRelatedWiiU:
+		return "Unknown5BlacklistRelatedWiiU"
+	case NotificationTypeUnknown6BlacklistRelatedWiiU:
+		return "Unknown6BlacklistRelatedWiiU"
+	case NotificationTypeFriendStatusMessageChangedWiiU:
+		return "FriendStatusMessageChangedWiiU"
+	case NotificationTypeUnknown7WiiU:
+		return "Unknown7WiiU"
+	case NotificationTypeUnknown8FriendshipRelatedWiiU:
+		return "Unknown8FriendshipRelatedWiiU"
+	case NotificationTypeUnknown9PersistentNotificationsRelatedWiiU:
+		return "Unknown9PersistentNotificationsRelatedWiiU"
+	default:
+		return fmt.Sprintf("NotificationType(%d)", int(nt))
+	}
 }
 
 // * 3DS notifications

--- a/notifications/constants/notification_category.go
+++ b/notifications/constants/notification_category.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // NotificationCategory represents the main category of a notification type.
 //
@@ -71,6 +75,68 @@ func (nc NotificationCategory) Build(subtype ...SubType) NotificationEvents {
 // ToSigned converts a NotificationCategory to a NotificationCategorySigned
 func (nc NotificationCategory) ToSigned() NotificationCategorySigned {
 	return NotificationCategorySigned(nc)
+}
+
+// String returns a human-readable representation of the NotificationCategory.
+func (nc NotificationCategory) String() string {
+	switch nc {
+	case NotificationCategorySessionLaunched:
+		return "SessionLaunched"
+	case NotificationCategoryParticipationEvent:
+		return "ParticipationEvent"
+	case NotificationCategoryOwnershipChangeEvent:
+		return "OwnershipChangeEvent"
+	case NotificationCategoryGameNotification1:
+		return "GameNotification1"
+	case NotificationCategoryGameNotification2:
+		return "GameNotification2"
+	case NotificationCategoryGameNotification3:
+		return "GameNotification3"
+	case NotificationCategoryGameNotification4:
+		return "GameNotification4"
+	case NotificationCategoryGameNotification5:
+		return "GameNotification5"
+	case NotificationCategoryGameNotification6:
+		return "GameNotification6"
+	case NotificationCategoryGameNotification7:
+		return "GameNotification7"
+	case NotificationCategoryGameNotification8:
+		return "GameNotification8"
+	case NotificationCategoryGatheringUnregistered:
+		return "GatheringUnregistered"
+	case NotificationCategoryHostChangeEvent:
+		return "HostChangeEvent"
+	case NotificationCategoryGameNotificationLogout:
+		return "GameNotificationLogout"
+	case NotificationCategorySubscriptionEvent:
+		return "SubscriptionEvent"
+	case NotificationCategoryGameServerMaintenance:
+		return "GameServerMaintenance"
+	case NotificationCategoryMaintenanceAnnouncement:
+		return "MaintenanceAnnouncement"
+	case NotificationCategoryServiceItemRequestCompleted:
+		return "ServiceItemRequestCompleted"
+	case NotificationCategoryRoundStarted:
+		return "RoundStarted"
+	case NotificationCategoryFirstRoundReportReceived:
+		return "FirstRoundReportReceived"
+	case NotificationCategoryRoundSummarized:
+		return "RoundSummarized"
+	case NotificationCategoryMatchmakeSystemConfigurationNotification:
+		return "MatchmakeSystemConfigurationNotification"
+	case NotificationCategoryMatchmakeSessionSystemPasswordSet:
+		return "MatchmakeSessionSystemPasswordSet"
+	case NotificationCategoryMatchmakeSessionSystemPasswordClear:
+		return "MatchmakeSessionSystemPasswordClear"
+	case NotificationCategoryAddedToGathering:
+		return "AddedToGathering"
+	case NotificationCategoryUserStatusUpdatedEvent:
+		return "UserStatusUpdatedEvent"
+	case NotificationCategoryEagleAddress:
+		return "EagleAddress"
+	default:
+		return fmt.Sprintf("NotificationCategory(%d)", int(nc))
+	}
 }
 
 const (

--- a/notifications/constants/sub_type.go
+++ b/notifications/constants/sub_type.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // SubType exists solely to restrict the kinds of values that can be passed
 // to SubType.Build()
@@ -20,4 +24,10 @@ func (st *SubType) ExtractFrom(readable types.Readable) error {
 
 	*st = SubType(value)
 	return nil
+}
+
+// String returns a human-readable representation of SubType.
+// This cannot differentiate between types of SubTypes
+func (st SubType) String() string {
+	return fmt.Sprintf("SubType(%d)", int(st))
 }

--- a/notifications/constants/sub_type.go
+++ b/notifications/constants/sub_type.go
@@ -31,3 +31,35 @@ func (st *SubType) ExtractFrom(readable types.Readable) error {
 func (st SubType) String() string {
 	return fmt.Sprintf("SubType(%d)", int(st))
 }
+
+// StringParticipationEvents returns a human-readable representation of the ParticipationEvents.
+func (st SubType) StringParticipationEvents() string {
+	pe := ParticipationEvents(st)
+	switch pe {
+	case ParticipationEventsParticipate:
+		return "Participate"
+	case ParticipationEventsCancelParticipation:
+		return "CancelParticipation"
+	case ParticipationEventsDisconnect:
+		return "Disconnect"
+	case ParticipationEventsEndParticipation:
+		return "EndParticipation"
+	default:
+		return fmt.Sprintf("ParticipationEvents(%d)", int(pe))
+	}
+}
+
+// StringSubscriptionEvents returns a human-readable representation of the SubscriptionEvents.
+func (st SubType) StringSubscriptionEvents() string {
+	se := SubscriptionEvents(st)
+	switch se {
+	case SubscriptionEventsEvent0:
+		return "Event0"
+	case SubscriptionEventsEvent1:
+		return "Event1"
+	case SubscriptionEventsEvent2:
+		return "Event2"
+	default:
+		return fmt.Sprintf("SubscriptionEvents(%d)", int(se))
+	}
+}

--- a/ranking/constants/filter_group_index.go
+++ b/ranking/constants/filter_group_index.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // FilterGroupIndex is used by RankingOrderParam.GroupIndex to select which group to filter by in a score request
 type FilterGroupIndex uint8
@@ -19,6 +23,24 @@ func (fgi *FilterGroupIndex) ExtractFrom(readable types.Readable) error {
 
 	*fgi = FilterGroupIndex(value)
 	return nil
+}
+
+// String returns a human-readable representation of the FilterGroupIndex.
+func (fgi FilterGroupIndex) String() string {
+	switch fgi {
+	case FilterGroupIndex0:
+		return "Index0"
+	case FilterGroupIndex1:
+		return "Index1"
+	case FilterGroupIndex2:
+		return "Index2"
+	case FilterGroupIndex3:
+		return "Index3"
+	case FilterGroupIndexNone:
+		return "None"
+	default:
+		return fmt.Sprintf("FilterGroupIndex(%d)", int(fgi))
+	}
 }
 
 const (

--- a/ranking/constants/modification_flag.go
+++ b/ranking/constants/modification_flag.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // ModificationFlag is used by RankingChangeAttributesParam.ModificationFlag to set which fields should be
 // updated.
@@ -40,6 +44,35 @@ func (mf ModificationFlag) HasFlags(flags ...ModificationFlag) bool {
 	}
 
 	return true
+}
+
+// String returns a human-readable representation of the ModificationFlag bitmask.
+// Multiple flags are joined with "|", e.g. "Group0|Group1|Param".
+// Returns "None" if no flags are set.
+func (mf ModificationFlag) String() string {
+	if mf == ModificationFlagNone {
+		return "None"
+	}
+
+	flags := []struct {
+		flag ModificationFlag
+		name string
+	}{
+		{ModificationFlagGroup0, "Group0"},
+		{ModificationFlagGroup1, "Group1"},
+		{ModificationFlagGroup2, "Group2"},
+		{ModificationFlagGroup3, "Group3"},
+		{ModificationFlagParam, "Param"},
+	}
+
+	var parts []string
+	for _, f := range flags {
+		if mf&f.flag != 0 {
+			parts = append(parts, f.name)
+		}
+	}
+
+	return strings.Join(parts, "|")
 }
 
 const (

--- a/ranking/constants/order_by.go
+++ b/ranking/constants/order_by.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // OrderBy is used in RankingScoreData.OrderBy to set the "golf scoring" mode for a category.
 type OrderBy uint8
@@ -19,6 +23,18 @@ func (ob *OrderBy) ExtractFrom(readable types.Readable) error {
 
 	*ob = OrderBy(value)
 	return nil
+}
+
+// String returns a human-readable representation of the OrderBy.
+func (ob OrderBy) String() string {
+	switch ob {
+	case OrderByAscending:
+		return "Ascending"
+	case OrderByDescending:
+		return "Descending"
+	default:
+		return fmt.Sprintf("OrderBy(%d)", int(ob))
+	}
 }
 
 const (

--- a/ranking/constants/order_calculation.go
+++ b/ranking/constants/order_calculation.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // OrderCalculation is used in OrderParam.OrderCalculation to control how ties are handled.
 type OrderCalculation uint8
@@ -19,6 +23,18 @@ func (oc *OrderCalculation) ExtractFrom(readable types.Readable) error {
 
 	*oc = OrderCalculation(value)
 	return nil
+}
+
+// String returns a human-readable representation of the OrderCalculation.
+func (oc OrderCalculation) String() string {
+	switch oc {
+	case OrderCalculation113:
+		return "113"
+	case OrderCalculation123:
+		return "123"
+	default:
+		return fmt.Sprintf("OrderCalculation(%d)", int(oc))
+	}
 }
 
 const (

--- a/ranking/constants/ranking_mode.go
+++ b/ranking/constants/ranking_mode.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // RankingMode represents the selection of who will be included on the leaderboard (global, friends, nearby etc.).
 type RankingMode uint8
@@ -19,6 +23,24 @@ func (rm *RankingMode) ExtractFrom(readable types.Readable) error {
 
 	*rm = RankingMode(value)
 	return nil
+}
+
+// String returns a human-readable representation of the RankingMode.
+func (rm RankingMode) String() string {
+	switch rm {
+	case RankingModeRange:
+		return "Range"
+	case RankingModeNear:
+		return "Near"
+	case RankingModeFriendRange:
+		return "FriendRange"
+	case RankingModeFriendNear:
+		return "FriendNear"
+	case RankingModeUser:
+		return "User"
+	default:
+		return fmt.Sprintf("RankingMode(%d)", int(rm))
+	}
 }
 
 const (

--- a/ranking/constants/stats_flag.go
+++ b/ranking/constants/stats_flag.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // StatsFlag is a bitmask used by GetRanking to request the inclusion of different aggregate stats
 type StatsFlag uint32
@@ -39,6 +43,35 @@ func (sf StatsFlag) HasFlags(flags ...StatsFlag) bool {
 	}
 
 	return true
+}
+
+// String returns a human-readable representation of the StatsFlag bitmask.
+// Multiple flags are joined with "|", e.g. "Total|Sum|Average".
+// Returns "None" if no flags are set.
+func (sf StatsFlag) String() string {
+	if sf == 0 {
+		return "None"
+	}
+
+	flags := []struct {
+		flag StatsFlag
+		name string
+	}{
+		{StatsFlagTotal, "Total"},
+		{StatsFlagSum, "Sum"},
+		{StatsFlagMin, "Min"},
+		{StatsFlagMax, "Max"},
+		{StatsFlagAverage, "Average"},
+	}
+
+	var parts []string
+	for _, f := range flags {
+		if sf&f.flag != 0 {
+			parts = append(parts, f.name)
+		}
+	}
+
+	return strings.Join(parts, "|")
 }
 
 const (

--- a/ranking/constants/time_scope.go
+++ b/ranking/constants/time_scope.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // TimeScope is used by RankingOrderParam.TimeScope to request that scores only be shown from a certain timeframe.
 type TimeScope uint8
@@ -19,6 +23,20 @@ func (ts *TimeScope) ExtractFrom(readable types.Readable) error {
 
 	*ts = TimeScope(value)
 	return nil
+}
+
+// String returns a human-readable representation of the TimeScope.
+func (ts TimeScope) String() string {
+	switch ts {
+	case TimeScopeCustom0:
+		return "Custom0"
+	case TimeScopeCustom1:
+		return "Custom1"
+	case TimeScopeAll:
+		return "All"
+	default:
+		return fmt.Sprintf("TimeScope(%d)", int(ts))
+	}
 }
 
 const (

--- a/ranking/constants/update_mode.go
+++ b/ranking/constants/update_mode.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // UpdateMode is used by RankingScoreData.UpdateMode to control if worse scores should be discarded or not.
 type UpdateMode uint8
@@ -19,6 +23,18 @@ func (um *UpdateMode) ExtractFrom(readable types.Readable) error {
 
 	*um = UpdateMode(value)
 	return nil
+}
+
+// String returns a human-readable representation of the UpdateMode.
+func (um UpdateMode) String() string {
+	switch um {
+	case UpdateModeNormal:
+		return "Normal"
+	case UpdateModeDeleteOld:
+		return "DeleteOld"
+	default:
+		return fmt.Sprintf("UpdateMode(%d)", int(um))
+	}
 }
 
 const (

--- a/ranking/legacy/constants/order_by.go
+++ b/ranking/legacy/constants/order_by.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // OrderBy is used to set the "golf scoring" mode for a category.
 type OrderBy uint8
@@ -19,6 +23,18 @@ func (ob *OrderBy) ExtractFrom(readable types.Readable) error {
 
 	*ob = OrderBy(value)
 	return nil
+}
+
+// String returns a human-readable representation of the OrderBy.
+func (ob OrderBy) String() string {
+	switch ob {
+	case OrderByAscending:
+		return "Ascending"
+	case OrderByDescending:
+		return "Descending"
+	default:
+		return fmt.Sprintf("OrderBy(%d)", int(ob))
+	}
 }
 
 const (

--- a/ranking/legacy/constants/order_calculation.go
+++ b/ranking/legacy/constants/order_calculation.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // OrderCalculation is used to control how ties are handled.
 type OrderCalculation uint8
@@ -19,6 +23,18 @@ func (oc *OrderCalculation) ExtractFrom(readable types.Readable) error {
 
 	*oc = OrderCalculation(value)
 	return nil
+}
+
+// String returns a human-readable representation of the OrderCalculation.
+func (oc OrderCalculation) String() string {
+	switch oc {
+	case OrderCalculation113:
+		return "113"
+	case OrderCalculation123:
+		return "123"
+	default:
+		return fmt.Sprintf("OrderCalculation(%d)", int(oc))
+	}
 }
 
 const (

--- a/ranking/legacy/constants/ranking_mode.go
+++ b/ranking/legacy/constants/ranking_mode.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // RankingMode represents the selection of who will be included on the leaderboard (global, friends, nearby etc.).
 type RankingMode uint8
@@ -19,6 +23,24 @@ func (rm *RankingMode) ExtractFrom(readable types.Readable) error {
 
 	*rm = RankingMode(value)
 	return nil
+}
+
+// String returns a human-readable representation of the RankingMode.
+func (rm RankingMode) String() string {
+	switch rm {
+	case RankingModeRange:
+		return "Range"
+	case RankingModeNear:
+		return "Near"
+	case RankingModeFriendRange:
+		return "FriendRange"
+	case RankingModeFriendNear:
+		return "FriendNear"
+	case RankingModeUser:
+		return "User"
+	default:
+		return fmt.Sprintf("RankingMode(%d)", int(rm))
+	}
 }
 
 const (

--- a/ranking/legacy/constants/result_code.go
+++ b/ranking/legacy/constants/result_code.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // ResultCode is a custom result value used by legacy Ranking representing the kind of operation performed by a method.
 //
@@ -21,6 +25,22 @@ func (rc *ResultCode) ExtractFrom(readable types.Readable) error {
 
 	*rc = ResultCode(value)
 	return nil
+}
+
+// String returns a human-readable representation of the ResultCode.
+func (rc ResultCode) String() string {
+	switch rc {
+	case ResultCodeGetOne:
+		return "GetOne"
+	case ResultCodeGetMany:
+		return "GetMany"
+	case ResultCodeUpdateOne:
+		return "UpdateOne"
+	case ResultCodeUpdateMany:
+		return "UpdateMany"
+	default:
+		return fmt.Sprintf("ResultCode(%d)", int(rc))
+	}
 }
 
 const (

--- a/ranking/legacy/constants/score_index.go
+++ b/ranking/legacy/constants/score_index.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // ScoreIndex is used to select the index for the score list to use when sorting.
 //
@@ -21,6 +25,18 @@ func (si *ScoreIndex) ExtractFrom(readable types.Readable) error {
 
 	*si = ScoreIndex(value)
 	return nil
+}
+
+// String returns a human-readable representation of the ScoreIndex.
+func (si ScoreIndex) String() string {
+	switch si {
+	case ScoreIndex0:
+		return "Index0"
+	case ScoreIndex1:
+		return "Index1"
+	default:
+		return fmt.Sprintf("ScoreIndex(%d)", int(si))
+	}
 }
 
 const (

--- a/ranking2/constants/ranking2_get_option_flags.go
+++ b/ranking2/constants/ranking2_get_option_flags.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // Ranking2GetOptionFlags determines what data is returned when requesting common data.
 type Ranking2GetOptionFlags uint32
@@ -39,6 +43,30 @@ func (r2gof Ranking2GetOptionFlags) HasFlags(flags ...Ranking2GetOptionFlags) bo
 	}
 
 	return true
+}
+
+// String returns a human-readable representation of the Ranking2GetOptionFlags.
+// Returns "Nothing" if no flags are set.
+func (r2gof Ranking2GetOptionFlags) String() string {
+	if r2gof == Ranking2GetOptionFlagsNothing {
+		return "Nothing"
+	}
+
+	flags := []struct {
+		flag Ranking2GetOptionFlags
+		name string
+	}{
+		{Ranking2GetOptionFlagsMii, "Mii"},
+	}
+
+	var parts []string
+	for _, f := range flags {
+		if r2gof&f.flag != 0 {
+			parts = append(parts, f.name)
+		}
+	}
+
+	return strings.Join(parts, "|")
 }
 
 const (

--- a/ranking2/constants/ranking2_mode.go
+++ b/ranking2/constants/ranking2_mode.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // Ranking2Mode determines what rankings to return and how to order them.
 //
@@ -24,6 +28,22 @@ func (r2m *Ranking2Mode) ExtractFrom(readable types.Readable) error {
 
 	*r2m = Ranking2Mode(value)
 	return nil
+}
+
+// String returns a human-readable representation of the Ranking2Mode.
+func (r2m Ranking2Mode) String() string {
+	switch r2m {
+	case Ranking2ModeUserRanking:
+		return "UserRanking"
+	case Ranking2ModeNearRanking:
+		return "NearRanking"
+	case Ranking2ModeRangeRanking:
+		return "RangeRanking"
+	case Ranking2ModeFriendRanking:
+		return "FriendRanking"
+	default:
+		return fmt.Sprintf("Ranking2Mode(%d)", int(r2m))
+	}
 }
 
 const (

--- a/ranking2/constants/ranking2_reset_day.go
+++ b/ranking2/constants/ranking2_reset_day.go
@@ -24,6 +24,8 @@ func (r2rd *Ranking2ResetDay) ExtractFrom(readable types.Readable) error {
 	return nil
 }
 
+// TODO - How can a String method be added here? The enum has 2 sets of overlapping values
+
 const (
 	// Ranking2ResetDayMonday means that season rankings should reset every Monday
 	// when the category reset mod is set to Ranking2ResetModeWeekday. This also means

--- a/ranking2/constants/ranking2_reset_day.go
+++ b/ranking2/constants/ranking2_reset_day.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // Ranking2ResetDay determines on what day of the week or month Ranking2 season rankings
 // will reset.
@@ -24,49 +28,141 @@ func (r2rd *Ranking2ResetDay) ExtractFrom(readable types.Readable) error {
 	return nil
 }
 
-// TODO - How can a String method be added here? The enum has 2 sets of overlapping values
+// String returns a human-readable representation of Ranking2ResetDay.
+// This cannot differentiate between types of Ranking2ResetDays
+func (r2rd Ranking2ResetDay) String() string {
+	return fmt.Sprintf("Ranking2ResetDay(%d)", int(r2rd))
+}
+
+// StringWeekday returns a human-readable representation of the Ranking2ResetDay
+// when the category reset mode is set to Ranking2ResetModeEveryWeek or Ranking2ResetModeMultiMonthWeekday.
+func (r2rd Ranking2ResetDay) StringWeekday() string {
+	switch r2rd {
+	case Ranking2ResetDayMonday:
+		return "Monday"
+	case Ranking2ResetDayTuesday:
+		return "Tuesday"
+	case Ranking2ResetDayWednesday:
+		return "Wednesday"
+	case Ranking2ResetDayThursday:
+		return "Thursday"
+	case Ranking2ResetDayFriday:
+		return "Friday"
+	case Ranking2ResetDaySaturday:
+		return "Saturday"
+	case Ranking2ResetDaySunday:
+		return "Sunday"
+	default:
+		return fmt.Sprintf("Ranking2ResetDay(%d)", int(r2rd))
+	}
+}
+
+// StringMonthly returns a human-readable representation of the Ranking2ResetDay
+// when the category reset mode is set to Ranking2ResetModeMultiMonth.
+func (r2rd Ranking2ResetDay) StringMonthly() string {
+	switch r2rd {
+	case Ranking2ResetDay1:
+		return "1st"
+	case Ranking2ResetDay2:
+		return "2nd"
+	case Ranking2ResetDay3:
+		return "3rd"
+	case Ranking2ResetDay4:
+		return "4th"
+	case Ranking2ResetDay5:
+		return "5th"
+	case Ranking2ResetDay6:
+		return "6th"
+	case Ranking2ResetDay7:
+		return "7th"
+	case Ranking2ResetDay8:
+		return "8th"
+	case Ranking2ResetDay9:
+		return "9th"
+	case Ranking2ResetDay10:
+		return "10th"
+	case Ranking2ResetDay11:
+		return "11th"
+	case Ranking2ResetDay12:
+		return "12th"
+	case Ranking2ResetDay13:
+		return "13th"
+	case Ranking2ResetDay14:
+		return "14th"
+	case Ranking2ResetDay15:
+		return "15th"
+	case Ranking2ResetDay16:
+		return "16th"
+	case Ranking2ResetDay17:
+		return "17th"
+	case Ranking2ResetDay18:
+		return "18th"
+	case Ranking2ResetDay19:
+		return "19th"
+	case Ranking2ResetDay20:
+		return "20th"
+	case Ranking2ResetDay21:
+		return "21st"
+	case Ranking2ResetDay22:
+		return "22nd"
+	case Ranking2ResetDay23:
+		return "23rd"
+	case Ranking2ResetDay24:
+		return "24th"
+	case Ranking2ResetDay25:
+		return "25th"
+	case Ranking2ResetDay26:
+		return "26th"
+	case Ranking2ResetDay27:
+		return "27th"
+	case Ranking2ResetDay28:
+		return "28th"
+	default:
+		return fmt.Sprintf("Ranking2ResetDay(%d)", int(r2rd))
+	}
+}
 
 const (
 	// Ranking2ResetDayMonday means that season rankings should reset every Monday
-	// when the category reset mod is set to Ranking2ResetModeWeekday. This also means
+	// when the category reset mode is set to Ranking2ResetModeEveryWeek. This also means
 	// that season rankings should reset on the first Monday of the month when the category
-	// reset mod is set to Ranking2ResetModeMultiMonthWeekday.
+	// reset mode is set to Ranking2ResetModeMultiMonthWeekday.
 	Ranking2ResetDayMonday Ranking2ResetDay = 0
 
 	// Ranking2ResetDayTuesday means that season rankings should reset every Tuesday
-	// when the category reset mod is set to Ranking2ResetModeWeekday. This also means
+	// when the category reset mode is set to Ranking2ResetModeEveryWeek. This also means
 	// that season rankings should reset on the first Tuesday of the month when the category
-	// reset mod is set to Ranking2ResetModeMultiMonthWeekday.
+	// reset mode is set to Ranking2ResetModeMultiMonthWeekday.
 	Ranking2ResetDayTuesday Ranking2ResetDay = 1
 
 	// Ranking2ResetDayWednesday means that season rankings should reset every Wednesday
-	// when the category reset mod is set to Ranking2ResetModeWeekday. This also means
+	// when the category reset mode is set to Ranking2ResetModeEveryWeek. This also means
 	// that season rankings should reset on the first Wednesday of the month when the category
-	// reset mod is set to Ranking2ResetModeMultiMonthWeekday.
+	// reset mode is set to Ranking2ResetModeMultiMonthWeekday.
 	Ranking2ResetDayWednesday Ranking2ResetDay = 2
 
 	// Ranking2ResetDayThursday means that season rankings should reset every Thursday
-	// when the category reset mod is set to Ranking2ResetModeWeekday. This also means
+	// when the category reset mode is set to Ranking2ResetModeEveryWeek. This also means
 	// that season rankings should reset on the first Thursday of the month when the category
-	// reset mod is set to Ranking2ResetModeMultiMonthWeekday.
+	// reset mode is set to Ranking2ResetModeMultiMonthWeekday.
 	Ranking2ResetDayThursday Ranking2ResetDay = 3
 
 	// Ranking2ResetDayFriday means that season rankings should reset every Friday
-	// when the category reset mod is set to Ranking2ResetModeWeekday. This also means
+	// when the category reset mode is set to Ranking2ResetModeEveryWeek. This also means
 	// that season rankings should reset on the first Friday of the month when the category
-	// reset mod is set to Ranking2ResetModeMultiMonthWeekday.
+	// reset mode is set to Ranking2ResetModeMultiMonthWeekday.
 	Ranking2ResetDayFriday Ranking2ResetDay = 4
 
 	// Ranking2ResetDaySaturday means that season rankings should reset every Saturday
-	// when the category reset mod is set to Ranking2ResetModeWeekday. This also means
+	// when the category reset mode is set to Ranking2ResetModeEveryWeek. This also means
 	// that season rankings should reset on the first Saturday of the month when the category
-	// reset mod is set to Ranking2ResetModeMultiMonthWeekday.
+	// reset mode is set to Ranking2ResetModeMultiMonthWeekday.
 	Ranking2ResetDaySaturday Ranking2ResetDay = 5
 
 	// Ranking2ResetDaySunday means that season rankings should reset every Sunday
-	// when the category reset mod is set to Ranking2ResetModeWeekday. This also means
+	// when the category reset mode is set to Ranking2ResetModeEveryWeek. This also means
 	// that season rankings should reset on the first Sunday of the month when the category
-	// reset mod is set to Ranking2ResetModeMultiMonthWeekday.
+	// reset mode is set to Ranking2ResetModeMultiMonthWeekday.
 	Ranking2ResetDaySunday Ranking2ResetDay = 6
 )
 

--- a/ranking2/constants/ranking2_reset_mode.go
+++ b/ranking2/constants/ranking2_reset_mode.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // Ranking2ResetMode determines when and how to reset ranking data. Ranking resets
 // begin a new "season" in Ranking2.
@@ -20,6 +24,24 @@ func (r2rm *Ranking2ResetMode) ExtractFrom(readable types.Readable) error {
 
 	*r2rm = Ranking2ResetMode(value)
 	return nil
+}
+
+// String returns a human-readable representation of the Ranking2ResetMode.
+func (r2rm Ranking2ResetMode) String() string {
+	switch r2rm {
+	case Ranking2ResetModeNothing:
+		return "Nothing"
+	case Ranking2ResetModeEveryDay:
+		return "EveryDay"
+	case Ranking2ResetModeEveryWeek:
+		return "EveryWeek"
+	case Ranking2ResetModeMultiMonth:
+		return "MultiMonth"
+	case Ranking2ResetModeMultiMonthWeekday:
+		return "MultiMonthWeekday"
+	default:
+		return fmt.Sprintf("Ranking2ResetMode(%d)", int(r2rm))
+	}
 }
 
 const (

--- a/ranking2/constants/ranking2_reset_mode.go
+++ b/ranking2/constants/ranking2_reset_mode.go
@@ -72,7 +72,7 @@ const (
 	// safely be assumed to go in month order, however. Starting with January
 	// and ending with December where January is the LSB. The value range for
 	// `resetDay` is also not known, however as it represents a calendar date it
-	// can be safely assumed to begin at 1. since not all months have the same
+	// can be safely assumed to begin at 1. Since not all months have the same
 	// number of days, it can be safely assumed that the upper limit would be the
 	// most amount of days all months have, making the range 1-28. This does, however,
 	// mean that months with more than 28 days cannot have rankings reset on those days.

--- a/ranking2/constants/ranking2_reset_month.go
+++ b/ranking2/constants/ranking2_reset_month.go
@@ -1,6 +1,7 @@
 package constants
 
 import (
+	"strings"
 	"time"
 
 	"github.com/PretendoNetwork/nex-go/v2/types"
@@ -71,6 +72,45 @@ func (r2rm Ranking2ResetMonth) EnabledMonths() []time.Month {
 // Count returns the number of enabled months
 func (r2rm Ranking2ResetMonth) Count() int {
 	return len(r2rm.EnabledMonths())
+}
+
+// String returns a human-readable representation of the Ranking2ResetMonth bitmask.
+// Multiple flags are joined with "|", e.g. "January|April|July|October".
+// Returns "None" if no flags are set.
+func (r2rm Ranking2ResetMonth) String() string {
+	if r2rm == Ranking2ResetMonthNone {
+		return "None"
+	}
+	if r2rm == Ranking2ResetMonthAll {
+		return "All"
+	}
+
+	flags := []struct {
+		flag Ranking2ResetMonth
+		name string
+	}{
+		{Ranking2ResetMonthJanuary, "January"},
+		{Ranking2ResetMonthFebruary, "February"},
+		{Ranking2ResetMonthMarch, "March"},
+		{Ranking2ResetMonthApril, "April"},
+		{Ranking2ResetMonthMay, "May"},
+		{Ranking2ResetMonthJune, "June"},
+		{Ranking2ResetMonthJuly, "July"},
+		{Ranking2ResetMonthAugust, "August"},
+		{Ranking2ResetMonthSeptember, "September"},
+		{Ranking2ResetMonthOctober, "October"},
+		{Ranking2ResetMonthNovember, "November"},
+		{Ranking2ResetMonthDecember, "December"},
+	}
+
+	var parts []string
+	for _, f := range flags {
+		if r2rm&f.flag != 0 {
+			parts = append(parts, f.name)
+		}
+	}
+
+	return strings.Join(parts, "|")
 }
 
 const (

--- a/ranking2/constants/ranking2_sort_flags.go
+++ b/ranking2/constants/ranking2_sort_flags.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // Ranking2SortFlags determines how ranking results should be ordered.
 type Ranking2SortFlags uint32
@@ -39,6 +43,33 @@ func (r2sf Ranking2SortFlags) HasFlags(flags ...Ranking2SortFlags) bool {
 	}
 
 	return true
+}
+
+// String returns a human-readable representation of the Ranking2SortFlags bitmask.
+// Multiple flags are joined with "|", e.g. "Ascending|MoveToTopInTie".
+// Returns "Nothing" if no flags are set.
+func (r2sf Ranking2SortFlags) String() string {
+	if r2sf == Ranking2SortFlagsNothing {
+		return "Nothing"
+	}
+
+	flags := []struct {
+		flag Ranking2SortFlags
+		name string
+	}{
+		{Ranking2SortFlagsAscending, "Ascending"},
+		{Ranking2SortFlagsDescending, "Descending"},
+		{Ranking2SortFlagsMoveToTopInTie, "MoveToTopInTie"},
+	}
+
+	var parts []string
+	for _, f := range flags {
+		if r2sf&f.flag != 0 {
+			parts = append(parts, f.name)
+		}
+	}
+
+	return strings.Join(parts, "|")
 }
 
 const (

--- a/ranking2/types/ranking2_category_setting.go
+++ b/ranking2/types/ranking2_category_setting.go
@@ -185,7 +185,15 @@ func (rcs Ranking2CategorySetting) FormatToString(indentationLevel int) string {
 	b.WriteString(fmt.Sprintf("%sMaxScore: %s,\n", indentationValues, rcs.MaxScore))
 	b.WriteString(fmt.Sprintf("%sLowestRank: %s,\n", indentationValues, rcs.LowestRank))
 	b.WriteString(fmt.Sprintf("%sResetMonth: %s,\n", indentationValues, rcs.ResetMonth))
-	b.WriteString(fmt.Sprintf("%sResetDay: %s,\n", indentationValues, rcs.ResetDay))
+	switch rcs.ResetMode {
+	case constants.Ranking2ResetModeEveryWeek:
+	case constants.Ranking2ResetModeMultiMonthWeekday:
+		b.WriteString(fmt.Sprintf("%sResetDay: %s,\n", indentationValues, rcs.ResetDay.StringWeekday()))
+	case constants.Ranking2ResetModeMultiMonth:
+		b.WriteString(fmt.Sprintf("%sResetDay: %s,\n", indentationValues, rcs.ResetDay.StringMonthly()))
+	default:
+		b.WriteString(fmt.Sprintf("%sResetDay: %s,\n", indentationValues, rcs.ResetDay))
+	}
 	b.WriteString(fmt.Sprintf("%sResetHour: %s,\n", indentationValues, rcs.ResetHour))
 	b.WriteString(fmt.Sprintf("%sResetMode: %s,\n", indentationValues, rcs.ResetMode))
 	b.WriteString(fmt.Sprintf("%sMaxSeasonsToGoBack: %s,\n", indentationValues, rcs.MaxSeasonsToGoBack))

--- a/ranking2/types/ranking2_category_setting.go
+++ b/ranking2/types/ranking2_category_setting.go
@@ -187,6 +187,7 @@ func (rcs Ranking2CategorySetting) FormatToString(indentationLevel int) string {
 	b.WriteString(fmt.Sprintf("%sResetMonth: %s,\n", indentationValues, rcs.ResetMonth))
 	switch rcs.ResetMode {
 	case constants.Ranking2ResetModeEveryWeek:
+		fallthrough
 	case constants.Ranking2ResetModeMultiMonthWeekday:
 		b.WriteString(fmt.Sprintf("%sResetDay: %s,\n", indentationValues, rcs.ResetDay.StringWeekday()))
 	case constants.Ranking2ResetModeMultiMonth:

--- a/screening/constants/report_category.go
+++ b/screening/constants/report_category.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 type ReportCategory uint32
 
@@ -18,6 +22,30 @@ func (rc *ReportCategory) ExtractFrom(readable types.Readable) error {
 
 	*rc = ReportCategory(value)
 	return nil
+}
+
+// String returns a human-readable representation of the ReportCategory.
+func (rc ReportCategory) String() string {
+	switch rc {
+	case ReportCategoryInvalid:
+		return "Invalid"
+	case ReportCategoryPersonal:
+		return "Personal"
+	case ReportCategoryCriminal:
+		return "Criminal"
+	case ReportCategoryImmoral:
+		return "Immoral"
+	case ReportCategoryHarassment:
+		return "Harassment"
+	case ReportCategoryCommercial:
+		return "Commercial"
+	case ReportCategorySexuallyExplicit:
+		return "SexuallyExplicit"
+	case ReportCategoryOther:
+		return "Other"
+	default:
+		return fmt.Sprintf("ReportCategory(%d)", int(rc))
+	}
 }
 
 const (

--- a/ticket-granting/constants/authentication_token_type.go
+++ b/ticket-granting/constants/authentication_token_type.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // AuthenticationTokenType denotes the type of authentication token
 // the client is using.
@@ -23,6 +27,20 @@ func (att *AuthenticationTokenType) ExtractFrom(readable types.Readable) error {
 
 	*att = AuthenticationTokenType(value)
 	return nil
+}
+
+// String returns a human-readable representation of the AuthenticationTokenType.
+func (att AuthenticationTokenType) String() string {
+	switch att {
+	case AuthenticationTokenTypeNASC:
+		return "NASC"
+	case AuthenticationTokenTypeNNAS:
+		return "NNAS"
+	case AuthenticationTokenTypeSwitch:
+		return "Switch"
+	default:
+		return fmt.Sprintf("AuthenticationTokenType(%d)", int(att))
+	}
 }
 
 const (

--- a/ticket-granting/constants/platform_type.go
+++ b/ticket-granting/constants/platform_type.go
@@ -1,6 +1,10 @@
 package constants
 
-import "github.com/PretendoNetwork/nex-go/v2/types"
+import (
+	"fmt"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
 
 // PlatformType denotes the type of console platform the client
 // is using.
@@ -23,6 +27,20 @@ func (pt *PlatformType) ExtractFrom(readable types.Readable) error {
 
 	*pt = PlatformType(value)
 	return nil
+}
+
+// String returns a human-readable representation of the PlatformType.
+func (pt PlatformType) String() string {
+	switch pt {
+	case PlatformType3DS:
+		return "3DS"
+	case PlatformTypeWiiU:
+		return "WiiU"
+	case PlatformTypeSwitch:
+		return "Switch"
+	default:
+		return fmt.Sprintf("PlatformType(%d)", int(pt))
+	}
 }
 
 const (


### PR DESCRIPTION
Resolves #XXX

### Changes:

Adds a `.String()` method to all enums/flags types, as mentioned here by @DaniElectra https://github.com/PretendoNetwork/nex-protocols-common-go/pull/62#issuecomment-4276339045

A few types couldn't have these added, unsure what to do about those. Open to ideas

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.