### PR TITLE
fix(match-making): update SetHandler functions with wrong prototype

### DIFF
--- a/match-making/protocol.go
+++ b/match-making/protocol.go
@@ -233,7 +233,7 @@ type Interface interface {
 	SetHandlerUpdateSessionURL(handler func(err error, packet nex.PacketInterface, callID uint32, idGathering types.UInt32, strURL types.String) (*nex.RMCMessage, *nex.Error))
 	SetHandlerGetSessionURL(handler func(err error, packet nex.PacketInterface, callID uint32, idGathering types.UInt32) (*nex.RMCMessage, *nex.Error))
 	SetHandlerGetState(handler func(err error, packet nex.PacketInterface, callID uint32, idGathering types.UInt32) (*nex.RMCMessage, *nex.Error))
-	SetHandlerSetState(handler func(err error, packet nex.PacketInterface, callID uint32, idGathering types.UInt32, uiNewState types.UInt32) (*nex.RMCMessage, *nex.Error))
+	SetHandlerSetState(handler func(err error, packet nex.PacketInterface, callID uint32, idGathering types.UInt32, uiNewState constants.GatheringState) (*nex.RMCMessage, *nex.Error))
 	SetHandlerReportStats(handler func(err error, packet nex.PacketInterface, callID uint32, idGathering types.UInt32, lstStats types.List[match_making_types.GatheringStats]) (*nex.RMCMessage, *nex.Error))
 	SetHandlerGetStats(handler func(err error, packet nex.PacketInterface, callID uint32, idGathering types.UInt32, lstParticipants types.List[types.PID], lstColumns types.Buffer) (*nex.RMCMessage, *nex.Error))
 	SetHandlerDeleteGathering(handler func(err error, packet nex.PacketInterface, callID uint32, idGathering types.UInt32) (*nex.RMCMessage, *nex.Error))

--- a/matchmake-extension/protocol.go
+++ b/matchmake-extension/protocol.go
@@ -278,7 +278,7 @@ type Interface interface {
 	SetHandlerGetSimpleCommunity(handler func(err error, packet nex.PacketInterface, callID uint32, gatheringIDList types.List[types.UInt32]) (*nex.RMCMessage, *nex.Error))
 	SetHandlerAutoMatchmakeWithGatheringIDPostpone(handler func(err error, packet nex.PacketInterface, callID uint32, lstGID types.List[types.UInt32], anyGathering match_making_types.GatheringHolder, strMessage types.String) (*nex.RMCMessage, *nex.Error))
 	SetHandlerUpdateProgressScore(handler func(err error, packet nex.PacketInterface, callID uint32, gid types.UInt32, progressScore types.UInt8) (*nex.RMCMessage, *nex.Error))
-	SetHandlerDebugNotifyEvent(handler func(err error, packet nex.PacketInterface, callID uint32, pid types.PID, mainType notifications_constants.NotificationCategory, subType types.UInt32, param1 types.UInt64, param2 types.UInt64, stringParam types.String) (*nex.RMCMessage, *nex.Error))
+	SetHandlerDebugNotifyEvent(handler func(err error, packet nex.PacketInterface, callID uint32, pid types.PID, mainType notifications_constants.NotificationCategory, subType notifications_constants.SubType, param1 types.UInt64, param2 types.UInt64, stringParam types.String) (*nex.RMCMessage, *nex.Error))
 	SetHandlerGenerateMatchmakeSessionSystemPassword(handler func(err error, packet nex.PacketInterface, callID uint32, gid types.UInt32) (*nex.RMCMessage, *nex.Error))
 	SetHandlerClearMatchmakeSessionSystemPassword(handler func(err error, packet nex.PacketInterface, callID uint32, gid types.UInt32) (*nex.RMCMessage, *nex.Error))
 	SetHandlerCreateMatchmakeSessionWithParam(handler func(err error, packet nex.PacketInterface, callID uint32, createMatchmakeSessionParam match_making_types.CreateMatchmakeSessionParam) (*nex.RMCMessage, *nex.Error))


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

Release v2.3.2 does not compile current servers due to mismatched types. The Protocol and Interface of match-making's SetState and matchmake-extension's DebugNotifyExt were not the same.

Compilation fails with errors like the following:
```
# github.com/PretendoNetwork/puyo-puyo-20th/nex
nex/register_common_secure_server_protocols.go:35:67: cannot use matchMakingProtocol (variable of type *"github.com/PretendoNetwork/nex-protocols-go/v2/match-making".Protocol) as "github.com/PretendoNetwork/nex-protocols-go/v2/match-making".Interface value in argument to commonmatchmaking.NewCommonProtocol: *"github.com/PretendoNetwork/nex-protocols-go/v2/match-making".Protocol does not implement "github.com/PretendoNetwork/nex-protocols-go/v2/match-making".Interface (wrong type for method SetHandlerSetState)
		have SetHandlerSetState(func(error, "github.com/PretendoNetwork/nex-go/v2".PacketInterface, uint32, "github.com/PretendoNetwork/nex-go/v2/types".UInt32, "github.com/PretendoNetwork/nex-protocols-go/v2/match-making/constants".GatheringState) (*"github.com/PretendoNetwork/nex-go/v2".RMCMessage, *"github.com/PretendoNetwork/nex-go/v2".Error))
		want SetHandlerSetState(func(error, "github.com/PretendoNetwork/nex-go/v2".PacketInterface, uint32, "github.com/PretendoNetwork/nex-go/v2/types".UInt32, "github.com/PretendoNetwork/nex-go/v2/types".UInt32) (*"github.com/PretendoNetwork/nex-go/v2".RMCMessage, *"github.com/PretendoNetwork/nex-go/v2".Error))
nex/register_common_secure_server_protocols.go:45:81: cannot use matchmakeExtensionProtocol (variable of type *"github.com/PretendoNetwork/nex-protocols-go/v2/matchmake-extension".Protocol) as "github.com/PretendoNetwork/nex-protocols-go/v2/matchmake-extension".Interface value in argument to commonmatchmakeextension.NewCommonProtocol: *"github.com/PretendoNetwork/nex-protocols-go/v2/matchmake-extension".Protocol does not implement "github.com/PretendoNetwork/nex-protocols-go/v2/matchmake-extension".Interface (wrong type for method SetHandlerDebugNotifyEvent)
		have SetHandlerDebugNotifyEvent(func(error, "github.com/PretendoNetwork/nex-go/v2".PacketInterface, uint32, "github.com/PretendoNetwork/nex-go/v2/types".PID, "github.com/PretendoNetwork/nex-protocols-go/v2/notifications/constants".NotificationCategory, "github.com/PretendoNetwork/nex-protocols-go/v2/notifications/constants".SubType, "github.com/PretendoNetwork/nex-go/v2/types".UInt64, "github.com/PretendoNetwork/nex-go/v2/types".UInt64, "github.com/PretendoNetwork/nex-go/v2/types".String) (*"github.com/PretendoNetwork/nex-go/v2".RMCMessage, *"github.com/PretendoNetwork/nex-go/v2".Error))
		want SetHandlerDebugNotifyEvent(func(error, "github.com/PretendoNetwork/nex-go/v2".PacketInterface, uint32, "github.com/PretendoNetwork/nex-go/v2/types".PID, "github.com/PretendoNetwork/nex-protocols-go/v2/notifications/constants".NotificationCategory, "github.com/PretendoNetwork/nex-go/v2/types".UInt32, "github.com/PretendoNetwork/nex-go/v2/types".UInt64, "github.com/PretendoNetwork/nex-go/v2/types".UInt64, "github.com/PretendoNetwork/nex-go/v2/types".String) (*"github.com/PretendoNetwork/nex-go/v2".RMCMessage, *"github.com/PretendoNetwork/nex-go/v2".Error))
```

I recommend immediate release of v2.3.3 since v2.3.2 can never work for servers with matchmaking due to this issue.

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.