### PR TITLE
fix(ranking-legacy): Fix UniqueID/PrincipalID struct order

### DIFF
--- a/ranking/legacy/types/ranking_data.go
+++ b/ranking/legacy/types/ranking_data.go
@@ -63,12 +63,6 @@ func (rd *RankingData) ExtractFrom(readable types.Readable) error {
 		return fmt.Errorf("Failed to extract RankingData header. %s", err.Error())
 	}
 
-	if err := rd.PrincipalID.ExtractFrom(readable); err != nil {
-		return fmt.Errorf("Failed to extract RankingData.PrincipalID. %s", err.Error())
-	}
-
-	if err := rd.UniqueID.ExtractFrom(readable); err != nil {
-		return fmt.Errorf("Failed to extract RankingData.UniqueID. %s", err.Error())
 	if err := rd.UniqueID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingData.UniqueID. %s", err.Error())
 	}

--- a/ranking/legacy/types/ranking_data.go
+++ b/ranking/legacy/types/ranking_data.go
@@ -31,8 +31,8 @@ func (rd RankingData) WriteTo(writable types.Writable) {
 
 	contentWritable := writable.CopyNew()
 
-	rd.PrincipalID.WriteTo(contentWritable)
 	rd.UniqueID.WriteTo(contentWritable)
+	rd.PrincipalID.WriteTo(contentWritable)
 	rd.Order.WriteTo(contentWritable)
 
 	if libraryVersion.GreaterOrEqual("2.0.0") {

--- a/ranking/legacy/types/ranking_data.go
+++ b/ranking/legacy/types/ranking_data.go
@@ -69,6 +69,12 @@ func (rd *RankingData) ExtractFrom(readable types.Readable) error {
 
 	if err := rd.UniqueID.ExtractFrom(readable); err != nil {
 		return fmt.Errorf("Failed to extract RankingData.UniqueID. %s", err.Error())
+	if err := rd.UniqueID.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("Failed to extract RankingData.UniqueID. %s", err.Error())
+	}
+
+	if err := rd.PrincipalID.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("Failed to extract RankingData.PrincipalID. %s", err.Error())
 	}
 
 	if err := rd.Order.ExtractFrom(readable); err != nil {


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

UniqueID and PrincipalID were in the wrong order. See https://nintendo-wiki.pretendo.network/docs/nex/protocols/ranking/legacy#rankingdata-structure

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.