### PR TITLE
feat: implement types and params of for some splatoon ranking methods

### DIFF
--- a/ranking/splatoon/get_competition_ranking_score.go
+++ b/ranking/splatoon/get_competition_ranking_score.go
@@ -2,8 +2,11 @@
 package protocol
 
 import (
+	"fmt"
+
 	nex "github.com/PretendoNetwork/nex-go/v2"
 	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+	ranking_splatoon_types "github.com/PretendoNetwork/nex-protocols-go/v2/ranking/splatoon/types"
 )
 
 func (protocol *Protocol) handleGetCompetitionRankingScore(packet nex.PacketInterface) {
@@ -16,12 +19,26 @@ func (protocol *Protocol) handleGetCompetitionRankingScore(packet nex.PacketInte
 		return
 	}
 
-	globals.Logger.Warning("RankingSplatoon::GetCompetitionRankingScore STUBBED")
-
 	request := packet.RMCMessage()
 	callID := request.CallID
+	endpoint := request.Endpoint
+	parameters := request.Parameters
 
-	rmcMessage, rmcError := protocol.GetCompetitionRankingScore(nil, packet, callID, packet.Payload())
+	param := ranking_splatoon_types.NewCompetitionRankingGetParam()
+
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	err := param.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.GetCompetitionRankingScore(fmt.Errorf("failed to read param from parameters. %s", err.Error()), packet, callID, param)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	rmcMessage, rmcError := protocol.GetCompetitionRankingScore(nil, packet, callID, param)
 	if rmcError != nil {
 		globals.RespondError(packet, ProtocolID, rmcError)
 		return

--- a/ranking/splatoon/protocol.go
+++ b/ranking/splatoon/protocol.go
@@ -7,6 +7,7 @@ import (
 	nex "github.com/PretendoNetwork/nex-go/v2"
 	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
 	ranking "github.com/PretendoNetwork/nex-protocols-go/v2/ranking"
+	ranking_splatoon_types "github.com/PretendoNetwork/nex-protocols-go/v2/ranking/splatoon/types"
 	"golang.org/x/exp/slices"
 )
 
@@ -41,9 +42,9 @@ type rankingProtocol = ranking.Protocol
 type Protocol struct {
 	endpoint nex.EndpointInterface
 	rankingProtocol
-	GetCompetitionRankingScore             func(err error, packet nex.PacketInterface, callID uint32, packetPayload []byte) (*nex.RMCMessage, *nex.Error)
+	GetCompetitionRankingScore             func(err error, packet nex.PacketInterface, callID uint32, param ranking_splatoon_types.CompetitionRankingGetParam) (*nex.RMCMessage, *nex.Error)
 	GetcompetitionRankingScoreByPeriodList func(err error, packet nex.PacketInterface, callID uint32, packetPayload []byte) (*nex.RMCMessage, *nex.Error)
-	UploadCompetitionRankingScore          func(err error, packet nex.PacketInterface, callID uint32, packetPayload []byte) (*nex.RMCMessage, *nex.Error)
+	UploadCompetitionRankingScore          func(err error, packet nex.PacketInterface, callID uint32, param ranking_splatoon_types.CompetitionRankingUploadScoreParam) (*nex.RMCMessage, *nex.Error)
 	DeleteCompetitionRankingScore          func(err error, packet nex.PacketInterface, callID uint32, packetPayload []byte) (*nex.RMCMessage, *nex.Error)
 }
 

--- a/ranking/splatoon/types/competition_ranking_get_param.go
+++ b/ranking/splatoon/types/competition_ranking_get_param.go
@@ -1,0 +1,134 @@
+// Package types implements all the types used by the Ranking protocol
+package types
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
+
+// CompetitionRankingGetParam is a type within the Ranking protocol
+type CompetitionRankingGetParam struct {
+	types.Structure
+	Unknown     types.UInt32
+	ResultRange types.ResultRange
+	FestivalIds types.List[types.UInt32]
+}
+
+// WriteTo writes the CompetitionRankingGetParam to the given writable
+func (crgp CompetitionRankingGetParam) WriteTo(writable types.Writable) {
+	contentWritable := writable.CopyNew()
+
+	crgp.Unknown.WriteTo(contentWritable)
+	crgp.ResultRange.WriteTo(contentWritable)
+	crgp.FestivalIds.WriteTo(contentWritable)
+
+	content := contentWritable.Bytes()
+
+	crgp.WriteHeaderTo(writable, uint32(len(content)))
+
+	writable.Write(content)
+}
+
+// ExtractFrom extracts the CompetitionRankingGetParam from the given readable
+func (crgp CompetitionRankingGetParam) ExtractFrom(readable types.Readable) error {
+	if err := crgp.ExtractHeaderFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingGetParam header. %s", err.Error())
+	}
+
+	if err := crgp.Unknown.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingGetParam.Unknown. %s", err.Error())
+	}
+
+	if err := crgp.ResultRange.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingGetParam.ResultRange. %s", err.Error())
+	}
+
+	if err := crgp.FestivalIds.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingGetParam.FestivalIds. %s", err.Error())
+	}
+
+	return nil
+}
+
+// Copy returns a new copied instance of CompetitionRankingGetParam
+func (crgp CompetitionRankingGetParam) Copy() types.RVType {
+	copied := NewCompetitionRankingGetParam()
+
+	copied.StructureVersion = crgp.StructureVersion
+	copied.Unknown = crgp.Unknown.Copy().(types.UInt32)
+	copied.ResultRange = crgp.Copy().(types.ResultRange)
+	copied.FestivalIds = crgp.FestivalIds.Copy().(types.List[types.UInt32])
+
+	return copied
+}
+
+// Equals checks if the given CompetitionRankingGetParam contains the same data as the current CompetitionRankingGetParam
+func (crgp CompetitionRankingGetParam) Equals(o types.RVType) bool {
+	if _, ok := o.(CompetitionRankingGetParam); !ok {
+		return false
+	}
+
+	other := o.(CompetitionRankingGetParam)
+
+	if crgp.StructureVersion != other.StructureVersion {
+		return false
+	}
+
+	if !crgp.Unknown.Equals(other.Unknown) {
+		return false
+	}
+
+	if !crgp.ResultRange.Equals(other.ResultRange) {
+		return false
+	}
+
+	return crgp.FestivalIds.Equals(other.FestivalIds)
+}
+
+// CopyRef copies the current value of the CompetitionRankingGetParam
+// and returns a pointer to the new copy
+func (crgp CompetitionRankingGetParam) CopyRef() types.RVTypePtr {
+	copied := crgp.Copy().(CompetitionRankingGetParam)
+	return &copied
+}
+
+// Deref takes a pointer to the CompetitionRankingGetParam
+// and dereferences it to the raw value.
+// Only useful when working with an instance of RVTypePtr
+func (crgp *CompetitionRankingGetParam) Deref() types.RVType {
+	return *crgp
+}
+
+// String returns the string representation of the CompetitionRankingGetParam
+func (crgp CompetitionRankingGetParam) String() string {
+	return crgp.FormatToString(0)
+}
+
+// FormatToString pretty-prints the CompetitionRankingGetParam using the provided indentation level
+func (crgp CompetitionRankingGetParam) FormatToString(indentationLevel int) string {
+	indentationValues := strings.Repeat("\t", indentationLevel+1)
+	indentationEnd := strings.Repeat("\t", indentationLevel)
+
+	var b strings.Builder
+
+	b.WriteString("CompetitionRankingGetParam{\n")
+	fmt.Fprintf(&b, "%sUnknown: %s,\n", indentationValues, crgp.Unknown)
+	fmt.Fprintf(&b, "%sResultRange: %s,\n", indentationValues, crgp.ResultRange)
+	fmt.Fprintf(&b, "%sFestivalIds: %s,\n", indentationValues, crgp.FestivalIds)
+	fmt.Fprintf(&b, "%s}", indentationEnd)
+
+	return b.String()
+}
+
+// NewCompetitionRankingGetParam returns a new CompetitionRankingGetParam
+func NewCompetitionRankingGetParam() CompetitionRankingGetParam {
+	return CompetitionRankingGetParam{
+		Structure:   types.Structure{StructureVersion: 1},
+		Unknown:     types.NewUInt32(0),
+		ResultRange: types.NewResultRange(),
+		FestivalIds: types.NewList[types.UInt32](),
+	}
+
+}

--- a/ranking/splatoon/types/competition_ranking_score_data.go
+++ b/ranking/splatoon/types/competition_ranking_score_data.go
@@ -1,0 +1,172 @@
+// Package types implements all the types used by the Ranking protocol
+package types
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
+
+// CompetitionRankingScoreData is a type within the Ranking protocol
+type CompetitionRankingScoreData struct {
+	types.Structure
+	Unknown1 types.UInt32
+	PID      types.PID
+	Score    types.UInt32
+	Modified types.DateTime
+	Unknown2 types.UInt8
+	AppData  types.QBuffer
+}
+
+// WriteTo writes the CompetitionRankingScoreData to the given writable
+func (crsd CompetitionRankingScoreData) WriteTo(writable types.Writable) {
+	contentWritable := writable.CopyNew()
+
+	crsd.Unknown1.WriteTo(contentWritable)
+	crsd.PID.WriteTo(contentWritable)
+	crsd.Score.WriteTo(contentWritable)
+	crsd.Modified.WriteTo(contentWritable)
+	crsd.Unknown2.WriteTo(contentWritable)
+	crsd.AppData.WriteTo(contentWritable)
+
+	content := contentWritable.Bytes()
+
+	crsd.WriteHeaderTo(writable, uint32(len(content)))
+
+	writable.Write(content)
+}
+
+// ExtractFrom extracts the CompetitionRankingScoreData from the given readable
+func (crsd CompetitionRankingScoreData) ExtractFrom(readable types.Readable) error {
+	if err := crsd.ExtractHeaderFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingScoreData header. %s", err.Error())
+	}
+
+	if err := crsd.Unknown1.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingScoreData.Unknown1. %s", err.Error())
+	}
+
+	if err := crsd.PID.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingScoreData.PID. %s", err.Error())
+	}
+
+	if err := crsd.Score.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingScoreData.Score. %s", err.Error())
+	}
+
+	if err := crsd.Modified.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingScoreData.Modified. %s", err.Error())
+	}
+
+	if err := crsd.Unknown2.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingScoreData.Unknown2. %s", err.Error())
+	}
+
+	if err := crsd.AppData.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingScoreData.AppData. %s", err.Error())
+	}
+
+	return nil
+}
+
+// Copy returns a new copied instance of CompetitionRankingScoreData
+func (csrd CompetitionRankingScoreData) Copy() types.RVType {
+	copied := NewCompetitionRankingScoreData()
+
+	copied.StructureVersion = csrd.StructureVersion
+	copied.Unknown1 = csrd.Unknown1.Copy().(types.UInt32)
+	copied.PID = csrd.PID.Copy().(types.PID)
+	copied.Score = csrd.Score.Copy().(types.UInt32)
+	copied.Modified = csrd.Modified.Copy().(types.DateTime)
+	copied.Unknown2 = csrd.Unknown2.Copy().(types.UInt8)
+	copied.AppData = csrd.AppData.Copy().(types.QBuffer)
+
+	return copied
+}
+
+// Equals checks if the given CompetitionRankingScoreData contains the same data as the current CompetitionRankingScoreData
+func (csrd CompetitionRankingScoreData) Equals(o types.RVType) bool {
+	if _, ok := o.(CompetitionRankingScoreData); !ok {
+		return false
+	}
+
+	other := o.(CompetitionRankingScoreData)
+
+	if csrd.StructureVersion != other.StructureVersion {
+		return false
+	}
+
+	if !csrd.Unknown1.Equals(other.Unknown1) {
+		return false
+	}
+
+	if !csrd.PID.Equals(other.PID) {
+		return false
+	}
+
+	if !csrd.Score.Equals(other.Score) {
+		return false
+	}
+
+	if !csrd.Modified.Equals(other.Modified) {
+		return false
+	}
+
+	if !csrd.Unknown2.Equals(other.Unknown2) {
+		return false
+	}
+
+	return csrd.AppData.Equals(other.AppData)
+}
+
+// CopyRef copies the current value of the CompetitionRankingScoreData
+// and returns a pointer to the new copy
+func (csrd CompetitionRankingScoreData) CopyRef() types.RVTypePtr {
+	copied := csrd.Copy().(CompetitionRankingScoreData)
+	return &copied
+}
+
+// Deref takes a pointer to the CompetitionRankingScoreData
+// and dereferences it to the raw value.
+// Only useful when working with an instance of RVTypePtr
+func (csrd *CompetitionRankingScoreData) Deref() types.RVType {
+	return *csrd
+}
+
+// String returns the string representation of the CompetitionRankingScoreData
+func (csrd CompetitionRankingScoreData) String() string {
+	return csrd.FormatToString(0)
+}
+
+// FormatToString pretty-prints the CompetitionRankingScoreData using the provided indentation level
+func (csrd CompetitionRankingScoreData) FormatToString(indentationLevel int) string {
+	indentationValues := strings.Repeat("\t", indentationLevel+1)
+	indentationEnd := strings.Repeat("\t", indentationLevel)
+
+	var b strings.Builder
+
+	b.WriteString("CompetitionRankingScoreData{\n")
+	fmt.Fprintf(&b, "%sUnknown1: %s,\n", indentationValues, csrd.Unknown1)
+	fmt.Fprintf(&b, "%sPID: %s,\n", indentationValues, csrd.PID)
+	fmt.Fprintf(&b, "%sScore: %s,\n", indentationValues, csrd.PID)
+	fmt.Fprintf(&b, "%sModified: %s,\n", indentationValues, csrd.Modified)
+	fmt.Fprintf(&b, "%ssUnknown2: %s,\n", indentationValues, csrd.Unknown2)
+	fmt.Fprintf(&b, "%sAppData: %s,\n", indentationValues, csrd.AppData)
+	fmt.Fprintf(&b, "%s}", indentationEnd)
+
+	return b.String()
+}
+
+// NewCompetitionRankingScoreData returns a new CompetitionRankingScoreData
+func NewCompetitionRankingScoreData() CompetitionRankingScoreData {
+	return CompetitionRankingScoreData{
+		Unknown1: types.NewUInt32(0),
+		PID:      types.NewPID(0),
+		Score:    types.NewUInt32(0),
+		Modified: types.NewDateTime(0),
+		Unknown2: types.NewUInt8(0),
+		AppData:  types.NewQBuffer([]byte{}),
+	}
+
+}

--- a/ranking/splatoon/types/competition_ranking_score_info.go
+++ b/ranking/splatoon/types/competition_ranking_score_info.go
@@ -1,0 +1,163 @@
+// Package types implements all the types used by the Ranking protocol
+package types
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
+
+// CompetitionRankingScoreInfo is a type within the Ranking protocol
+type CompetitionRankingScoreInfo struct {
+	types.Structure
+	FestId    types.UInt32
+	ScoreData types.List[CompetitionRankingScoreData]
+	Unknown   types.UInt32
+	TeamWins  types.List[types.UInt32]
+	TeamVotes types.List[types.UInt32]
+}
+
+// WriteTo writes the CompetitionRankingScoreInfo to the given writable
+func (crsi CompetitionRankingScoreInfo) WriteTo(writable types.Writable) {
+	contentWritable := writable.CopyNew()
+
+	crsi.FestId.WriteTo(contentWritable)
+	crsi.ScoreData.WriteTo(contentWritable)
+	crsi.Unknown.WriteTo(contentWritable)
+	crsi.TeamWins.WriteTo(contentWritable)
+	crsi.TeamVotes.WriteTo(contentWritable)
+
+	content := contentWritable.Bytes()
+
+	crsi.WriteHeaderTo(writable, uint32(len(content)))
+
+	writable.Write(content)
+}
+
+// ExtractFrom extracts the CompetitionRankingScoreInfo from the given readable
+func (crsi CompetitionRankingScoreInfo) ExtractFrom(readable types.Readable) error {
+	if err := crsi.ExtractHeaderFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingScoreInfo header. %s", err.Error())
+	}
+
+	if err := crsi.FestId.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingScoreInfo.FestId. %s", err.Error())
+	}
+
+	if err := crsi.ScoreData.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingScoreInfo.ScoreData. %s", err.Error())
+	}
+
+	if err := crsi.Unknown.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingScoreInfo.Unknown. %s", err.Error())
+	}
+
+	if err := crsi.TeamWins.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingScoreInfo.TeamWins. %s", err.Error())
+	}
+
+	if err := crsi.TeamVotes.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingScoreInfo.TeamVotes. %s", err.Error())
+	}
+
+	return nil
+}
+
+// Copy returns a new copied instance of CompetitionRankingScoreInfo
+func (crsi CompetitionRankingScoreInfo) Copy() types.RVType {
+	copied := NewCompetitionRankingScoreInfo()
+
+	copied.StructureVersion = crsi.StructureVersion
+	copied.FestId = crsi.FestId.Copy().(types.UInt32)
+	copied.ScoreData = crsi.ScoreData.Copy().(types.List[CompetitionRankingScoreData])
+	copied.Unknown = crsi.Unknown.Copy().(types.UInt32)
+	copied.TeamWins = crsi.TeamWins.Copy().(types.List[types.UInt32])
+	copied.TeamVotes = crsi.TeamVotes.Copy().(types.List[types.UInt32])
+
+	return copied
+}
+
+// Equals checks if the given CompetitionRankingScoreInfo contains the same data as the current CompetitionRankingScoreInfo
+func (crsi CompetitionRankingScoreInfo) Equals(o types.RVType) bool {
+	if _, ok := o.(CompetitionRankingScoreInfo); !ok {
+		return false
+	}
+
+	other := o.(CompetitionRankingScoreInfo)
+
+	if crsi.StructureVersion != other.StructureVersion {
+		return false
+	}
+
+	if !crsi.FestId.Equals(other.FestId) {
+		return false
+	}
+
+	if !crsi.ScoreData.Equals(other.ScoreData) {
+		return false
+	}
+
+	if !crsi.Unknown.Equals(other.Unknown) {
+		return false
+	}
+
+	if !crsi.TeamWins.Equals(other.TeamWins) {
+		return false
+	}
+
+	if !crsi.TeamVotes.Equals(other.TeamVotes) {
+		return false
+	}
+
+	return crsi.TeamVotes.Equals(other.TeamVotes)
+}
+
+// CopyRef copies the current value of the CompetitionRankingScoreInfo
+// and returns a pointer to the new copy
+func (crsi CompetitionRankingScoreInfo) CopyRef() types.RVTypePtr {
+	copied := crsi.Copy().(CompetitionRankingScoreInfo)
+	return &copied
+}
+
+// Deref takes a pointer to the CompetitionRankingScoreInfo
+// and dereferences it to the raw value.
+// Only useful when working with an instance of RVTypePtr
+func (crsi *CompetitionRankingScoreInfo) Deref() types.RVType {
+	return *crsi
+}
+
+// String returns the string representation of the CompetitionRankingScoreInfo
+func (crsi CompetitionRankingScoreInfo) String() string {
+	return crsi.FormatToString(0)
+}
+
+// FormatToString pretty-prints the CompetitionRankingScoreInfo using the provided indentation level
+func (crsi CompetitionRankingScoreInfo) FormatToString(indentationLevel int) string {
+	indentationValues := strings.Repeat("\t", indentationLevel+1)
+	indentationEnd := strings.Repeat("\t", indentationLevel)
+
+	var b strings.Builder
+
+	b.WriteString("CompetitionRankingScoreInfo{\n")
+	fmt.Fprintf(&b, "%sFestId: %s,\n", indentationValues, crsi.FestId)
+	fmt.Fprintf(&b, "%sScoreData: %s,\n", indentationValues, crsi.ScoreData)
+	fmt.Fprintf(&b, "%sUnknown: %s,\n", indentationValues, crsi.Unknown)
+	fmt.Fprintf(&b, "%sTeamWins: %s,\n", indentationValues, crsi.TeamWins)
+	fmt.Fprintf(&b, "%sTeamVotes: %s,\n", indentationValues, crsi.TeamVotes)
+	fmt.Fprintf(&b, "%s}", indentationEnd)
+
+	return b.String()
+}
+
+// NewCompetitionRankingScoreInfo returns a new CompetitionRankingScoreInfo
+func NewCompetitionRankingScoreInfo() CompetitionRankingScoreInfo {
+	return CompetitionRankingScoreInfo{
+		FestId:    types.NewUInt32(0),
+		ScoreData: types.NewList[CompetitionRankingScoreData](),
+		Unknown:   types.NewUInt32(0),
+		TeamWins:  types.NewList[types.UInt32](),
+		TeamVotes: types.NewList[types.UInt32](),
+	}
+
+}

--- a/ranking/splatoon/types/competition_ranking_upload_score_param.go
+++ b/ranking/splatoon/types/competition_ranking_upload_score_param.go
@@ -1,0 +1,185 @@
+// Package types implements all the types used by the Ranking protocol
+package types
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/PretendoNetwork/nex-go/v2/types"
+)
+
+// CompetitionRankingUploadScoreParam is a type within the Ranking protocol
+type CompetitionRankingUploadScoreParam struct {
+	types.Structure
+	Unknown1      types.UInt32
+	SplatfestId   types.UInt32
+	Unknown2      types.UInt32
+	Score         types.UInt32
+	TeamId        types.UInt8
+	TeamWin       types.UInt8
+	IsFirstUpload types.Bool
+	AppData       types.QBuffer
+}
+
+// WriteTo writes the CompetitionRankingUploadScoreParam to the given writable
+func (crusp CompetitionRankingUploadScoreParam) WriteTo(writable types.Writable) {
+	contentWritable := writable.CopyNew()
+
+	crusp.Unknown1.WriteTo(contentWritable)
+	crusp.SplatfestId.WriteTo(contentWritable)
+	crusp.Unknown2.WriteTo(contentWritable)
+	crusp.Score.WriteTo(contentWritable)
+	crusp.TeamId.WriteTo(contentWritable)
+	crusp.TeamWin.WriteTo(contentWritable)
+	crusp.IsFirstUpload.WriteTo(contentWritable)
+	crusp.AppData.WriteTo(contentWritable)
+
+	content := contentWritable.Bytes()
+
+	crusp.WriteHeaderTo(writable, uint32(len(content)))
+
+	writable.Write(content)
+}
+
+// ExtractFrom extracts the CompetitionRankingUploadScoreParam from the given readable
+func (crusp CompetitionRankingUploadScoreParam) ExtractFrom(readable types.Readable) error {
+	if err := crusp.ExtractHeaderFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingUploadScoreParam header. %s", err.Error())
+	}
+
+	if err := crusp.Unknown1.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingUploadScoreParam.Unknown1. %s", err.Error())
+	}
+	if err := crusp.SplatfestId.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingUploadScoreParam.SplatfestId. %s", err.Error())
+	}
+	if err := crusp.Unknown2.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingUploadScoreParam.Unknown2. %s", err.Error())
+	}
+	if err := crusp.Score.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingUploadScoreParam.Score. %s", err.Error())
+	}
+	if err := crusp.TeamId.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingUploadScoreParam.TeamId. %s", err.Error())
+	}
+	if err := crusp.TeamWin.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingUploadScoreParam.TeamWin. %s", err.Error())
+	}
+	if err := crusp.IsFirstUpload.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingUploadScoreParam.IsFirstUpload. %s", err.Error())
+	}
+	if err := crusp.AppData.ExtractFrom(readable); err != nil {
+		return fmt.Errorf("failed to extract CompetitionRankingUploadScoreParam.AppData. %s", err.Error())
+	}
+
+	return nil
+}
+
+// Copy returns a new copied instance of CompetitionRankingUploadScoreParam
+func (crusp CompetitionRankingUploadScoreParam) Copy() types.RVType {
+	copied := NewCompetitionRankingUploadScoreParam()
+
+	copied.StructureVersion = crusp.StructureVersion
+	copied.Unknown1 = crusp.Unknown1.Copy().(types.UInt32)
+	copied.SplatfestId = crusp.SplatfestId.Copy().(types.UInt32)
+	copied.Unknown2 = crusp.Unknown2.Copy().(types.UInt32)
+	copied.Score = crusp.Score.Copy().(types.UInt32)
+	copied.TeamId = crusp.TeamId.Copy().(types.UInt8)
+	copied.TeamWin = crusp.TeamWin.Copy().(types.UInt8)
+	copied.IsFirstUpload = crusp.IsFirstUpload.Copy().(types.Bool)
+	copied.AppData = crusp.AppData.Copy().(types.QBuffer)
+
+	return copied
+}
+
+// Equals checks if the given CompetitionRankingUploadScoreParam contains the same data as the current CompetitionRankingUploadScoreParam
+func (crusp CompetitionRankingUploadScoreParam) Equals(o types.RVType) bool {
+	if _, ok := o.(CompetitionRankingUploadScoreParam); !ok {
+		return false
+	}
+
+	other := o.(CompetitionRankingUploadScoreParam)
+
+	if crusp.StructureVersion != other.StructureVersion {
+		return false
+	}
+
+	if !crusp.Unknown1.Equals(other.Unknown1) {
+		return false
+	}
+	if !crusp.SplatfestId.Equals(other.SplatfestId) {
+		return false
+	}
+	if !crusp.Unknown2.Equals(other.Unknown2) {
+		return false
+	}
+	if !crusp.Score.Equals(other.Score) {
+		return false
+	}
+	if !crusp.TeamId.Equals(other.TeamId) {
+		return false
+	}
+	if !crusp.TeamWin.Equals(other.TeamWin) {
+		return false
+	}
+	if !crusp.IsFirstUpload.Equals(other.IsFirstUpload) {
+		return false
+	}
+
+	return crusp.AppData.Equals(other.AppData)
+}
+
+// CopyRef copies the current value of the CompetitionRankingUploadScoreParam
+// and returns a pointer to the new copy
+func (crusp CompetitionRankingUploadScoreParam) CopyRef() types.RVTypePtr {
+	copied := crusp.Copy().(CompetitionRankingScoreInfo)
+	return &copied
+}
+
+// Deref takes a pointer to the CompetitionRankingUploadScoreParam
+// and dereferences it to the raw value.
+// Only useful when working with an instance of RVTypePtr
+func (crusp *CompetitionRankingUploadScoreParam) Deref() types.RVType {
+	return *crusp
+}
+
+// String returns the string representation of the CompetitionRankingUploadScoreParam
+func (crusp CompetitionRankingUploadScoreParam) String() string {
+	return crusp.FormatToString(0)
+}
+
+// FormatToString pretty-prints the CompetitionRankingUploadScoreParam using the provided indentation level
+func (crusp CompetitionRankingUploadScoreParam) FormatToString(indentationLevel int) string {
+	indentationValues := strings.Repeat("\t", indentationLevel+1)
+	indentationEnd := strings.Repeat("\t", indentationLevel)
+
+	var b strings.Builder
+
+	b.WriteString("CompetitionRankingUploadScoreParam{\n")
+	fmt.Fprintf(&b, "%sUnknown1: %s,\n", indentationValues, crusp.Unknown1)
+	fmt.Fprintf(&b, "%sSplatfestId: %s,\n", indentationValues, crusp.SplatfestId)
+	fmt.Fprintf(&b, "%sUnknown2: %s,\n", indentationValues, crusp.Unknown2)
+	fmt.Fprintf(&b, "%sScore: %s,\n", indentationValues, crusp.Score)
+	fmt.Fprintf(&b, "%sTeamId: %s,\n", indentationValues, crusp.TeamId)
+	fmt.Fprintf(&b, "%sTeamWin: %s,\n", indentationValues, crusp.TeamWin)
+	fmt.Fprintf(&b, "%sIsFirstUpload: %s,\n", indentationValues, crusp.IsFirstUpload)
+	fmt.Fprintf(&b, "%sAppData: %s,\n", indentationValues, crusp.AppData)
+	fmt.Fprintf(&b, "%s}", indentationEnd)
+
+	return b.String()
+}
+
+// CompetitionRankingUploadScoreParam returns a new CompetitionRankingUploadScoreParam
+func NewCompetitionRankingUploadScoreParam() CompetitionRankingUploadScoreParam {
+	return CompetitionRankingUploadScoreParam{
+		Unknown1:      types.NewUInt32(0),
+		SplatfestId:   types.NewUInt32(0),
+		Unknown2:      types.NewUInt32(0),
+		Score:         types.NewUInt32(0),
+		TeamId:        types.NewUInt8(0),
+		TeamWin:       types.NewUInt8(0),
+		IsFirstUpload: types.NewBool(false),
+		AppData:       types.NewQBuffer([]byte{}),
+	}
+
+}

--- a/ranking/splatoon/upload_competition_ranking_score.go
+++ b/ranking/splatoon/upload_competition_ranking_score.go
@@ -19,8 +19,6 @@ func (protocol *Protocol) handleUploadCompetitionRankingScore(packet nex.PacketI
 		return
 	}
 
-	globals.Logger.Warning("RankingSplatoon::UploadCompetitionRankingScore STUBBED")
-
 	request := packet.RMCMessage()
 	callID := request.CallID
 	endpoint := request.Endpoint

--- a/ranking/splatoon/upload_competition_ranking_score.go
+++ b/ranking/splatoon/upload_competition_ranking_score.go
@@ -2,8 +2,11 @@
 package protocol
 
 import (
+	"fmt"
+
 	nex "github.com/PretendoNetwork/nex-go/v2"
 	"github.com/PretendoNetwork/nex-protocols-go/v2/globals"
+	ranking_splatoon_types "github.com/PretendoNetwork/nex-protocols-go/v2/ranking/splatoon/types"
 )
 
 func (protocol *Protocol) handleUploadCompetitionRankingScore(packet nex.PacketInterface) {
@@ -20,8 +23,24 @@ func (protocol *Protocol) handleUploadCompetitionRankingScore(packet nex.PacketI
 
 	request := packet.RMCMessage()
 	callID := request.CallID
+	endpoint := request.Endpoint
+	parameters := request.Parameters
 
-	rmcMessage, rmcError := protocol.UploadCompetitionRankingScore(nil, packet, callID, packet.Payload())
+	param := ranking_splatoon_types.NewCompetitionRankingUploadScoreParam()
+
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	err := param.ExtractFrom(parametersStream)
+	if err != nil {
+		_, rmcError := protocol.UploadCompetitionRankingScore(fmt.Errorf("failed to read param from parameters. %s", err.Error()), packet, callID, param)
+		if rmcError != nil {
+			globals.RespondError(packet, ProtocolID, rmcError)
+		}
+
+		return
+	}
+
+	rmcMessage, rmcError := protocol.UploadCompetitionRankingScore(nil, packet, callID, param)
 	if rmcError != nil {
 		globals.RespondError(packet, ProtocolID, rmcError)
 		return


### PR DESCRIPTION
### Changes:

- Adds `CompetitionRankingGetParam` to Splatoon ranking types
- Adds `CompetitionRankingScoreData` to Splatoon ranking types
- Adds `CompetitionRankingScoreInfo` to Splatoon ranking types
- Adds `CompetitionRankingUploadScoreParam` to Splatoon ranking types
- Adds function parameters to method `GetCompetitionRankingScore` of the Splatoon ranking protocol
- Adds function parameters to method `UploadCompetitionRankingScore` of the Splatoon ranking protocol 

- [X] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.